### PR TITLE
update oldpwd when using cd

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -25,9 +25,9 @@ def cd(args, stdin=None):
         return '', 'cd: no such file or directory: {0}\n'.format(d)
     if not os.path.isdir(d):
         return '', 'cd: {0} is not a directory\n'.format(d)
-    env.update({'OLDPWD': os.getcwd()})
+    env['OLDPWD'] = os.getcwd()
     os.chdir(d)
-    env.update({'PWD': os.getcwd()})
+    env['PWD'] = os.getcwd()
     return None, None
 
 def exit(args, stdin=None):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -11,7 +11,8 @@ def cd(args, stdin=None):
     If no directory is specified (i.e. if `args` is None) then this
     changes to the current user's home directory.
     """
-    cur_oldpwd = builtins.__xonsh_env__['OLDPWD']
+    env = builtins.__xonsh_env__
+    cur_oldpwd = env.get('OLDPWD') or os.getcwd()
     if len(args) == 0:
         d = os.path.expanduser('~')
     elif len(args) == 1:
@@ -24,9 +25,9 @@ def cd(args, stdin=None):
         return '', 'cd: no such file or directory: {0}\n'.format(d)
     if not os.path.isdir(d):
         return '', 'cd: {0} is not a directory\n'.format(d)
-    builtins.__xonsh_env__['OLDPWD'] = os.getcwd()
+    env.update({'OLDPWD': os.getcwd()})
     os.chdir(d)
-    builtins.__xonsh_env__['PWD'] = os.getcwd()
+    env.update({'PWD': os.getcwd()})
     return None, None
 
 def exit(args, stdin=None):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -12,7 +12,6 @@ def cd(args, stdin=None):
     changes to the current user's home directory.
     """
     cur_oldpwd = builtins.__xonsh_env__['OLDPWD']
-    builtins.__xonsh_env__['OLDPWD'] = os.getcwd()
     if len(args) == 0:
         d = os.path.expanduser('~')
     elif len(args) == 1:
@@ -25,6 +24,7 @@ def cd(args, stdin=None):
         return '', 'cd: no such file or directory: {0}\n'.format(d)
     if not os.path.isdir(d):
         return '', 'cd: {0} is not a directory\n'.format(d)
+    builtins.__xonsh_env__['OLDPWD'] = os.getcwd()
     os.chdir(d)
     builtins.__xonsh_env__['PWD'] = os.getcwd()
     return None, None

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -11,10 +11,14 @@ def cd(args, stdin=None):
     If no directory is specified (i.e. if `args` is None) then this
     changes to the current user's home directory.
     """
+    cur_oldpwd = builtins.__xonsh_env__['OLDPWD']
+    builtins.__xonsh_env__['OLDPWD'] = os.getcwd()
     if len(args) == 0:
         d = os.path.expanduser('~')
     elif len(args) == 1:
         d = args[0]
+        if d == '-':
+            d = cur_oldpwd
     else:
         return '', 'cd takes 0 or 1 arguments, not {0}\n'.format(len(args))
     if not os.path.exists(d):


### PR DESCRIPTION
The cd alias now updates $OLDPWD and also checks if the argument is a
‘-‘ (single dash) and cd to $OLDPWD if it is. Based on bash’s cd
behaviour. http://ss64.com/bash/cd.html