### PR TITLE
Attempt to fix #148

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -427,7 +427,15 @@ def run_subproc(cmds, captured=True):
         write_target = cmds[-1][0]
         write_mode = WRITER_MODES[cmds[-2]]
         cmds = cmds[:-2]
-        last_stdout = PIPE
+        if write_target is not None:
+            try:
+                last_stdout = open(write_target, write_mode)
+            except FileNotFoundError:
+                e = 'xonsh: {0}: no such file or directory'
+                print(e.format(write_target))
+                return
+        else:
+            last_stdout = PIPE
     last_cmd = cmds[-1]
     prev = None
     procs = []
@@ -508,13 +516,6 @@ def run_subproc(cmds, captured=True):
         output = prev_proc.stdout
     elif prev_proc.stdout is not None:
         output = prev_proc.stdout.read()
-    # write the output if we should
-    if write_target is not None:
-        try:
-            with open(write_target, write_mode) as f:
-                f.write(output)
-        except FileNotFoundError:
-            print('xonsh: {0}: no such file or directory'.format(write_target))
     if captured:
         return output
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -519,6 +519,8 @@ def run_subproc(cmds, captured=True):
             output = prev_proc.stdout.read()
         if captured:
             return output
+    elif last_stdout not in (PIPE, None):
+        last_stdout.close()
 
 
 def subproc_captured(*cmds):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -511,13 +511,14 @@ def run_subproc(cmds, captured=True):
         print_one_job(num)
         return
     wait_for_active_job()
-    # get output
-    if isinstance(prev_proc, ProcProxy):
-        output = prev_proc.stdout
-    elif prev_proc.stdout is not None:
-        output = prev_proc.stdout.read()
-    if captured:
-        return output
+    if write_target is None:
+        # get output
+        if isinstance(prev_proc, ProcProxy):
+            output = prev_proc.stdout
+        elif prev_proc.stdout is not None:
+            output = prev_proc.stdout.read()
+        if captured:
+            return output
 
 
 def subproc_captured(*cmds):


### PR DESCRIPTION
This is an attempt to fix #148, implementing @SmartViking's suggestion of feeding an appropriate file object directly into the constructor for `Popen`.