### PR TITLE
Job control bugfix

### DIFF
--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -110,8 +110,11 @@ def wait_for_active_job():
                 obj.done = True
                 job['bg'] = True
                 job['status'] = 'stopped'
+                print()  # get a newline because ^Z will have been printed
+                print_one_job(act)
                 break
             elif os.WIFSIGNALED(s) or os.WIFEXITED(s):
+                print()  # get a newline because ^C will have been printed
                 break
         time.sleep(0.1)
     if obj.poll() is not None:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -113,8 +113,10 @@ def wait_for_active_job():
                 print()  # get a newline because ^Z will have been printed
                 print_one_job(act)
                 break
-            elif os.WIFSIGNALED(s) or os.WIFEXITED(s):
+            elif os.WIFSIGNALED(s):
                 print()  # get a newline because ^C will have been printed
+                break
+            elif os.WIFEXITED(s):
                 break
         time.sleep(0.1)
     if obj.poll() is not None:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -102,18 +102,20 @@ def wait_for_active_job():
     pgrp = job['pgrp']
     obj.done = False
 
-    def handle_sigchld(num, frame):
-        obj.done = True
-        job['bg'] = True
-        job['status'] = 'stopped'
-
     _give_terminal_to(pgrp)  # give the terminal over to the fg process
-    signal.signal(signal.SIGCHLD, handle_sigchld)
-    while obj.poll() is None and not obj.done:
+    while True:
+        p, s = os.waitpid(obj.pid, os.WNOHANG | os.WUNTRACED)
+        if p == obj.pid:
+            if os.WIFSTOPPED(s):
+                obj.done = True
+                job['bg'] = True
+                job['status'] = 'stopped'
+                break
+            elif os.WIFSIGNALED(s) or os.WIFEXITED(s):
+                break
         time.sleep(0.1)
     if obj.poll() is not None:
         builtins.__xonsh_active_job__ = None
-    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
     _give_terminal_to(_shell_pgrp)  # give terminal back to the shell
 
 


### PR DESCRIPTION
This fixes a bug in #152 (Job Control).

The old method for waiting for child processes to terminate/stop was to wait for a `SIGCHLD` signal; when that signal was received, the active job was considered done.  The problem with this approach is that processes earlier in the pipeline also send `SIGCHLD` to the parent upon terminating/stopping.  It was possible to construct a pipeline such that the last process would be interpreted as terminated before it actually was, and it and xonsh would be left fighting over the input to the terminal.

This change implements a much simpler and more robust check for a change of status in a child process.