### PR TITLE
SSH fixes

### DIFF
--- a/scripts/xonsh
+++ b/scripts/xonsh
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python -u
 from xonsh.main import main
 main()

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -49,7 +49,7 @@ def _give_terminal_to(pgid):
     # over-simplified version of:
     #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
     # this will give the terminal to the process group pgid
-    if _shell_tty is not None and builtins.__xonsh_env__['XONSH_INTERACTIVE']:
+    if _shell_tty is not None and os.isatty(_shell_tty):
         oldmask = signal.pthread_sigmask(signal.SIG_BLOCK, _block_when_giving)
         os.tcsetpgrp(_shell_tty, pgid)
         signal.pthread_sigmask(signal.SIG_SETMASK, oldmask)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -49,7 +49,7 @@ def _give_terminal_to(pgid):
     # over-simplified version of:
     #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
     # this will give the terminal to the process group pgid
-    if _shell_tty is not None:
+    if _shell_tty is not None and builtins.__xonsh_env__['XONSH_INTERACTIVE']:
         oldmask = signal.pthread_sigmask(signal.SIG_BLOCK, _block_when_giving)
         os.tcsetpgrp(_shell_tty, pgid)
         signal.pthread_sigmask(signal.SIG_SETMASK, oldmask)


### PR DESCRIPTION
This is an attempt to fix the issues described in #176 by doing the following:

* only trying to give the controlling terminal to child processes if xonsh is _actually_ running in a terminal
* running xonsh from python in unbuffered mode

I will continue testing, but this is probably ready for more eyes.