### PR TITLE
Accept -c argument (a la bash)

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -11,8 +11,18 @@ def main(argv=None):
     """Main entry point for xonsh cli."""
     if argv is None:
         argv = sys.argv[1:]
+
+    mode = 'shell'
+
+    if '-c' in argv:
+        mode = 'command'
+        argv.remove('-c')
+
     shell = Shell()
-    shell.cmdloop()
+    if mode == 'shell':
+        shell.cmdloop()
+    else:
+        shell.default(' '.join(argv))
 
 if __name__ == '__main__':
     main()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -7,22 +7,24 @@ from argparse import ArgumentParser, Namespace
 
 from xonsh.shell import Shell
 
+parser = ArgumentParser(description='xonsh')
+parser.add_argument('-c', 
+        help="Run a single command and exit", 
+        dest='command', 
+        required=False, 
+        default=None)
+
 def main(argv=None):
     """Main entry point for xonsh cli."""
-    if argv is None:
-        argv = sys.argv[1:]
 
-    mode = 'shell'
-
-    if '-c' in argv:
-        mode = 'command'
-        argv.remove('-c')
+    args = parser.parse_args()
 
     shell = Shell()
-    if mode == 'shell':
+
+    if args.command is None:
         shell.cmdloop()
     else:
-        shell.default(' '.join(argv))
+        shell.default(args.command)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This patch allows xonsh to run a single command with the -c argument, similar to bash (though not quite 100% compatable since here the command to be run must follow -c directly).

This seems to allow running a single command through ssh to a machine running xonsh (which is what I was hoping to accomplish), e.g. `ssh machine_running_xonsh echo "hello"`