### PR TITLE
xonsh should error on finding a line break inside a regex path (backtick)

### DIFF
--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -139,6 +139,8 @@ def handle_backtick(state, token, stream):
         if n.type == tokenize.ERRORTOKEN and n.string == '`':
             found_match = True
             break
+        elif n.type == tokenize.NEWLINE or n.type == tokenize.NL:
+            break
         n = next(stream, None)
     if found_match:
         state['last'] = n


### PR DESCRIPTION
This change causes xonsh to throw an error when a regex expression started with a backtick doesn't have a matching backtick on the same line (if a newline is found when scanning forward to find the matching backtick).