### PR TITLE
Command line switch --no-rc

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -14,6 +14,11 @@ parser.add_argument('-c',
                     dest='command',
                     required=False,
                     default=None)
+parser.add_argument('--no-rc',
+                    help="Do not load the .xonshrc file",
+                    dest='norc',
+                    action='store_true',
+                    default=False)
 parser.add_argument('file',
                     metavar='script-file',
                     help='If present, execute the script in script-file'
@@ -33,7 +38,7 @@ def main(argv=None):
 
     args = parser.parse_args()
 
-    shell = Shell()
+    shell = Shell() if not args.norc else Shell(ctx={})
 
     env = builtins.__xonsh_env__
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -90,8 +90,8 @@ class Shell(Cmd):
                                     stdout=stdout)
         self.execer = Execer()
         env = builtins.__xonsh_env__
-        self.ctx = ctx or xonshrc_context(rcfile=env.get('XONSHRC', None), 
-                                          execer=self.execer)
+        self.ctx = ctx if ctx is not None else \
+            xonshrc_context(rcfile=env.get('XONSHRC', None), execer=self.execer)
         self.completer = Completer()
         self.buffer = []
         self.need_more_lines = False


### PR DESCRIPTION
Just a minor addition: a command-line switch to prevent parsing the .xonshrc file.

Useful when a recent change broke something in your .xonshrc file, and probably in other scenarios. Bash has it as well.
