### PR TITLE
Documentation and refactoring of window title and suggestions

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -174,6 +174,13 @@ PROMPT             xosh.environ.default_prompt The prompt text, may be str or
 MULTILINE_PROMPT   ``'.'``                     Prompt text for 2nd+ lines of
                                                input, may be str or 
                                                function which returns a str.
+TITLE              xonsh.environ.default_title The title text for the window
+                                               in which xonsh is running.  As
+                                               with PROMPT, may be a str or a
+                                               function that returns a str.
+                                               The str is formatted in the
+                                               same manner as PROMPT (see 
+                                               below).
 XONSHRC            ``'~/.xonshrc'``            Location of run control file
 XONSH_HISTORY_SIZE 8128                        Number of items to store in the
                                                history.
@@ -181,8 +188,23 @@ XONSH_HISTORY_FILE ``'~/.xonsh_history'``      Location of history file
 BASH_COMPLETIONS   ``[] or ['/etc/...']``      This is a list of strings that 
                                                specifies where the BASH 
                                                completion files may be found. 
-                                               The default values is platform
+                                               The default values are platform
                                                dependent, but sane.
+SUGGEST_COMMANDS   ``True``                    When a user types an invalid
+                                               command, xonsh will try to offer
+                                               suggestions of similar valid 
+                                               commands if this is ``True``.
+SUGGEST_THRESHOLD  ``3``                       An error threshold.  If the
+                                               Levenshtein distance between the
+                                               entered command and a valid
+                                               command is less than this value,
+                                               the valid command will be 
+                                               offered as a suggestion.
+SUGGEST_MAX_NUM    ``5``                       xonsh will show at most this
+                                               many suggestions in response to
+                                               an invalid command.  If 
+                                               negative, there is no limit to
+                                               how many suggestions are shown.
 ================== =========================== ================================
 
 Customizing the prompt is probably the most common reason for altering an

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -49,6 +49,7 @@ def current_branch(cwd=None):
 
 default_prompt = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
                   '{cwd}{BOLD_RED}{curr_branch} {BOLD_BLUE}${NO_COLOR} ')
+default_title = '{user}@{hostname}: {cwd} | xonsh'
 
 def format_prompt(template=default_prompt):
     """Formats a xonsh prompt template string.
@@ -106,6 +107,7 @@ def multiline_prompt():
 BASE_ENV = {
     'INDENT': '    ',
     'PROMPT': default_prompt,
+    'TITLE': default_title,
     'MULTILINE_PROMPT': '.',
     'XONSHRC': os.path.expanduser('~/.xonshrc'),
     'XONSH_HISTORY_SIZE': 8128,

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -172,12 +172,12 @@ class Shell(Cmd):
         term = env.get('TERM', None)
         if term is None or term == 'linux':
             return
-        if 'XONSH_TITLE' in env:
-            t = env['XONSH_TITLE']
+        if 'TITLE' in env:
+            t = env['TITLE']
             if callable(t):
                 t = t()
         else:
-            t = '{user}@{hostname}: {cwd} | xonsh'
+            return
         t = format_prompt(t)
         sys.stdout.write("\x1b]2;{0}\x07".format(t))
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -224,7 +224,7 @@ class redirect_stderr(_RedirectStream):
 def suggest_commands(cmd, env, aliases):
     """Suggests alternative commands given an environment and aliases."""
     if(env.get('SUGGEST_COMMANDS', True)):
-        threshold = env.get('SUGGEST_ERROR_THRESHOLD', 3)
+        threshold = env.get('SUGGEST_THRESHOLD', 3)
         max_sugg = env.get('SUGGEST_MAX_NUM', 5)
         if max_sugg < 0:
             max_sugg = float('inf')


### PR DESCRIPTION
Documentation for the environment variables for setting the window title and offering suggestions for mis-typed commands.  

I renamed some of these variables and shuffled things around a little bit, in an attempt to avoid screwing up the table of environment variables in the docs, and for more consistent (I think) naming of environment variables.