### PR TITLE
Alternative Prompt Format Refactor

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -164,64 +164,55 @@ useful to have more sophisticated types, like functions, in the environment.
 There are handful of environment variables that xonsh considers special.
 They can be seen in the table below:
 
-================== =========================== ================================
-variable           default                     description
-================== =========================== ================================
-PROMPT             xosh.environ.default_prompt The prompt text, may be str or
-                                               function which returns a str.
-                                               The str may contain keyword
-                                               arguments which are
-                                               auto-formatted (see below).
-MULTILINE_PROMPT   ``'.'``                     Prompt text for 2nd+ lines of
-                                               input, may be str or
-                                               function which returns a str.
-TITLE              xonsh.environ.default_title The title text for the window
-                                               in which xonsh is running.  As
-                                               with PROMPT, may be a str or a
-                                               function that returns a str.
-                                               The str is formatted in the
-                                               same manner as PROMPT (see
-                                               below).
-XONSHRC            ``'~/.xonshrc'``            Location of run control file
-XONSH_HISTORY_SIZE 8128                        Number of items to store in the
-                                               history.
-XONSH_HISTORY_FILE ``'~/.xonsh_history'``      Location of history file
-BASH_COMPLETIONS   ``[] or ['/etc/...']``      This is a list of strings that
-                                               specifies where the BASH
-                                               completion files may be found.
-                                               The default values are platform
-                                               dependent, but sane.  To specify an alternate list,
-                                               do so in the run control file.
-SUGGEST_COMMANDS   ``True``                    When a user types an invalid
-                                               command, xonsh will try to offer
-                                               suggestions of similar valid
-                                               commands if this is ``True``.
-SUGGEST_THRESHOLD  ``3``                       An error threshold.  If the
-                                               Levenshtein distance between the
-                                               entered command and a valid
-                                               command is less than this value,
-                                               the valid command will be
-                                               offered as a suggestion.
-SUGGEST_MAX_NUM    ``5``                       xonsh will show at most this
-                                               many suggestions in response to
-                                               an invalid command.  If
-                                               negative, there is no limit to
-                                               how many suggestions are shown.
-================== =========================== ================================
-
-Customizing the prompt is probably the most common reason for altering an
-environment variable.  To make this easier, you can use keyword
-arguments in a prompt string that will get replaced automatically:
-
-.. code-block:: xonshcon
-
-    >>> $PROMPT = '{user}@{hostname}:{cwd} > '
-    snail@home:~ > # it works!
-
-You can also color your prompt easily by inserting keywords such as ``{GREEN}``
-or ``{BOLD_BLUE}`` -- for the full list of keyword arguments, refer to the API
-documentation of :py:func:`xonsh.environ.format_prompt`.
-
+================== ============================= ================================
+variable           default                       description
+================== ============================= ================================
+PROMPT             xosh.environ.DEFAULT_PROMPT   The prompt text.  May contain
+                                                 keyword arguments which are
+                                                 auto-formatted (see `Customizing
+                                                 the Prompt`_ below).
+MULTILINE_PROMPT   ``'.'``                       Prompt text for 2nd+ lines of
+                                                 input, may be str or
+                                                 function which returns a str.
+TITLE              xonsh.environ.DEFAULT_TITLE   The title text for the window
+                                                 in which xonsh is running.
+                                                 Formatted in the same manner
+                                                 as PROMPT (see `Customizing the
+                                                 Prompt`_ below).
+FORMATTER_DICT     xonsh.environ.FORMATTER_DICT  Dictionary containing variables
+                                                 to be used when formatting PROMPT
+                                                 and TITLE (see `Customizing the
+                                                 Prompt`_ below).
+XONSHRC            ``'~/.xonshrc'``              Location of run control file
+XONSH_HISTORY_SIZE 8128                          Number of items to store in the
+                                                 history.
+XONSH_HISTORY_FILE ``'~/.xonsh_history'``        Location of history file
+XONSH_INTERACTIVE                                ``True`` if xonsh is running 
+                                                 interactively, and ``False`` 
+                                                 otherwise.
+BASH_COMPLETIONS   ``[] or ['/etc/...']``        This is a list of strings that
+                                                 specifies where the BASH
+                                                 completion files may be found.
+                                                 The default values are platform
+                                                 dependent, but sane.  To
+                                                 specify an alternate list,
+                                                 do so in the run control file.
+SUGGEST_COMMANDS   ``True``                      When a user types an invalid
+                                                 command, xonsh will try to offer
+                                                 suggestions of similar valid
+                                                 commands if this is ``True``.
+SUGGEST_THRESHOLD  ``3``                         An error threshold.  If the
+                                                 Levenshtein distance between the
+                                                 entered command and a valid
+                                                 command is less than this value,
+                                                 the valid command will be
+                                                 offered as a suggestion.
+SUGGEST_MAX_NUM    ``5``                         xonsh will show at most this
+                                                 many suggestions in response to
+                                                 an invalid command.  If
+                                                 negative, there is no limit to
+                                                 how many suggestions are shown.
+================== ============================= ================================
 
 Environment Lookup with ``${}``
 ================================
