### PR TITLE
Glob Fix

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -293,7 +293,8 @@ def regexpath(s):
 def globpath(s):
     """Simple wrapper around glob that also expands home and env vars."""
     s = expand_path(s)
-    return glob(s)
+    o = glob(s)
+    return o if len(o) != 0 else [s]
 
 
 def iglobpath(s):


### PR DESCRIPTION
If globbing an expression containing `*` fails, I think the right behavior is to add that string verbatim to the argument list, rather than ignoring it.  For example, consider the following:
`$ scp other_machine:file*.txt .`

Currently, xonsh tries to expand the whole expression `other_machine:file*.txt` on the local machine, finds no matches, and effectively deletes it from the argument list by replacing it with the (empty) results of globbing.

This patch should fix this issue.