### PR TITLE
Fix lexer's handling of #

### DIFF
--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -325,9 +325,6 @@ def _new_token(type, value, pos):
     return o
 
 
-COMMENT_REGEX = re.compile(r'#.*')
-
-
 class Lexer(object):
     """Implements a lexer for the xonsh language."""
 
@@ -355,7 +352,6 @@ class Lexer(object):
 
     def input(self, s):
         """Calls the lexer on the string s."""
-        s = re.sub(COMMENT_REGEX, '', s)
         self.token_stream = get_tokens(s)
 
     def token(self):


### PR DESCRIPTION
You were right, @scopatz, the handling of `#` in the lexer was totally bogus (a trivial case where it breaks down is an octothorpe inside of a string).  After some testing, I think the main code in `lexer.py` should handle comments appropriately, so just removing that silly regex replacement seems to fix this.

Amusingly, I ran into this issue when trying to run a `git commit -m` with an issue number in the commit message.