### PR TITLE
Update to #38 (Virtual Terminal Title)

### DIFF
--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -165,7 +165,8 @@ class Shell(Cmd):
             if callable(t):
                 t = t()
         else:
-            t = '{0} | xonsh'.format(env['PWD'].replace(env['HOME'], '~'))
+            t = '{user}@{hostname}: {cwd} | xonsh'
+        t = format_prompt(t)
         sys.stdout.write("\x1b]2;{0}\x07".format(t))
 
     @property

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -157,7 +157,8 @@ class Shell(Cmd):
 
     def settitle(self):
         env = builtins.__xonsh_env__
-        if env.get('TERM', None) is None:
+        term = env.get('TERM',None)
+        if term is None or term == 'linux':
             return
         if 'XONSH_TITLE' in env:
             t = env['XONSH_TITLE']


### PR DESCRIPTION
This patch tries to make sure that xonsh only tries to set the title when running in a virtual terminal.