### PR TITLE
xonsh should be able to run binaries outside the path, as well as scripts

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -414,6 +414,9 @@ def run_subproc(cmds, captured=True):
                 e = 'xonsh: subprocess mode: permission denied: {0}'
                 print(e.format(cmd[0]))
                 return
+            # fall back to trying to run directly with subproc
+            except:
+                aliased_cmd = cmd
         elif alias is None:
             aliased_cmd = cmd
         elif callable(alias):


### PR DESCRIPTION
This should fix the issue mentioned in #135, where xonsh has trouble handling binary files outside the path.  There might be something more elegant, but the simplest fix is to fall back to running the command exactly as specified if _anything_ goes wrong when trying to figure out how to run the specified file.