@@ -768,6 +759,58 @@ as well as xonsh languages keywords & operator, files & directories, and
 environment variable names. In subprocess-mode, you additionally complete
 on any file names on your ``$PATH``, alias keys, and full BASH completion
 for the commands themselves.
+
+Customizing the Prompt
+======================
+
+Customizing the prompt is probably the most common reason for altering an
+environment variable.  The ``PROMPT`` variable can be a string, or it can be a
+function (of no arguments) that returns a string.  The result can contain
+keyword arguments, which will be replaced automatically:
+
+.. code-block:: xonshcon
+
+    >>> $PROMPT = '{user}@{hostname}:{cwd} > '
+    snail@home:~ > # it works!
+    snail@home:~ > $PROMPT = lambda : '{user}@{hostname}:{cwd} >> '
+    snail@home:~ >> # so does that!
+    
+By default, the following variables are available for use:
+  * ``user``: The username of the current user
+  * ``hostname``: The name of the host computer
+  * ``cwd``: The current working directory
+  * ``curr_branch``: The name of the current git branch (preceded by space),
+    if any.
+
+You can also color your prompt easily by inserting keywords such as ``{GREEN}``
+or ``{BOLD_BLUE}``.  Colors have the form shown below:
+    
+  * ``(QUALIFIER\_)COLORNAME``: Inserts an ANSI color code
+      * ``COLORNAME`` can be any of: ``BLACK``, ``RED``, ``GREEN``, ``YELLOW``,
+        ``BLUE``, ``PURPLE``, ``CYAN``, or ``WHITE``
+      * ``QUALIFIER`` is optional and can be any of: ``BOLD``, ``UNDERLINE``,
+        ``BACKGROUND``, ``INTENSE``, ``BOLD_INTENSE``, or 
+        ``BACKGROUND_INTENSE``
+  * ``NO_COLOR``: Resets any previously used color codes
+
+You can make use of additional variables beyond these by adding them to the
+``FORMATTER_PROMPT`` environment variable.  The values in this dictionary
+should be strings (which will be inserted into the prompt verbatim), or
+functions of no arguments (which will be called each time the prompt is
+generated, and the results of those calls will be inserted into the prompt).
+For example:
+
+.. code-block:: xonshcon
+
+    snail@home ~ $ $FORMATTER_DICT['test'] = "hey"
+    snail@home ~ $ $PROMPT = "{test} {cwd} $ "
+    hey ~ $ 
+    hey ~ $ import random
+    hey ~ $ $FORMATTER_DICT['test'] = lambda: random.randint(1,9)
+    3 ~ $ 
+    5 ~ $ 
+    2 ~ $ 
+    8 ~ $ 
 
 Executing Commands and Scripts
 ==============================

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -86,20 +86,6 @@ _formatter = string.Formatter()
 
 def format_prompt(template=DEFAULT_PROMPT):
     """Formats a xonsh prompt template string.
-
-    The following keyword arguments are recognized in the template string:
-
-    + user -- Name of current user
-    + hostname -- Name of host computer
-    + cwd -- Current working directory
-    + curr_branch -- Name of current git branch (preceded by a space), if any
-    + (QUALIFIER\_)COLORNAME -- Inserts an ANSI color code
-        - COLORNAME can be any of:
-              BLACK, RED, GREEN, YELLOW, BLUE, PURPLE, CYAN, WHITE
-        - QUALIFIER is optional and can be any of:
-              BOLD, UNDERLINE, BACKGROUND, INTENSE,
-              BOLD_INTENSE, BACKGROUND_INTENSE
-    + NO_COLOR -- Resets any previously used color codes
     """
     env = builtins.__xonsh_env__
     template = template() if callable(template) else template

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -13,6 +13,7 @@ from warnings import warn
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import TERM_COLORS
 
