### PR TITLE
Bash completion clarifications

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -190,7 +190,8 @@ BASH_COMPLETIONS   ``[] or ['/etc/...']``      This is a list of strings that
                                                specifies where the BASH
                                                completion files may be found.
                                                The default values are platform
-                                               dependent, but sane.
+                                               dependent, but sane.  To specify an alternate list,
+                                               do so in the run control file.
 SUGGEST_COMMANDS   ``True``                    When a user types an invalid
                                                command, xonsh will try to offer
                                                suggestions of similar valid
@@ -232,8 +233,8 @@ operator.
 .. warning:: In BASH, ``$NAME`` and ``${NAME}`` are syntactically equivalent.
              In xonsh, they have separate meanings.
 
-We can place any valid Python expression inside of the curly braces in 
-``${<expr>}``. This result of this expression will then be used to look up a 
+We can place any valid Python expression inside of the curly braces in
+``${<expr>}``. This result of this expression will then be used to look up a
 value in the environment.  In fact, ``${<expr>}`` is the same as doing
 ``__xonsh_env__[<expr>]``, but much nicer to look at. Here are a couple of
 examples in action:
@@ -386,8 +387,8 @@ Python Evaluation with ``@()``
 The ``@(<expr>)`` operator from will evaluate arbitrary Python code in
 subprocess mode, and the result will be appended to the subprocess command
 list. If the result is a string, it is appended to the argument list.
-If the result is a list or other non-string sequence, the contents are 
-converted to strings and appended to the argument list in order. Otherwise, the 
+If the result is a list or other non-string sequence, the contents are
+converted to strings and appended to the argument list in order. Otherwise, the
 result is automatically converted to a string.  For example,
 
 .. code-block:: xonshcon
@@ -825,8 +826,8 @@ or by invoking xonsh with its filename as an argument:
 
 xonsh scripts can also accept arguments.  These arguments are made available to
 the script in two different ways:
-    
-#. In either mode, as individual variables ``$ARG<n>`` (e.g., ``$ARG1``)    
+
+#. In either mode, as individual variables ``$ARG<n>`` (e.g., ``$ARG1``)
 #. In Python mode only, as a list ``$ARGS``
 
 For example, consider a slight variation of the example script from above that
@@ -869,9 +870,9 @@ operates on a given argument, rather than on the string ``'xonsh'`` (notice how
 
 Importing Xonsh (``*.xsh``)
 ==============================
-You can import xonsh source files with the ``*.xsh`` file extension using 
+You can import xonsh source files with the ``*.xsh`` file extension using
 the normal Python syntax.  Say you had a file called ``mine.xsh``, you could
-therefore perform a Bash-like source into your current shell with the 
+therefore perform a Bash-like source into your current shell with the
 following:
 
 .. code-block:: xonsh

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -14,7 +14,7 @@ from xonsh.tools import TERM_COLORS
 
 def current_branch(cwd=None):
     """Gets the branch for a current working directory. Returns None
-    if the cwd is not a repository.  This currently only works for git, 
+    if the cwd is not a repository.  This currently only works for git,
     bust should be extended in the future.
     """
     branch = None
@@ -50,7 +50,7 @@ def current_branch(cwd=None):
         try:
             s = subprocess.check_output(['git', 'rev-parse','--abbrev-ref', 'HEAD'],
                     stderr=subprocess.PIPE, cwd=cwd,
-                    universal_newlines=True) 
+                    universal_newlines=True)
             s = s.strip()
             if len(s) > 0:
                 branch = s
@@ -135,9 +135,10 @@ BASE_ENV = {
     }
 
 if platform.system() == 'Darwin':
-    BASE_ENV['BASH_COMPLETIONS'] = []
+    BASE_ENV['BASH_COMPLETIONS'] = ['/usr/local/etc/bash_completion',
+                                    '/opt/local/etc/profile.d/bash_completion.sh']
 else:
-    BASE_ENV['BASH_COMPLETIONS'] = ['/etc/bash_completion', 
+    BASE_ENV['BASH_COMPLETIONS'] = ['/etc/bash_completion',
                                     '/usr/share/bash-completion/completions/git']
 
 def bash_env():
@@ -146,7 +147,7 @@ def bash_env():
     if hasattr(builtins, '__xonsh_env__'):
         currenv = builtins.__xonsh_env__.detype()
     try:
-        s = subprocess.check_output(['bash', '-i'], input='env', env=currenv, 
+        s = subprocess.check_output(['bash', '-i'], input='env', env=currenv,
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True)
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Fixes #171.  Clarifies documentation on the use of `BASH_COMPLETIONS` variable, and provides sane defaults for Homebrew and MacPorts standard locations on OSX.