### PR TITLE
Nested structures

### DIFF
--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1589,11 +1589,18 @@ class Parser(object):
                          | test_or_star_expr comma_test_or_star_expr_list comma_opt
         """
         p1, p2 = p[1], p[2]
-        p0 = ensure_has_elts(p1, lineno=self.lineno, col_offset=self.col)
+        p0 = ast.Tuple(elts=[p1], ctx=ast.Load(), lineno=self.lineno, 
+                      col_offset=self.col)
         if len(p) == 3:
             if p2 is None:
                 # split out grouping parentheses.
-                p0 = p0.elts[0]
+                p1 = p0.elts[0]
+                if isinstance(p1, ast.Tuple) and \
+                        (hasattr(p1, '_real_tuple') and p1._real_tuple):
+                    p1 = ast.Tuple(elts=[p1], ctx=ast.Load(), lineno=self.lineno,
+                                   col_offset=self.col)
+                    p0.elts[0] = p1
+                pass
             elif p2 == ',':
                 pass
             elif 'comps' in p2:

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1721,18 +1721,26 @@ class Parser(object):
         p1 = p[1]
         lenp = len(p)
         if lenp == 2:
-            p1 = ensure_has_elts(p1)
-            p0 = ast.Set(elts=p1.elts, ctx=ast.Load(), lineno=self.lineno, 
+            elts = [p1]
+            if isinstance(p1, ast.Tuple) and \
+                    not (hasattr(p1, '_real_tuple') and p1._real_tuple):
+                elts = p1.elts
+            p0 = ast.Set(elts=elts, ctx=ast.Load(), lineno=self.lineno, 
                          col_offset=self.col)
         elif lenp == 3:
             comps = p[2].get('comps', [])
             p0 = ast.SetComp(elt=p1, generators=comps, lineno=self.lineno, 
                              col_offset=self.col)
         elif lenp == 4:
-            p3 = ensure_has_elts(p[3])
-            p0 = ast.Dict(keys=[p1], values=p3.elts, ctx=ast.Load(),
+            p3 = p[3]
+            vals = [p3]
+            if isinstance(p3, ast.Tuple) and \
+                   not (hasattr(p3, '_real_tuple') and p3._real_tuple):
+                vals = p3.elts
+            p0 = ast.Dict(keys=[p1], values=vals, ctx=ast.Load(),
                           lineno=self.lineno, col_offset=self.col)
         elif lenp == 5:
+            print(p[1],p[2],p[3],p[4])
             comps = p[4].get('comps', [])
             p0 = ast.DictComp(key=p1, value=p[3], generators=comps,
                               lineno=self.lineno, col_offset=self.col)

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1699,9 +1699,9 @@ class Parser(object):
                     | test
         """
         lenp = len(p)
-        p1 = p[1]
+        p1 = ast.Tuple(elts=[p[1]], ctx=ast.Load(), lineno=self.lineno, 
+                      col_offset=self.col)
         if lenp > 2:
-            p1 = ensure_has_elts(p1, lineno=self.lineno, col_offset=self.col)
             p2 = p[2] if lenp > 2 else []
             p2 = [] if p2 == ',' else p2
             p1.elts += p2
@@ -1721,11 +1721,7 @@ class Parser(object):
         p1 = p[1]
         lenp = len(p)
         if lenp == 2:
-            elts = [p1]
-            if isinstance(p1, ast.Tuple) and \
-                    not (hasattr(p1, '_real_tuple') and p1._real_tuple):
-                elts = p1.elts
-            p0 = ast.Set(elts=elts, ctx=ast.Load(), lineno=self.lineno, 
+            p0 = ast.Set(elts=p1.elts, ctx=ast.Load(), lineno=self.lineno, 
                          col_offset=self.col)
         elif lenp == 3:
             comps = p[2].get('comps', [])


### PR DESCRIPTION
Attemped fix for issues #61 and #85, where xonsh interprets nested structures incorrectly (and an alternative to PR #100).

The issue was being unable to distinguish between an AST list or tuple node that was organic, and one that was created using `ensure_has_elts`.  Hopefully this catches most/all issues.  I'll continue to test, and would appreciate any feedback.