### PR TITLE
Prompt documentation (for #31)

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -168,6 +168,9 @@ variable           default                     description
 ================== =========================== ================================
 PROMPT             xosh.environ.default_prompt The prompt text, may be str or 
                                                function which returns a str.
+                                               The str may contain keyword
+                                               arguments which are
+                                               auto-formatted (see below).
 MULTILINE_PROMPT   ``'.'``                     Prompt text for 2nd+ lines of
                                                input, may be str or 
                                                function which returns a str.
@@ -182,8 +185,19 @@ BASH_COMPLETIONS   ``[] or ['/etc/...']``      This is a list of strings that
                                                dependent, but sane.
 ================== =========================== ================================
 
-Customizing the prompt is probably the most common reason for altering an 
-environment variable.
+Customizing the prompt is probably the most common reason for altering an
+environment variable.  To make this easier, you can use keyword
+arguments in a prompt string that will get replaced automatically:
+
+.. code-block:: bash
+
+    >>> $PROMPT = '{user}@{hostname}:{cwd} > '
+    snail@home:~ > # it works!
+
+You can also color your prompt easily by inserting keywords such as ``{GREEN}``
+or ``{BOLD_BLUE}`` -- for the full list of keyword arguments, refer to the API
+documentation of :py:func:`xonsh.environ.format_prompt`.
+
 
 Environment Lookup with ``${}``
 ================================

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -42,17 +42,18 @@ def format_prompt(template=default_prompt):
     """Formats a xonsh prompt template string.
 
     The following keyword arguments are recognized in the template string:
-    user -- Name of current user
-    hostname -- Name of host computer
-    cwd -- Current working directory
-    curr_branch -- Name of current git branch (preceded by a space), if any
-    (QUALIFIER_)COLORNAME -- Inserts an ANSI color code
-        COLORNAME can be any of:
-            BLACK, RED, GREEN, YELLOW, BLUE, PURPLE, CYAN, WHITE
-        QUALIFIER is optional and can be any of:
-            BOLD, UNDERLINE, BACKGROUND, INTENSE,
-            BOLD_INTENSE, BACKGROUND_INTENSE
-    NO_COLOR -- Resets any previously used color codes
+
+    + user -- Name of current user
+    + hostname -- Name of host computer
+    + cwd -- Current working directory
+    + curr_branch -- Name of current git branch (preceded by a space), if any
+    + (QUALIFIER\_)COLORNAME -- Inserts an ANSI color code
+        - COLORNAME can be any of:
+              BLACK, RED, GREEN, YELLOW, BLUE, PURPLE, CYAN, WHITE
+        - QUALIFIER is optional and can be any of:
+              BOLD, UNDERLINE, BACKGROUND, INTENSE,
+              BOLD_INTENSE, BACKGROUND_INTENSE
+    + NO_COLOR -- Resets any previously used color codes
     """
     env = builtins.__xonsh_env__
     cwd = env['PWD']


### PR DESCRIPTION
I kept this pretty short for now.

I agree that a separate doc page for environment variables would be nice, but I wasn't sure how to best fit that into the current structure of the docs. Split up the tutorial into several files? Make a subsection "User guide" that contains more detailed information than the tutorial? Just make another page on the same level as the others?