### PR TITLE
fix #28

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -119,7 +119,7 @@ class Completer(object):
         script = BASH_COMPLETE_SCRIPT.format(filename=fnme, line=line, n=n,
                     func=func, cmd=cmd, end=endidx+1, prefix=prefix, prev=prev)
         out = subprocess.check_output(['bash'], input=script, 
-                                      universal_newlines=True)
+                                      universal_newlines=True, stderr=subprocess.PIPE)
         space = ' '
         rtn = {s+space if s[-1:].isalnum() else s for s in out.splitlines()}
         return rtn


### PR DESCRIPTION
Bash completion still works when auto-completing paths for vim, but writes to stderr.

This worked for me to fix this problem, and hasn't seemed to create any problems anywhere else, though I'm not sure how general of a fix this is.