### PR TITLE
Job control

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -25,6 +25,7 @@ For those of you who want the gritty details.
     environ
     aliases
     dirstack
+    jobs
     inspectors
     completer
     shell

--- a/docs/api/jobs.rst
+++ b/docs/api/jobs.rst
@@ -1,0 +1,10 @@
+.. _xonsh_jobs:
+
+******************************************************
+Job Control (``xonsh.jobs``)
+******************************************************
+
+.. automodule:: xonsh.jobs
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -5,10 +5,11 @@ import platform
 import builtins
 import subprocess
 import shlex
+import signal
 from warnings import warn
 
 from xonsh.dirstack import dirs, pushd, popd
-
+from xonsh.jobs import jobs, fg, bg, kill_all_jobs
 
 def cd(args, stdin=None):
     """Changes the directory.
@@ -40,6 +41,7 @@ def cd(args, stdin=None):
 def exit(args, stdin=None):
     """Sends signal to exit shell."""
     builtins.__xonsh_exit__ = True
+    kill_all_jobs()
     print()  # gimme a newline
     return None, None
 
@@ -97,6 +99,9 @@ DEFAULT_ALIASES = {
     'pushd': pushd,
     'popd': popd,
     'dirs': dirs,
+    'jobs': jobs,
+    'fg': fg,
+    'bg': bg,
     'EOF': exit,
     'exit': exit,
     'quit': exit,

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -463,6 +463,7 @@ def run_subproc(cmds, captured=True):
         prev = None
         if prev_is_proxy:
             proc.stdin.write(prev_proc.stdout)
+            proc.stdin.close()
         prev_proc = proc
     for proc in procs[:-1]:
         proc.stdout.close()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -381,6 +381,9 @@ def get_script_subproc_command(fname, args):
 
     return interp + [fname] + args
 
+def _subproc_pre():
+    os.setpgrp()
+    signal.signal(signal.SIGTSTP, lambda n,f: signal.pause())
 
 def run_subproc(cmds, captured=True):
     """Runs a subprocess, in its many forms. This takes a list of 'commands,'
@@ -441,12 +444,9 @@ def run_subproc(cmds, captured=True):
             stdin = PIPE
         else:
             stdin = prev_proc.stdout
-        def subproc_pre():
-            os.setpgrp()
-            signal.signal(signal.SIGTSTP, lambda n,f: signal.pause())
         subproc_kwargs = {}
         if os.name == 'posix':
-            subproc_kwargs['preexec_fn'] = subproc_pre
+            subproc_kwargs['preexec_fn'] = _subproc_pre
         try:
             proc = Popen(aliased_cmd, universal_newlines=uninew, env=ENV.detype(),
                          stdin=stdin, stdout=stdout, **subproc_kwargs)

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -20,7 +20,7 @@ from xonsh.tools import string_types, redirect_stdout, redirect_stderr, suggest_
 from xonsh.inspectors import Inspector
 from xonsh.environ import default_env
 from xonsh.aliases import DEFAULT_ALIASES, bash_aliases
-from xonsh.jobs import _get_pid, _print_one_job, _get_job_number, _wait_for_active_job, ProcProxy 
+from xonsh.jobs import get_pid_string, print_one_job, get_next_job_number, wait_for_active_job, ProcProxy 
 
 ENV = None
 BUILTINS_LOADED = False
@@ -458,8 +458,8 @@ def run_subproc(cmds, captured=True):
         prev_proc = proc
     for proc in procs[:-1]:
         proc.stdout.close()
