### PR TITLE
Allow running scripts not in the path

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -300,6 +300,38 @@ def _run_callable_subproc(alias, cmd, captured=True, prev_proc=None,
         proc = ProcProxy(rtnout, rtnerr)
     return proc
 
+def is_script(fname):
+    """
+    Checks whether a file should be considered for running as a script
+    """
+    return os.path.isfile(fname) and fname != os.path.basename(fname)
+
+def get_script_subproc_command(fname, args):
+    """
+    Given the name of a script outside the path, returns a list representing
+    an appropriate subprocess command to execute the script.  Raises
+    PermissionError if the script is not executable.
+    """
+    # make sure file is executable
+    if not os.access(fname, os.X_OK):
+        raise PermissionError
+    
+    # find interpreter
+    with open(fname) as f:
+        first_line = f.readline().strip()
+    m = re.match(r'#![ \t]*(.+?)$', first_line)
+    
+    # xonsh is the default interpreter
+    if m is None:
+        interp = ['xonsh']
+    else:
+        interp = m.group(1).strip()
+        if len(interp) > 0:
+            interp = shlex.split(interp)
+        else:
+            interp = ['xonsh']
+
+    return interp + [fname] + args
 
 def run_subproc(cmds, captured=True):
     """Runs a subprocess, in its many forms. This takes a list of 'commands,'
@@ -337,27 +369,13 @@ def run_subproc(cmds, captured=True):
         stdout = last_stdout if cmd is last_cmd else PIPE
         uninew = cmd is last_cmd
         alias = builtins.aliases.get(cmd[0], None)
-        if os.path.isfile(cmd[0]) and cmd[0] != os.path.basename(cmd[0]):
-            aliased_cmd = cmd
-            fname = cmd[0]
-            # make sure file is executable
-            if not (os.access(fname, os.X_OK)):
-                cmd = aliased_cmd[0]
-                print('xonsh: subprocess mode: permission denied: {0}'.format(cmd))
+        if is_script(cmd[0]):
+            try:
+                aliased_cmd = get_script_subproc_command(cmd[0], cmd[1:]) 
+            except PermissionError:
+                e = 'xonsh: subprocess mode: permission denied: {0}'
+                print(e.format(cmd[0]))
                 return
-            # find interpreter
-            with open(fname) as f:
-                first_line = f.readline().strip()
-            m = re.match(r'#![ \t]*(.+?)$', first_line)
-            if m is None:
-                interp = ['xonsh']
-            else:
-                interp = m.group(1).strip()
-                if interp != '':
-                    interp = shlex.split(interp)
-                else:
-                    interp = ['xonsh']
-            aliased_cmd = interp + [fname] + cmd[1:]
         elif alias is None:
             aliased_cmd = cmd
         elif callable(alias):
@@ -385,7 +403,7 @@ def run_subproc(cmds, captured=True):
             cmd = aliased_cmd[0]
             print('xonsh: subprocess mode: command not found: {0}'.format(cmd))
             s = suggest_commands(cmd, ENV, builtins.aliases)
-            if s.strip():
+            if len(s.strip()) > 0:
                 print(suggest_commands(cmd, ENV, builtins.aliases))
             return
         if prev_is_proxy:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -4,7 +4,6 @@ not to be confused with the special Python builtins module.
 import os
 import re
 import sys
-import stat
 import shlex
 import locale
 import builtins
@@ -342,7 +341,7 @@ def run_subproc(cmds, captured=True):
             aliased_cmd = cmd
             fname = cmd[0]
             # make sure file is executable
-            if not (stat.S_IXUSR & os.stat(fname)[stat.ST_MODE]):
+            if not (os.access(fname, os.X_OK)):
                 cmd = aliased_cmd[0]
                 print('xonsh: subprocess mode: permission denied: {0}'.format(cmd))
                 return


### PR DESCRIPTION
This changeset allows xonsh to run scripts with shebang lines as in bash, rather than having to invoke other interpreters directly.  Even though `subprocess` can handle shebang lines on its own, falling back to using xonsh as the default interpreter necessitates doing a little bit of checking.