### PR TITLE
Fixes #56 about taking over bash aliases into xonsh.

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -69,8 +69,6 @@ def bash_aliases():
     return dict(aliases)
 
 
-BASH_ALIASES = bash_aliases()
-
 DEFAULT_ALIASES = {
     'cd': cd,
     'EOF': exit,

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -64,7 +64,8 @@ def bash_aliases():
     except subprocess.CalledProcessError:
         s = ''
     items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
-    aliases = [(item[0][6:],shlex.split(item[1].strip('\''))) for item in items]
+    aliases = [(item[0][6:], shlex.split(item[1].strip('\''))) \
+                for item in items]
     return dict(aliases)
 
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -5,6 +5,7 @@ import platform
 import builtins
 import subprocess
 import shlex
+from warnings import warn
 
 def cd(args, stdin=None):
     """Changes the directory.
@@ -64,9 +65,17 @@ def bash_aliases():
     except subprocess.CalledProcessError:
         s = ''
     items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
-    aliases = [(item[0][6:], shlex.split(item[1].strip('\''))) \
-                for item in items]
-    return dict(aliases)
+    aliases = dict()
+    for key,value in items:
+        try:
+            key = key[6:]
+            value = value.strip('\'')
+            value = shlex.split(value)
+            aliases[key] = value
+        except Exception as exc:
+            warn('could not parse Bash alias "{0}": {1!r}'.format(key,exc),
+                    RuntimeWarning)
+    return aliases
 
 
 DEFAULT_ALIASES = {

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -4,6 +4,7 @@ import os
 import platform
 import builtins
 import subprocess
+import shlex
 
 def cd(args, stdin=None):
     """Changes the directory.
@@ -54,6 +55,20 @@ def source_bash(args, stdin=None):
             continue  # no change from original
         env[k] = v
     return
+
+def bash_aliases():
+    try:
+        s = subprocess.check_output(['bash', '-i'], input='alias',
+                                    stderr=subprocess.PIPE,
+                                    universal_newlines=True)
+    except subprocess.CalledProcessError:
+        s = ''
+    items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
+    aliases = [(item[0][6:],shlex.split(item[1].strip('\''))) for item in items]
+    return dict(aliases)
+
+
+BASH_ALIASES = bash_aliases()
 
 DEFAULT_ALIASES = {
     'cd': cd,

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -16,7 +16,7 @@ from collections import Sequence, MutableMapping, Iterable, namedtuple
 from xonsh.tools import string_types, redirect_stdout, redirect_stderr, suggest_commands
 from xonsh.inspectors import Inspector
 from xonsh.environ import default_env
-from xonsh.aliases import DEFAULT_ALIASES
+from xonsh.aliases import DEFAULT_ALIASES, BASH_ALIASES
 
 ENV = None
 BUILTINS_LOADED = False
@@ -415,6 +415,7 @@ def load_builtins(execer=None):
     builtins.execx = None if execer is None else execer.exec
     builtins.compilex = None if execer is None else execer.compile
     builtins.aliases = Aliases(DEFAULT_ALIASES)
+    builtins.aliases._raw.update(BASH_ALIASES)
     BUILTINS_LOADED = True
 
 def unload_builtins():

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -16,7 +16,7 @@ from collections import Sequence, MutableMapping, Iterable, namedtuple
 from xonsh.tools import string_types, redirect_stdout, redirect_stderr, suggest_commands
 from xonsh.inspectors import Inspector
 from xonsh.environ import default_env
-from xonsh.aliases import DEFAULT_ALIASES, BASH_ALIASES
+from xonsh.aliases import DEFAULT_ALIASES, bash_aliases
 
 ENV = None
 BUILTINS_LOADED = False
@@ -415,7 +415,7 @@ def load_builtins(execer=None):
     builtins.execx = None if execer is None else execer.exec
     builtins.compilex = None if execer is None else execer.compile
     builtins.aliases = Aliases(DEFAULT_ALIASES)
-    builtins.aliases._raw.update(BASH_ALIASES)
+    builtins.aliases.update(bash_aliases())
     BUILTINS_LOADED = True
 
 def unload_builtins():


### PR DESCRIPTION
Not sure if the split and stripping of 'alias ' and the single quotes is right, but it seems to work here.

I chose to add it to aliases.py instead of extending bash_env() in environ.py since it felt better that way.

BTW, in built_ins.py calling builtins.aliases.update instead of builtins.aliases._raw.update failed with NoneType iterable error.