+
 def current_branch(cwd=None, pad=True):
     """Gets the branch for a current working directory. Returns None
     if the cwd is not a repository.  This currently only works for git,
@@ -70,17 +71,18 @@ DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
                   '{cwd}{BOLD_RED}{curr_branch} {BOLD_BLUE}${NO_COLOR} ')
 DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
 
+
 def _replace_home(x):
     return x.replace(builtins.__xonsh_env__['HOME'], '~')
 
 FORMAT_DICT = dict(user=os.environ.get('USER', '<user>'),
-                   hostname=socket.gethostname().split('.',1)[0],
-                   fqdn=socket.getfqdn(),
+                   hostname=socket.gethostname().split('.', 1)[0],
                    cwd=lambda: _replace_home(builtins.__xonsh_env__['PWD']),
                    curr_branch=lambda: current_branch() or '',
                    **TERM_COLORS)
 
-FORMATTER = string.Formatter()
+_formatter = string.Formatter()
+
 
 def format_prompt(template=DEFAULT_PROMPT):
     """Formats a xonsh prompt template string.
@@ -102,7 +104,7 @@ def format_prompt(template=DEFAULT_PROMPT):
     env = builtins.__xonsh_env__
     template = template() if callable(template) else template
     fmt = env.get('FORMAT_DICT', FORMAT_DICT)
-    included_names = set(i[1] for i in FORMATTER.parse(template))
+    included_names = set(i[1] for i in _formatter.parse(template))
     fmt = {k: (v() if callable(v) else v)
            for (k, v) in fmt.items()
            if k in included_names}