-    num = _get_job_number()
-    pids = [_get_pid(i) for i in procs]
+    num = get_next_job_number()
+    pids = [get_pid_string(i) for i in procs]
     builtins.__xonsh_all_jobs__[num] = {'cmds': cmds, 
                                         'pids': pids, 
                                         'obj': prev_proc,
@@ -468,13 +468,13 @@ def run_subproc(cmds, captured=True):
     if not isinstance(prev_proc, ProcProxy):
         builtins.__xonsh_active_job__ = num
     if background:
-        _print_one_job(num)
+        print_one_job(num)
         return
     # the following prevents Crtl-c from being interpreted by xonsh
     # while running a subprocess
     while True:
         try:
-            _wait_for_active_job()
+            wait_for_active_job()
             break
         except KeyboardInterrupt:
             pass

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -114,6 +114,8 @@ def kill_all_jobs():
 
 def jobs(args, stdin=None):
     """
+    xonsh command: jobs
+
     Display a list of all current jobs.
     """
     _clear_dead_jobs()
@@ -124,6 +126,8 @@ def jobs(args, stdin=None):
 
 def fg(args, stdin=None):
     """
+    xonsh command: fg
+
     Bring the currently active job to the foreground, or, if a single number is
     given as an argument, bring that job to the foreground.
     """
@@ -152,6 +156,8 @@ def fg(args, stdin=None):
 
 def bg(args, stdin=None):
     """
+    xonsh command: bg
+
     Resume execution of the currently active job in the background, or, if a
     single number is given as an argument, resume that job in the background.
     """

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -80,6 +80,7 @@ def wait_for_active_job():
     def handle_sigint(num, frame):
         obj.done = True
         os.kill(obj.pid, signal.SIGINT)
+        raise KeyboardInterrupt
 
     signal.signal(signal.SIGTSTP, handle_sigstop)
     signal.signal(signal.SIGINT, handle_sigint)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -1,0 +1,152 @@
+import os
+import time
+import signal
+import builtins
+from collections import namedtuple
+
+ProcProxy = namedtuple('ProcProxy', ['stdout', 'stderr'])
+
+
+def _get_pid(o):
+    if isinstance(o, ProcProxy):
+        return 'pyfunc_{}'.format(o.__name__)
+    else:
+        return str(o.pid)
+
+
+def _clear_dead_jobs():
+    to_remove = set()
+    for i in builtins.__xonsh_all_jobs__.keys():
+        obj = builtins.__xonsh_all_jobs__[i]['obj']
+        if isinstance(obj, ProcProxy) or obj.poll() is not None:
+            to_remove.add(i)
+    for i in to_remove:
+        del builtins.__xonsh_all_jobs__[i]
+        if builtins.__xonsh_active_job__ == i:
+            builtins.__xonsh_active_job__ = None
+    if builtins.__xonsh_active_job__ is None:
+        _reactivate_job()
+
+
+def _reactivate_job():
+    if len(builtins.__xonsh_all_jobs__) == 0:
+        return
+    builtins.__xonsh_active_job__ = max(builtins.__xonsh_all_jobs__)
+
+
+def _print_one_job(num):
+    job = builtins.__xonsh_all_jobs__[num]
+    act = '*' if num == builtins.__xonsh_active_job__ else ' '
+    status = job['status']
+    cmd = [' '.join(i) if isinstance(i, list) else i for i in job['cmds']]
+    cmd = ' '.join(cmd)
+    pids = ', '.join(job['pids'])
+    bg = ' &' if job['bg'] else ''
+    print('{}[{}] {}: {}{} ({})'.format(act, num, status, cmd, bg, pids))
+
+
+def _get_job_number():
+    _clear_dead_jobs()
+    i = 1
+    while i in builtins.__xonsh_all_jobs__:
+        i += 1
+    return i
+
+
+def _default_sigint_handler(num, frame):
+    raise KeyboardInterrupt
+
+
+def _wait_for_active_job():
+    _clear_dead_jobs()
+    act = builtins.__xonsh_active_job__
+    if act is None:
+        return
+    obj = builtins.__xonsh_all_jobs__[act]['obj']
+    if isinstance(obj, ProcProxy):
+        return
+    if builtins.__xonsh_all_jobs__[act]['bg']:
+        return
+    obj.done = False
+
+    def handle_sigstop(num, frame):
+        obj.done = True
+        builtins.__xonsh_all_jobs__[act]['status'] = 'stopped'
+        builtins.__xonsh_all_jobs__[act]['bg'] = True
+        print()
+        _print_one_job(act)
+        os.kill(obj.pid, signal.SIGSTOP)
+
+    def handle_sigint(num, frame):
+        obj.done = True
+        os.kill(obj.pid, signal.SIGINT)
+
+    signal.signal(signal.SIGTSTP, handle_sigstop)
+    signal.signal(signal.SIGINT, handle_sigint)
+    while obj.poll() is None and not obj.done:
+        time.sleep(0.01)
+    if obj.poll() is not None:
+        builtins.__xonsh_active_job__ = None
+    signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+    signal.signal(signal.SIGINT, _default_sigint_handler)
+
+
+def kill_all_jobs():
+    _clear_dead_jobs()
+    for num, job in builtins.__xonsh_all_jobs__.items():
+        os.kill(job['obj'].pid, signal.SIGKILL)
+
+
+def jobs(args, stdin=None):
+    _clear_dead_jobs()
+    for j in sorted(builtins.__xonsh_all_jobs__.keys()):
+        _print_one_job(j)
+    return None, None
+
+
+def fg(args, stdin=None):
+    _clear_dead_jobs()
+    if len(args) == 0:
+        # start active job in foreground
+        act = builtins.__xonsh_active_job__
+        if act is None:
+            return '', 'Cannot bring nonexistent job to foreground.'
+    elif len(args) == 1:
+        try:
+            act = int(args[0])
+        except:
+            return '', 'Invalid job: {}'.format(args[0])
+        if act not in builtins.__xonsh_all_jobs__:
+            return '', 'Invalid job: {}'.format(args[0])
+    else:
+        return '', 'fg expects 0 or 1 arguments, not {}'.format(len(args))
+    builtins.__xonsh_active_job__ = act
+    job = builtins.__xonsh_all_jobs__[act]
+    job['bg'] = False
+    job['status'] = 'running'
+    _print_one_job(act)
+    os.kill(job['obj'].pid, signal.SIGCONT)
+
+
+def bg(args, stdin=None):
+    _clear_dead_jobs()
+    if len(args) == 0:
+        # start active job in foreground
+        act = builtins.__xonsh_active_job__
+        if act is None:
+            return '', 'Cannot send nonexistent job to background.'
+    elif len(args) == 1:
+        try:
+            act = int(args[0])
+        except:
+            return '', 'Invalid job: {}'.format(args[0])
+        if act not in builtins.__xonsh_all_jobs__:
+            return '', 'Invalid job: {}'.format(args[0])
+    else:
+        return '', 'bg expects 0 or 1 arguments, not {}'.format(len(args))
+    builtins.__xonsh_active_job__ = act
+    job = builtins.__xonsh_all_jobs__[act]
+    job['bg'] = True
+    job['status'] = 'running'
+    _print_one_job(act)
+    os.kill(job['obj'].pid, signal.SIGCONT)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -43,7 +43,7 @@ def _reactivate_job():
 
 
 _block_when_giving = [signal.SIGTTOU, signal.SIGTTIN,
-                      signal.SIGTSTP, signal.SIGCHLD]
+                      signal.SIGTSTP]
 
 
 def _give_terminal_to(pgid):
