### PR TITLE
Fall back to using git binary to determine branch when necessary

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -53,7 +53,7 @@ def current_branch(cwd=None):
             s = s.strip()
             if s != '':
                 branch = s
-        except:
+        except subprocess.CalledProcessError:
             pass
 
     return branch

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -44,6 +44,18 @@ def current_branch(cwd=None):
         except subprocess.CalledProcessError:
             continue
 
+    # fall back to using the git binary if the above failed
+    if branch is None:
+        try:
+            s = subprocess.check_output(['git', 'rev-parse','--abbrev-ref', 'HEAD'],
+                    stderr=subprocess.PIPE, cwd=cwd,
+                    universal_newlines=True) 
+            s = s.strip()
+            if s != '':
+                branch = s
+        except:
+            pass
+
     return branch
 
 


### PR DESCRIPTION
Resurrecting #74 (in response to issue #73), this time using the git binary only as a fallback, for when the current method fails.