### PR TITLE
Un-detypes env for mutable value access

### DIFF
--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -26,6 +26,13 @@ def test_env_detype():
     env = Env(MYPATH=['wakka', 'jawaka'])
     assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
 
+def test_env_detype_mutable_access_clear():
+    env = Env(MYPATH=['wakka', 'jawaka'])
+    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
+    env['MYPATH'][0] = 'woah'
+    assert_equal(None, env._detyped)
+    assert_equal({'MYPATH': 'woah' + os.pathsep + 'jawaka'}, env.detype())
+
 def test_reglob_tests():
     testfiles = reglob('test_.*')
     for f in testfiles:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -68,6 +68,12 @@ def test_subproc_toks_indent_ls_no_min_nl():
     obs = subproc_toks(INDENT + s + '\n', lexer=LEXER, returnline=True)
     assert_equal(exp, obs)
 
+def test_subproc_toks_indent_ls_no_min_semi():
+    s = 'ls'
+    exp = INDENT + '$[{0}];'.format(s)
+    obs = subproc_toks(INDENT + s + ';', lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
 def test_subproc_toks_ls_comment():
     s = 'ls -l'
     com = '  # lets list'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -74,6 +74,12 @@ def test_subproc_toks_indent_ls_no_min_semi():
     obs = subproc_toks(INDENT + s + ';', lexer=LEXER, returnline=True)
     assert_equal(exp, obs)
 
+def test_subproc_toks_indent_ls_no_min_semi_nl():
+    s = 'ls'
+    exp = INDENT + '$[{0}];\n'.format(s)
+    obs = subproc_toks(INDENT + s + ';\n', lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
 def test_subproc_toks_ls_comment():
     s = 'ls -l'
     com = '  # lets list'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -56,6 +56,18 @@ def test_subproc_toks_indent_ls_nl():
                        returnline=True)
     assert_equal(exp, obs)
 
+def test_subproc_toks_indent_ls_no_min():
+    s = 'ls -l'
+    exp = INDENT + '$[{0}]'.format(s)
+    obs = subproc_toks(INDENT + s, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_indent_ls_no_min_nl():
+    s = 'ls -l'
+    exp = INDENT + '$[{0}]\n'.format(s)
+    obs = subproc_toks(INDENT + s + '\n', lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
 def test_subproc_toks_ls_comment():
     s = 'ls -l'
     com = '  # lets list'

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -138,7 +138,11 @@ class CtxAwareTransformer(NodeTransformer):
         if self.is_in_scope(node):
             return node
         else:
-            return self.try_subproc_toks(node)
+            newnode = self.try_subproc_toks(node)
+            if not isinstance(newnode, Expr):
+                newnode = Expr(value=newnode, lineno=node.lineno, 
+                               col_offset=node.col_offset)
+            return newnode
 
     def visit_Assign(self, node):
         ups = set()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -14,7 +14,8 @@ from io import TextIOWrapper, StringIO
 from glob import glob, iglob
 from subprocess import Popen, PIPE
 from contextlib import contextmanager
-from collections import Sequence, MutableMapping, Iterable, namedtuple
+from collections import Sequence, MutableMapping, Iterable, namedtuple, \
+    MutableSequence, MutableSet
 
 from xonsh.tools import string_types, redirect_stdout, redirect_stderr
 from xonsh.tools import suggest_commands
@@ -106,6 +107,9 @@ class Env(MutableMapping):
                 e = "Not enough arguments given to access ARG{0}."
                 raise IndexError(e.format(ix))
             return self._d['ARGS'][ix]
+        val = self._d[key]
+        if isinstance(val, (MutableSet, MutableSequence, MutableMapping)):
+            self._detyped = None
         return self._d[key]
 
     def __setitem__(self, key, val):

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -152,8 +152,6 @@ class Execer(object):
                     last_error_line = last_error_col = -1
                     input = '\n'.join(lines)
                     continue
-                if line.startswith('$'):
-                    raise original_error
                 maxcol = line.find(';', last_error_col)
                 maxcol = None if maxcol < 0 else maxcol + 1
                 sbpline = subproc_toks(line, returnline=True,

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -60,6 +60,7 @@ class XonshConsoleLexer(PythonLexer):
 
     name = 'Xonsh console lexer'
     aliases = ['xonshcon']
+    filenames = []
 
     tokens = {
         'root': [

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -51,7 +51,8 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
             break
         if len(toks) == 0 and tok.type in ('WS', 'INDENT'):
             continue  # handle indentation
-        elif len(toks) > 0 and toks[-1].type == 'SEMI':
+        elif len(toks) > 0 and toks[-1].type == 'SEMI' and pos < maxcol and \
+                tok.type not in ('NEWLINE', 'DEDENT', 'WS'):
             toks.clear()
         if pos < mincol:
             continue
@@ -77,6 +78,8 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
         else:
             el = line[pos:].split('#')[0].rstrip()
             end_offset = len(el)
+    if toks[-1].type == 'SEMI':
+        toks.pop()
     if len(toks) == 0:
         return  # handle comment lines
     beg, end = toks[0].lexpos, (toks[-1].lexpos + end_offset)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -51,9 +51,11 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
             break
         if len(toks) == 0 and tok.type in ('WS', 'INDENT'):
             continue  # handle indentation
-        elif len(toks) > 0 and toks[-1].type == 'SEMI' and pos < maxcol and \
-                tok.type not in ('NEWLINE', 'DEDENT', 'WS'):
-            toks.clear()
+        elif len(toks) > 0 and toks[-1].type == 'SEMI':
+            if pos < maxcol and tok.type not in ('NEWLINE', 'DEDENT', 'WS'):
+                toks.clear()
+            else:
+                break
         if pos < mincol:
             continue
         toks.append(tok)
@@ -78,8 +80,6 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
         else:
             el = line[pos:].split('#')[0].rstrip()
             end_offset = len(el)
-    if toks[-1].type == 'SEMI':
-        toks.pop()
     if len(toks) == 0:
         return  # handle comment lines
     beg, end = toks[0].lexpos, (toks[-1].lexpos + end_offset)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -49,12 +49,21 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
         pos = tok.lexpos
         if tok.type != 'SEMI' and pos >= maxcol:
             break
-        if len(toks) > 0 and toks[-1].type == 'SEMI':
+        if len(toks) == 0 and tok.type in ('WS', 'INDENT'):
+            continue  # handle indentation
+        elif len(toks) > 0 and toks[-1].type == 'SEMI':
             toks.clear()
         if pos < mincol:
             continue
         toks.append(tok)
         if tok.type == 'NEWLINE':
+            break
+        elif tok.type == 'DEDENT':
+            # fake a newline when dedenting without a newline
+            tok.type = 'NEWLINE'
+            tok.value = '\n'
+            tok.lineno -= 1
+            tok.lexpos = len(line)
             break
     else:
         if len(toks) == 0:


### PR DESCRIPTION
This should fix #174 and is built on #168 (because my text editor needs to have syntax highlighting ~_~)