@@ -114,7 +114,7 @@ def wait_for_active_job():
         time.sleep(0.01)
     if obj.poll() is not None:
         builtins.__xonsh_active_job__ = None
-    signal.signal(signal.SIGCHLD, signal.SIG_IGN)
+    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
     _give_terminal_to(_shell_pgrp)  # give terminal back to the shell
 
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -42,8 +42,7 @@ def _reactivate_job():
                                         key=lambda x: x[1]['started'])[0]
 
 
-_block_when_giving = [signal.SIGTTOU, signal.SIGTTIN,
-                      signal.SIGTSTP]
+_block_when_giving = (signal.SIGTTOU, signal.SIGTTIN, signal.SIGTSTP)
 
 
 def _give_terminal_to(pgid):

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -110,7 +110,7 @@ def wait_for_active_job():
     _give_terminal_to(pgrp)  # give the terminal over to the fg process
     signal.signal(signal.SIGCHLD, handle_sigchld)
     while obj.poll() is None and not obj.done:
-        time.sleep(0.01)
+        time.sleep(0.1)
     if obj.poll() is not None:
         builtins.__xonsh_active_job__ = None
     signal.signal(signal.SIGCHLD, signal.SIG_DFL)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 ProcProxy = namedtuple('ProcProxy', ['stdout', 'stderr'])
 
 
