### PR TITLE
Ignore Python keywords in subprocess mode

### DIFF
--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -265,13 +265,17 @@ def handle_token(state, token, stream):
     """
     typ = token.type
     st = token.string
-    if not state['pymode'][-1]:
+    pymode = state['pymode'][-1]
+    if not pymode:
         if state['last'] is not None and state['last'].end != token.start:
             cur = token.start
             old = state['last'].end
             if cur[0] == old[0] and cur[1] > old[1]:
                 yield _new_token('WS', token.line[old[1]:cur[1]], old)
-    if (typ, st) in token_map:
+    if typ == tokenize.NAME and not pymode:
+        state['last'] = token
+        yield _new_token('NAME', st, token.start)
+    elif (typ, st) in token_map:
         state['last'] = token
         yield _new_token(token_map[(typ, st)], st, token.start)
     elif typ in token_map:


### PR DESCRIPTION
Currently, xonsh gets confused by Python keywords showing up in subprocess mode (since they are tokenized differently from other names).  For example:
`git config --global ...`

This change causes all names (regardless of whether they are Python keywords) to be tokenized as `NAME` tokens when in subprocess mode, so that they can be interpreted properly.