### PR TITLE
Add a #coding declaration to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding=utf-8
 """The xonsh installer."""
 from __future__ import print_function, unicode_literals
 import os


### PR DESCRIPTION
Python2 won't even parse Unicode files without a #coding declaration, because it assumes ascii.

This way, at least you get a sane error (`xonsh currently requires Python 3.4+`).