-def _get_pid(o):
+def get_pid_string(o):
     if isinstance(o, ProcProxy):
         return 'pyfunc_{}'.format(o.__name__)
     else:
@@ -34,7 +34,7 @@ def _reactivate_job():
     builtins.__xonsh_active_job__ = max(builtins.__xonsh_all_jobs__)
 
 
-def _print_one_job(num):
+def print_one_job(num):
     job = builtins.__xonsh_all_jobs__[num]
     act = '*' if num == builtins.__xonsh_active_job__ else ' '
     status = job['status']
@@ -45,7 +45,7 @@ def _print_one_job(num):
     print('{}[{}] {}: {}{} ({})'.format(act, num, status, cmd, bg, pids))
 
 
-def _get_job_number():
+def get_next_job_number():
     _clear_dead_jobs()
     i = 1
     while i in builtins.__xonsh_all_jobs__:
@@ -57,7 +57,7 @@ def _default_sigint_handler(num, frame):
     raise KeyboardInterrupt
 
 
-def _wait_for_active_job():
+def wait_for_active_job():
     _clear_dead_jobs()
     act = builtins.__xonsh_active_job__
     if act is None:
@@ -74,7 +74,7 @@ def _wait_for_active_job():
         builtins.__xonsh_all_jobs__[act]['status'] = 'stopped'
         builtins.__xonsh_all_jobs__[act]['bg'] = True
         print()
-        _print_one_job(act)
+        print_one_job(act)
         os.kill(obj.pid, signal.SIGSTOP)
 
     def handle_sigint(num, frame):
@@ -100,7 +100,7 @@ def kill_all_jobs():
 def jobs(args, stdin=None):
     _clear_dead_jobs()
     for j in sorted(builtins.__xonsh_all_jobs__.keys()):
-        _print_one_job(j)
+        print_one_job(j)
     return None, None
 
 
@@ -124,7 +124,7 @@ def fg(args, stdin=None):
     job = builtins.__xonsh_all_jobs__[act]
     job['bg'] = False
     job['status'] = 'running'
-    _print_one_job(act)
+    print_one_job(act)
     os.kill(job['obj'].pid, signal.SIGCONT)
 
 
@@ -148,5 +148,5 @@ def bg(args, stdin=None):
     job = builtins.__xonsh_all_jobs__[act]
     job['bg'] = True
     job['status'] = 'running'
-    _print_one_job(act)
+    print_one_job(act)
     os.kill(job['obj'].pid, signal.SIGCONT)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import shlex
+import signal
 import subprocess
 from argparse import ArgumentParser, Namespace
 
@@ -64,6 +65,7 @@ def main(argv=None):
         shell.execer.exec(code, mode='exec', glbs=shell.ctx)
     else:
         # otherwise, enter the shell
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         shell.cmdloop()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR is an attempt to implement some amount of job control in xonsh, as mentioned in #141.

This changeset implements the following:
* suspending foreground process with ctrl-z
* resuming suspended process in foreground or background
* listing of all current jobs
* killing foreground process with ctrl-c

It also:
* documents the `jobs`, `fg`, and `bg` commands
* modifies `exit` to kill (maybe too forcefully?) all subprocesses, suspended or otherwise, before exiting
* fixes a bug where ctrl-c would kill all child processes, including those running in the background