@@ -134,7 +136,7 @@ def multiline_prompt():
 BASE_ENV = {
     'XONSH_VERSION': XONSH_VERSION,
     'INDENT': '    ',
-    'FORMAT_DICT': FORMAT_DICT,
+    'FORMAT_DICT': dict(FORMAT_DICT),
     'PROMPT': DEFAULT_PROMPT,
     'TITLE': DEFAULT_TITLE,
     'MULTILINE_PROMPT': '.',

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -104,8 +104,7 @@ def format_prompt(template=DEFAULT_PROMPT):
     fmt = env.get('FORMAT_DICT', FORMAT_DICT)
     included_names = set(i[1] for i in FORMATTER.parse(template))
     fmt = {k: (v() if callable(v) else v)
-           for (k, v)
-           in fmt.items()
+           for (k, v) in fmt.items()
            if k in included_names}
     return template.format(**fmt)
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -75,11 +75,11 @@ DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
 def _replace_home(x):
     return x.replace(builtins.__xonsh_env__['HOME'], '~')
 
-FORMAT_DICT = dict(user=os.environ.get('USER', '<user>'),
-                   hostname=socket.gethostname().split('.', 1)[0],
-                   cwd=lambda: _replace_home(builtins.__xonsh_env__['PWD']),
-                   curr_branch=lambda: current_branch() or '',
-                   **TERM_COLORS)
+FORMATTER_DICT = dict(user=os.environ.get('USER', '<user>'),
+                      hostname=socket.gethostname().split('.', 1)[0],
+                      cwd=lambda: _replace_home(builtins.__xonsh_env__['PWD']),
+                      curr_branch=lambda: current_branch() or '',
+                      **TERM_COLORS)
 
 _formatter = string.Formatter()
 
@@ -103,7 +103,7 @@ def format_prompt(template=DEFAULT_PROMPT):
     """
     env = builtins.__xonsh_env__
     template = template() if callable(template) else template
-    fmt = env.get('FORMAT_DICT', FORMAT_DICT)
+    fmt = env.get('FORMATTER_DICT', FORMATTER_DICT)
     included_names = set(i[1] for i in _formatter.parse(template))
     fmt = {k: (v() if callable(v) else v)
            for (k, v) in fmt.items()
@@ -136,7 +136,7 @@ def multiline_prompt():
 BASE_ENV = {
     'XONSH_VERSION': XONSH_VERSION,
     'INDENT': '    ',
-    'FORMAT_DICT': dict(FORMAT_DICT),
+    'FORMATTER_DICT': dict(FORMATTER_DICT),
     'PROMPT': DEFAULT_PROMPT,
     'TITLE': DEFAULT_TITLE,
     'MULTILINE_PROMPT': '.',

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -115,7 +115,6 @@ RE_HIDDEN = re.compile('\001.*?\002')
 def multiline_prompt():
     """Returns the filler text for the prompt in multiline scenarios."""
     curr = builtins.__xonsh_env__.get('PROMPT', "set '$PROMPT = ...' $ ")
-    curr = curr() if callable(curr) else curr
     curr = format_prompt(curr)
     line = curr.rsplit('\n', 1)[1] if '\n' in curr else curr
     line = RE_HIDDEN.sub('', line)  # gets rid of colors

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -103,8 +103,10 @@ def format_prompt(template=DEFAULT_PROMPT):
     template = template() if callable(template) else template
     fmt = env.get('FORMAT_DICT', FORMAT_DICT)
     included_names = set(i[1] for i in FORMATTER.parse(template))
-    fmt = {k: v for (k, v) in fmt.items() if k in included_names}
-    fmt = {k: (v() if callable(v) else v) for (k, v) in fmt.items()}
+    fmt = {k: (v() if callable(v) else v)
+           for (k, v)
+           in fmt.items()
+           if k in included_names}
     return template.format(**fmt)
 
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -188,8 +188,6 @@ class Shell(Cmd):
             return
         if 'TITLE' in env:
             t = env['TITLE']
-            if callable(t):
-                t = t()
         else:
             return
         t = format_prompt(t)
@@ -210,8 +208,6 @@ class Shell(Cmd):
         env = builtins.__xonsh_env__
         if 'PROMPT' in env:
             p = env['PROMPT']
-            if callable(p):
-                p = p()
             p = format_prompt(p)
         else:
             p = "set '$PROMPT = ...' $ "


### PR DESCRIPTION
This is a proof-of-concept for an alternative prompt formatter implementation.

New variables for the format string are added to the environment variable `$FORMAT_DICT`.  They can either be strings (which are inserted into the template verbatim) or callables (which are called each time, and whose result is inserted into the template).

`$PROMPT` can still be a callable (which returns the template string) or a string itself.

Values are only computed/used if they show up in the template string.

I have not written tests yet, but I like this structure a lot.  I would be happy to write tests if this is what we want to go with.

Examples:
```
>>> $FORMAT_DICT['test'] = "hey"
>>> $PROMPT = "{test} {cwd} $ "
hey ~ $
```
```
>>> import random
>>> $FORMAT_DICT['test'] = lambda: random.randint(1,9)
>>> $PROMPT = "{test} {cwd} $ "
9 ~ $ 
2 ~ $ 
1 ~ $ 
2 ~ $ 
9 ~ $ 
```