### PR TITLE
change terminal title to show message or current directory

### DIFF
--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -4,6 +4,7 @@ import traceback
 from cmd import Cmd
 import builtins
 from argparse import Namespace
+import sys
 
 from xonsh.execer import Execer
 from xonsh.completer import Completer
@@ -147,6 +148,13 @@ class Shell(Cmd):
             self.reset_buffer()
             self.cmdloop(intro=None)
 
+    def settitle(self):
+        env = builtins.__xonsh_env__
+        t = env.get('XONSH_TITLE', env['PWD'].replace(env['HOME'], '~') + ' | xonsh')
+        if callable(t):
+            t = t()
+        sys.stdout.write("\x1b]2;%s\x07" % t)
+
     @property
     def prompt(self):
         """Obtains the current prompt string."""
@@ -161,4 +169,6 @@ class Shell(Cmd):
                 p = p()
         else:
             p = "set '$PROMPT = ...' $ "
+        if env.get('TERM','linux')!='linux':
+            self.settitle()
         return p

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -150,10 +150,13 @@ class Shell(Cmd):
 
     def settitle(self):
         env = builtins.__xonsh_env__
-        t = env.get('XONSH_TITLE', env['PWD'].replace(env['HOME'], '~') + ' | xonsh')
-        if callable(t):
-            t = t()
-        sys.stdout.write("\x1b]2;%s\x07" % t)
+        if 'XONSH_TITLE' in env:
+            t = env['XONSH_TITLE']
+            if callable(t):
+                t = t()
+        else:
+            t = '{0} | xonsh'.format(env['PWD'].replace(env['HOME'], '~'))
+        sys.stdout.write("\x1b]2;{0}\x07".format(t))
 
     @property
     def prompt(self):
@@ -169,6 +172,6 @@ class Shell(Cmd):
                 p = p()
         else:
             p = "set '$PROMPT = ...' $ "
-        if env.get('TERM','linux')!='linux':
+        if env.get('TERM', 'linux') != 'linux':
             self.settitle()
         return p


### PR DESCRIPTION
This is a proposed change that lets xonsh update the title of a virtual terminal to show a message (specified via a function or a string in the `XONSH_TITLE` environment variable).  Currently defaults to showing the current working directory.  I do a lot of work in tabbed terminals, and this small addition has made a world of difference for me.

The check in lines 172-173 is so that xonsh doesn't try to set the title when running in a tty.  I am not sure if there is actually a robust cross-platform way to detect whether one is running in a tty or not; if so, then this check should definitely be replaced.