### PR TITLE
convert result of ${} expression to string

### DIFF
--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -2045,7 +2045,10 @@ class Parser(object):
             p0 = self._envvar_by_name(p[2], lineno=self.lineno, col=self.col)
             p0._cliarg_action = 'ensure_list'
         elif p1 == '${':
-            p0 = p[2]
+            l = self.lineno
+            c = self.col
+            n = ast.Name("str", ast.Load(), lineno=l, col_offset=c)
+            p0 = ast.Call(n, [p[2]], [], None, None, lineno=l, col_offset=c)
             p0._cliarg_action = 'append'
         elif p1 == '$(':
             p0 = xonsh_call('__xonsh_subproc_captured__', args=p[2],


### PR DESCRIPTION
This is an attempt to deal with part of #86 by converting the results of `${...}` expressions to strings automatically.  Now, for example, the following works:

```
$ echo ${20+2.}
22.0
```