### PR TITLE
Interactive Flag, and Parser Bugfix

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -40,6 +40,7 @@ def main(argv=None):
     shell = Shell() if not args.norc else Shell(ctx={})
     from xonsh import imphooks
     env = builtins.__xonsh_env__
+    env['XONSH_INTERACTIVE'] = False
     if args.command is not None:
         # run a single command and exit
         shell.default(args.command)
@@ -62,6 +63,7 @@ def main(argv=None):
         shell.execer.exec(code, mode='exec', glbs=shell.ctx)
     else:
         # otherwise, enter the shell
+        env['XONSH_INTERACTIVE'] = True
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
         shell.cmdloop()
 

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -2062,8 +2062,11 @@ class Parser(object):
                                     lineno=self.lineno, col=self.col)
                     p0._cliarg_action = 'extend'
                 elif p1.startswith('$'):
-                    p0 = self._envvar_by_name(p1[1:], lineno=self.lineno, col=self.col)
-                    p0._cliarg_action = 'ensure_list'
+                    p0 = self._envvar_by_name(p1[1:], lineno=self.lineno,
+                                              col=self.col)
+                    p0 = xonsh_call('__xonsh_ensure_list_of_strs__', [p0],
+                            lineno=self.lineno, col=self.col)
+                    p0._cliarg_action = 'extend'
                 else:
                     p0._cliarg_action = 'append'
             elif isinstance(p1, ast.AST):


### PR DESCRIPTION
Two changes here:
* Include a boolean environment variable called `$XONSH_INTERACTIVE` (#166), which is `True` if we are running in interactive mode and `False` otherwise (running a single command or running a script).
* Modify `parser.py` to convert environment variables to strings when they are part of a subprocess expression (so that, e.g., `echo $SOMETHING` can be called, where `$SOMETHING` is neither a string nor a list of strings).