### PR TITLE
Attempt to fix #34

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -13,9 +13,9 @@ from subprocess import Popen, PIPE
 from contextlib import contextmanager
 from collections import Sequence, MutableMapping, Iterable, namedtuple
 
-from xonsh.tools import string_types, redirect_stdout, redirect_stderr
+from xonsh.tools import string_types, redirect_stdout, redirect_stderr, is_function_string
 from xonsh.inspectors import Inspector
-from xonsh.environ import default_env, locale_env
+from xonsh.environ import BASE_ENV, default_env, locale_env
 from xonsh.aliases import DEFAULT_ALIASES
 
 ENV = None
@@ -45,7 +45,13 @@ class Env(MutableMapping):
         if len(args) == 0 and len(kwargs) == 0:
             args = (os.environ,)
         for key, val in dict(*args, **kwargs).items():
-            self[key] = val
+            if is_function_string(val):
+                if key in (ENV or {}):
+                    self[key] = ENV[key]
+                elif key in BASE_ENV:
+                    self[key] = BASE_ENV[key]
+            else:
+                self[key] = val
         self._detyped = None
         self._orig_env = None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -9,7 +9,7 @@ import platform
 import subprocess
 from warnings import warn
 
-from xonsh.tools import TERM_COLORS
+from xonsh.tools import TERM_COLORS, is_function_string
 
 def current_branch(cwd=None):
     """Gets the branch for a current working directory. Returns None
@@ -112,8 +112,7 @@ def bash_env():
     except subprocess.CalledProcessError:
         s = ''
     items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
-    env = dict(items)
-    return env
+    return {k:v for (k,v) in items if not is_function_string(v)}
 
 def xonshrc_context(rcfile=None, execer=None):
     """Attempts to read in xonshrc file, and return the contents."""

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -60,7 +60,7 @@ RE_HIDDEN = re.compile('\001.*?\002')
 
 def multiline_prompt():
     """Returns the filler text for the prompt in multiline scenarios."""
-    curr = builtins.__xonsh_env__.get('PROMPT', "set '$PROMPT = ...' $ ")
+    curr = builtins.__xonsh_env__.get('XONSH_PROMPT', "set '$XONSH_PROMPT = ...' $ ")
     curr = curr() if callable(curr) else curr
     line = curr.rsplit('\n', 1)[1] if '\n' in curr else curr
     line = RE_HIDDEN.sub('', line)  # gets rid of colors
@@ -70,7 +70,7 @@ def multiline_prompt():
     # tail is the trailing whitespace
     tail = line if headlen == 0 else line.rsplit(head[-1], 1)[1]
     # now to constuct the actual string
-    dots = builtins.__xonsh_env__.get('MULTILINE_PROMPT', '.')
+    dots = builtins.__xonsh_env__.get('XONSH_MULTILINE_PROMPT', '.')
     dots = dots() if callable(dots) else dots
     if dots is None or len(dots) == 0:
         return ''
@@ -90,8 +90,8 @@ def locale_env():
 
 BASE_ENV = {
     'INDENT': '    ',
-    'PROMPT': default_prompt,
-    'MULTILINE_PROMPT': '.',
+    'XONSH_PROMPT': default_prompt,
+    'XONSH_MULTILINE_PROMPT': '.',
     'XONSHRC': os.path.expanduser('~/.xonshrc'),
     'XONSH_HISTORY_SIZE': 8128,
     'XONSH_HISTORY_FILE': os.path.expanduser('~/.xonsh_history'),

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -155,10 +155,11 @@ class Shell(Cmd):
                 self.mlprompt = multiline_prompt()
             return self.mlprompt
         env = builtins.__xonsh_env__
-        if 'PROMPT' in env:
-            p = env['PROMPT']
+        if 'XONSH_PROMPT' in env:
+            p = env['XONSH_PROMPT']
             if callable(p):
                 p = p()
+            env['PROMPT'] = p
         else:
-            p = "set '$PROMPT = ...' $ "
+            p = "set '$XONSH_PROMPT = ...' $ "
         return p

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -16,6 +16,7 @@ Implementations:
 
 """
 import sys
+import re
 
 if sys.version_info[0] >= 3:
     string_types = (str, bytes)
@@ -170,3 +171,10 @@ class redirect_stdout(_RedirectStream):
 class redirect_stderr(_RedirectStream):
     """Context manager for temporarily redirecting stderr to another file."""
     _stream = "stderr"
+
+def is_function_string(x):
+    try:
+        return re.match(r'<function .*? at 0x[0-9a-fA-F]+>', x) is not None
+    except:
+        return False
+


### PR DESCRIPTION
I was looking for a fix for #34, and the following has worked for me.  I am honestly not quite sure how things are fitting together here as far as the terminal emulators I have tried, but my current hypothesis is that they actually rely on the `PROMPT` environment variable, and of course they don't know how to interpret it as a Python function.  My proposed solution is to move the xonsh prompt to a variable called `XONSH_PROMPT`, and use that to update a string `PROMPT` (again, a bit hackish, but it seems to work).

I am not sure how best to reconcile this with #31, or whether this is even a change worth making.  What do you think?