### PR TITLE
Auto-formatting prompt string

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -39,12 +39,27 @@ default_prompt = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
                   '{cwd}{BOLD_RED}{curr_branch} {BOLD_BLUE}${NO_COLOR} ')
 
 def format_prompt(template=default_prompt):
-    """Formats a xonsh prompt template string."""
+    """Formats a xonsh prompt template string.
+
+    The following keyword arguments are recognized in the template string:
+    user -- Name of current user
+    hostname -- Name of host computer
+    cwd -- Current working directory
+    curr_branch -- Name of current git branch (preceded by a space), if any
+    (QUALIFIER_)COLORNAME -- Inserts an ANSI color code
+        COLORNAME can be any of:
+            BLACK, RED, GREEN, YELLOW, BLUE, PURPLE, CYAN, WHITE
+        QUALIFIER is optional and can be any of:
+            BOLD, UNDERLINE, BACKGROUND, INTENSE,
+            BOLD_INTENSE, BACKGROUND_INTENSE
+    NO_COLOR -- Resets any previously used color codes
+    """
     env = builtins.__xonsh_env__
     cwd = env['PWD']
     branch = current_branch(cwd=cwd)
     branch = '' if branch is None else ' ' + branch
-    p = template.format(user=env.get('USER', '<user>'),
+    p = template.format(
+            user=env.get('USER', '<user>'),
             hostname=socket.gethostname(),
             cwd=cwd.replace(env['HOME'], '~'),
             curr_branch=branch,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -35,23 +35,20 @@ def current_branch(cwd=None):
     return s
 
 
-default_prompt_template = ('{GREEN}{user}@{hostname}{BLUE} '
-                           '{cwd}{RED}{curr_branch} {BLUE}${NO_COLOR} ')
+default_prompt = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
+                  '{cwd}{BOLD_RED}{curr_branch} {BOLD_BLUE}${NO_COLOR} ')
 
-def default_prompt():
-    """Returns the default xonsh prompt string. This takes no arguments."""
+def format_prompt(template=default_prompt):
+    """Formats a xonsh prompt template string."""
     env = builtins.__xonsh_env__
     cwd = env['PWD']
     branch = current_branch(cwd=cwd)
     branch = '' if branch is None else ' ' + branch
-    p = default_prompt_template.format(user=env.get('USER', '<user>'), 
+    p = template.format(user=env.get('USER', '<user>'),
             hostname=socket.gethostname(),
             cwd=cwd.replace(env['HOME'], '~'),
             curr_branch=branch,
-            RED=TERM_COLORS['BOLD_RED'],
-            BLUE=TERM_COLORS['BOLD_BLUE'],
-            GREEN=TERM_COLORS['BOLD_GREEN'],
-            NO_COLOR=TERM_COLORS['NO_COLOR'],
+            **TERM_COLORS
             )
     return p
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 
 from xonsh.execer import Execer
 from xonsh.completer import Completer
-from xonsh.environ import xonshrc_context, multiline_prompt
+from xonsh.environ import xonshrc_context, multiline_prompt, format_prompt
 
 RL_COMPLETION_SUPPRESS_APPEND = None
 
@@ -159,6 +159,8 @@ class Shell(Cmd):
             p = env['PROMPT']
             if callable(p):
                 p = p()
+            else:
+                p = format_prompt(p)
         else:
             p = "set '$PROMPT = ...' $ "
         return p


### PR DESCRIPTION
Changing the prompt in a meaningful way usually requires me to write a function, but I found myself duplicating a lot of the code in `default_prompt()` for that. Small changes could also be made by doing

```
from xonsh import environ
environ.default_prompt_template = ...
```

but this feels a bit hacky. I wondered if it wouldn't be more convenient if $PROMPT would automatically format itself if it's a string. Setting the prompt to a static string seems rather unusual to me. What do you think?