### PR TITLE
Allow arguments for xonsh shell scripts

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -91,11 +91,11 @@ class Env(MutableMapping):
 
     def __getitem__(self, key):
         m = re.match(r'ARG(\d+)',key)
-        if m is not None and 'ARGS' in self._d.keys():
+        if (m is not None) and (key not in self._d) and ('ARGS' in self._d):
             args = self._d['ARGS']
             ix = int(m.group(1))
             if ix >= len(args):
-                e = "Not enough arguments given to access argument {0}."
+                e = "Not enough arguments given to access ARG{0}."
                 raise IndexError(e.format(ix))
             return self._d['ARGS'][ix]
         return self._d[key]

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -90,6 +90,14 @@ class Env(MutableMapping):
     #
 
     def __getitem__(self, key):
+        m = re.match(r'ARG(\d+)',key)
+        if m is not None and 'ARGS' in self._d.keys():
+            args = self._d['ARGS']
+            ix = int(m.group(1))
+            if ix >= len(args):
+                e = "Not enough arguments given to access argument {0}."
+                raise IndexError(e.format(ix))
+            return self._d['ARGS'][ix]
         return self._d[key]
 
     def __setitem__(self, key, val):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -40,6 +40,8 @@ class Env(MutableMapping):
     use in a subprocess.
     """
 
+    _arg_regex = re.compile(r'ARG(\d+)') 
+
     def __init__(self, *args, **kwargs):
         """If no initial environment is given, os.environ is used."""
         self._d = {}
@@ -90,7 +92,7 @@ class Env(MutableMapping):
     #
 
     def __getitem__(self, key):
-        m = re.match(r'ARG(\d+)',key)
+        m = self._arg_regex.match(key)
         if (m is not None) and (key not in self._d) and ('ARGS' in self._d):
             args = self._d['ARGS']
             ix = int(m.group(1))

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -5,7 +5,8 @@ import shlex
 import subprocess
 from argparse import ArgumentParser, Namespace
 
-from xonsh.shell import Shell, builtins
+import builtins
+from xonsh.shell import Shell
 
 parser = ArgumentParser(description='xonsh')
 parser.add_argument('-c',

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -45,6 +45,7 @@ def main(argv=None):
             with open(args.file) as f:
                 code = f.read()
             code = code if code.endswith('\n') else code + '\n'
+            env['ARGS'] = [args.file] + args.args
             env['0'] = args.file
             for ix, arg in enumerate(args.args):
                 env[str(ix+1)] = arg

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -47,9 +47,6 @@ def main(argv=None):
                 code = f.read()
             code = code if code.endswith('\n') else code + '\n'
             env['ARGS'] = [args.file] + args.args
-            env['0'] = args.file
-            for ix, arg in enumerate(args.args):
-                env[str(ix+1)] = arg
             code = shell.execer.compile(code, mode='exec', glbs=shell.ctx)
             shell.execer.exec(code, mode='exec', glbs=shell.ctx)
         else:

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -2038,7 +2038,6 @@ class Parser(object):
                         | string_literal
                         | REGEXPATH
                         | DOLLAR NAME
-                        | DOLLAR INT_LITERAL
                         | AT_LPAREN test RPAREN
                         | DOLLAR_LBRACE test RBRACE
                         | DOLLAR_LPAREN subproc RPAREN


### PR DESCRIPTION
This change allows scripts to be run from xonsh with additional arguments (e.g., `xonsh test.sh uno zwei trois`), and for these arguments to be referenced within the script in bash style (with `$0`, `$1`, ...) by loading them into the script's environment.