### PR TITLE
main.py takes script file or script on stdin

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -13,6 +13,11 @@ parser.add_argument('-c',
         dest='command', 
         required=False, 
         default=None)
+parser.add_argument('file',
+        metavar='script-file',
+        help='If present, execute the script contained in script-file and exit',
+        nargs='?',
+        default=None)
 
 def main(argv=None):
     """Main entry point for xonsh cli."""
@@ -21,10 +26,23 @@ def main(argv=None):
 
     shell = Shell()
 
-    if args.command is None:
-        shell.cmdloop()
-    else:
+    if args.command is not None:
+        # run a single command and exit
         shell.default(args.command)
+    elif args.file is not None:
+        if os.path.isfile(args.file):
+            with open(args.file) as f:
+                for line in f:
+                    shell.default(line)
+        else:
+            print('xonsh: {0}: No such file or directory.'.format(args.file))
+    elif not sys.stdin.isatty():
+        # run a script given on stdin
+        for line in sys.stdin:
+            shell.default(line)
+    else:
+        # otherwise, enter the shell
+        shell.cmdloop()
 
 if __name__ == '__main__':
     main()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -33,14 +33,14 @@ def main(argv=None):
         # run a script contained in a file
         if os.path.isfile(args.file):
             with open(args.file) as f:
-                code = shell.execer.compile(f.read(), mode='exec')
-                shell.execer.exec(code, mode='exec')
+                code = shell.execer.compile(f.read(), mode='exec', glbs=shell.ctx)
+                shell.execer.exec(code, mode='exec', glbs=shell.ctx)
         else:
             print('xonsh: {0}: No such file or directory.'.format(args.file))
     elif not sys.stdin.isatty():
         # run a script given on stdin
-        code = shell.execer.compile(sys.stdin.read(), mode='exec')
-        shell.execer.exec(code, mode='exec')
+        code = shell.execer.compile(sys.stdin.read(), mode='exec', glbs=shell.ctx)
+        shell.execer.exec(code, mode='exec', glbs=shell.ctx)
     else:
         # otherwise, enter the shell
         shell.cmdloop()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -33,14 +33,14 @@ def main(argv=None):
         # run a script contained in a file
         if os.path.isfile(args.file):
             with open(args.file) as f:
-                for line in f:
-                    shell.default(line)
+                code = shell.execer.compile(f.read(), mode='exec')
+                shell.execer.exec(code, mode='exec')
         else:
             print('xonsh: {0}: No such file or directory.'.format(args.file))
     elif not sys.stdin.isatty():
         # run a script given on stdin
-        for line in sys.stdin:
-            shell.default(line)
+        code = shell.execer.compile(sys.stdin.read(), mode='exec')
+        shell.execer.exec(code, mode='exec')
     else:
         # otherwise, enter the shell
         shell.cmdloop()

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -30,6 +30,7 @@ def main(argv=None):
         # run a single command and exit
         shell.default(args.command)
     elif args.file is not None:
+        # run a script contained in a file
         if os.path.isfile(args.file):
             with open(args.file) as f:
                 for line in f:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -33,8 +33,9 @@ def main(argv=None):
         # run a script contained in a file
         if os.path.isfile(args.file):
             with open(args.file) as f:
-                code = shell.execer.compile(f.read(), mode='exec', glbs=shell.ctx)
-                shell.execer.exec(code, mode='exec', glbs=shell.ctx)
+                code = f.read()
+            code = shell.execer.compile(code, mode='exec', glbs=shell.ctx)
+            shell.execer.exec(code, mode='exec', glbs=shell.ctx)
         else:
             print('xonsh: {0}: No such file or directory.'.format(args.file))
     elif not sys.stdin.isatty():


### PR DESCRIPTION
This is an attempt to fix issue #92.

main.py now takes an optional positional argument, the filename of a script to be run.  If present, xonsh will execute that script and exit, rather than entering the command loop (e.g., `xonsh some_xonsh_script`)

If stdin is non-empty and no filename is specified, xonsh will run the contents of stdin as a xonsh script and exit, rather than entering the command loop (e.g., `echo "print(7+3)" | xonsh`).