### PR TITLE
Removed `subproc_line`, fixed typos, small changes

### DIFF
--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -91,7 +91,7 @@ class CtxAwareTransformer(NodeTransformer):
 
     def ctxremove(self, value):
         """Removes a value the most recent context."""
-        for ctx in self.contexts[::-1]:
+        for ctx in reversed(self.contexts):
             if value in ctx:
                 ctx.remove(value)
                 break
@@ -121,7 +121,7 @@ class CtxAwareTransformer(NodeTransformer):
         if lname is None:
             return node
         inscope = False
-        for ctx in self.contexts[::-1]:
+        for ctx in reversed(self.contexts):
             if lname in ctx:
                 inscope = True 
                 break
@@ -135,11 +135,10 @@ class CtxAwareTransformer(NodeTransformer):
         return node
 
     def visit_Expr(self, node):
-        inscope = self.is_in_scope(node)
-        if inscope:
+        if self.is_in_scope(node):
             return node
-        newnode = self.try_subproc_toks(node)
-        return newnode
+        else:
+            return self.try_subproc_toks(node)
 
     def visit_Assign(self, node):
         ups = set()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -301,7 +301,7 @@ def _run_callable_subproc(alias, cmd, captured=True, prev_proc=None,
 
 def run_subproc(cmds, captured=True):
     """Runs a subprocess, in its many forms. This takes a list of 'commands,'
-    which may be a list of command line arguments or a string, represnting
+    which may be a list of command line arguments or a string, representing
     a special connecting character.  For example::
 
         $ ls | grep wakka
@@ -419,7 +419,7 @@ def load_builtins(execer=None):
     BUILTINS_LOADED = True
 
 def unload_builtins():
-    """Removes the xonsh builtins from the Python builins, if the 
+    """Removes the xonsh builtins from the Python builtins, if the 
     BUILTINS_LOADED is True, sets BUILTINS_LOADED to False, and returns.
     """
     global BUILTINS_LOADED, ENV

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -9,7 +9,7 @@ from collections import Iterable, Sequence, Mapping
 
 from xonsh import ast
 from xonsh.parser import Parser
-from xonsh.tools import subproc_line, subproc_toks
+from xonsh.tools import subproc_toks
 from xonsh.built_ins import load_builtins, unload_builtins
 
 class Execer(object):
@@ -46,11 +46,11 @@ class Execer(object):
             ctx = set(ctx.keys())
 
         # Parsing actually happens in a couple of phases. The first is a
-        # shortcut for a context-free parser. Nomrally, all subprocess
+        # shortcut for a context-free parser. Normally, all subprocess
         # lines should be wrapped in $(), to indicate that they are a 
         # subproc. But that would be super annoying. Unfortnately, Python
         # mode - after indentation - is whitespace agnostic while, using 
-        # the Python token, subproc mode is whitepsace aware. That is to say,
+        # the Python token, subproc mode is whitespace aware. That is to say,
         # in Python mode "ls -l", "ls-l", and "ls - l" all parse to the 
         # same AST because whitespace doesn't matter to the minus binary op. 
         # However, these phases all have very different meaning in subproc
@@ -67,7 +67,7 @@ class Execer(object):
         # because the "ls -l" is valid Python. The only way that we know 
         # it is not actually Python is by checking to see if the first token
         # (ls) is part of the execution context. If it isn't, then we will 
-        # assume that this line is suppossed to be a subprocess line, assuming
+        # assume that this line is supposed to be a subprocess line, assuming
         # it also is valid as a subprocess line.
         tree = self.ctxtransformer.ctxvisit(tree, input, ctx, mode=mode)
         return tree
@@ -118,9 +118,8 @@ class Execer(object):
                             mode=mode, debug_level=self.debug_level)
                 parsed = True
             except SyntaxError as e:
-                if (e.loc is None) or (last_error_line == e.loc.lineno and 
-                                      ((last_error_col == e.loc.column + 1) or
-                                       (last_error_col == e.loc.column))):
+                if (e.loc is None) or (last_error_line == e.loc.lineno and
+                                       last_error_col in (e.loc.column + 1, e.loc.column)):
                     raise
                 last_error_col = e.loc.column
                 last_error_line = e.loc.lineno
@@ -143,7 +142,7 @@ class Execer(object):
                 sbpline = subproc_toks(line, returnline=True, 
                                        maxcol=maxcol, lexer=self.parser.lexer)
                 if sbpline is None:
-                    # subporcess line had no valid tokens, likely because
+                    # subprocess line had no valid tokens, likely because
                     # it only contained a comment.
                     del lines[idx]
                     last_error_line = last_error_col = -1

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1901,7 +1901,7 @@ class Parser(object):
         p1, p2 = p[1], p[2]
         col = self.col
         lineno = self.lineno
-        if lenp == 3:
+        if lenp == 3: # $NAME
             p0 = self._envvar_by_name(p2, lineno=lineno, col=col)
         elif p1 == '${':
             xenv = self._xenv(lineno=lineno, col=col)
@@ -1919,7 +1919,7 @@ class Parser(object):
         return p0
 
     def _xenv(self, lineno=lineno, col=col):
-        """Creates a new xonsh env referece."""
+        """Creates a new xonsh env reference."""
         return ast.Name(id='__xonsh_env__', ctx=ast.Load(), lineno=lineno,
                         col_offset=col)
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -30,18 +30,6 @@ else:
 
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
-def subproc_line(line):
-    """Excapsulates a source code line in a uncaptured subprocess $[]."""
-    tok = line.split(None, 1)[0]
-    line = line.replace(tok, '$[' + tok, 1)
-    if line.endswith('\n'):
-        line += ']'
-    else:
-        len_nl = len(line)
-        no_nl = line.rstrip('\n')
-        line = no_nl + ']' + ('\n'*(len_nl-len(no_nl)))
-    return line
-
 def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
     """Excapsulates tokens in a source code line in a uncaptured 
     subprocess $[] starting at a minimum column. If there are no tokens 


### PR DESCRIPTION
`subproc_line` wasn't used and probably contained a bug (I think there should be a `not` in the if clause, only way it makes sense), so I just assumed it could be removed. I could be mistaken.

I haven't actually tested the changes as I'm running python 3.2, so I made sure to not to change behavior, but there's a risk of typo-type errors.