### PR TITLE
Optimization for waiting for active job to stop

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -502,14 +502,7 @@ def run_subproc(cmds, captured=True):
     if background:
         print_one_job(num)
         return
-    # the following prevents Crtl-c from being interpreted by xonsh
-    # while running a subprocess
-    while True:
-        try:
-            wait_for_active_job()
-            break
-        except KeyboardInterrupt:
-            pass
+    wait_for_active_job()
     # get output
     if isinstance(prev_proc, ProcProxy):
         output = prev_proc.stdout

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -103,22 +103,15 @@ def wait_for_active_job():
     obj.done = False
 
     _give_terminal_to(pgrp)  # give the terminal over to the fg process
-    while True:
-        p, s = os.waitpid(obj.pid, os.WNOHANG | os.WUNTRACED)
-        if p == obj.pid:
-            if os.WIFSTOPPED(s):
-                obj.done = True
-                job['bg'] = True
-                job['status'] = 'stopped'
-                print()  # get a newline because ^Z will have been printed
-                print_one_job(act)
-                break
-            elif os.WIFSIGNALED(s):
-                print()  # get a newline because ^C will have been printed
-                break
-            elif os.WIFEXITED(s):
-                break
-        time.sleep(0.1)
+    p, s = os.waitpid(obj.pid, os.WUNTRACED)
+    if os.WIFSTOPPED(s):
+        obj.done = True
+        job['bg'] = True
+        job['status'] = 'stopped'
+        print()  # get a newline because ^Z will have been printed
+        print_one_job(act)
+    elif os.WIFSIGNALED(s):
+        print()  # get a newline because ^C will have been printed
     if obj.poll() is not None:
         builtins.__xonsh_active_job__ = None
     _give_terminal_to(_shell_pgrp)  # give terminal back to the shell


### PR DESCRIPTION
This patch improves the `wait_for_active_job` method.  Rather than polling, we can just wait for `os.waitpid` to return.  This minimizes the time delay between the process actually ending and the next prompt being displayed, and probably saves some extra CPU churning by eliminating the loop.