### PR TITLE
Completer Updates

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -69,30 +69,47 @@ class Completer(object):
         """
         space = ' '  # intern some strings for faster appending
         slash = '/'
+        ctx = ctx or {}
+        cmd = line.split(' ', 1)[0]
         if begidx == 0:
+            # the first thing we're typing; could be python or subprocess, so
+            # anything goes.
             rtn = self.cmd_complete(prefix)
-        elif line.split(' ', 1)[0] in self.bash_complete_funcs:
+        elif cmd in self.bash_complete_funcs:
             rtn = set()
             for s in self.bash_complete(prefix, line, begidx, endidx):
                 if os.path.isdir(s.rstrip()):
                     s = s.rstrip() + slash
                 rtn.add(s)
-            if len(rtn) == 0:
+            if len(rtn) != 0:
                 rtn = self.path_complete(prefix)
             return sorted(rtn)
+        elif cmd not in ctx and cmd not in XONSH_TOKENS:
+            # subproc mode; do path completions
+            return sorted(self.path_complete(prefix))
         else:
+            # if we're here, we're definitely python?
             rtn = set()
         rtn |= {s for s in XONSH_TOKENS if s.startswith(prefix)}
         if ctx is not None:
             rtn |= {s for s in ctx if s.startswith(prefix)}
         rtn |= {s for s in dir(builtins) if s.startswith(prefix)}
         rtn |= {s + space for s in builtins.aliases if s.startswith(prefix)}
+        self._add_env(rtn, prefix)
+        rtn |= self.path_complete(prefix)
+        return sorted(rtn)
+
+    def _add_env(self, paths, prefix):
         if prefix.startswith('$'):
             env = builtins.__xonsh_env__
             key = prefix[1:]
-            rtn |= {'$' + k for k in env if k.startswith(key)}
-        rtn |= self.path_complete(prefix)
-        return sorted(rtn)
+            paths.update({'$' + k for k in env if k.startswith(key)})
+
+    def _add_dots(self, paths, prefix):
+        if prefix in {'', '.'}:
+            paths.update({'./', '../'})
+        if prefix == '..':
+            paths.add('../')
 
     def cmd_complete(self, cmd):
         """Completes a command name based on what is on the $PATH"""
@@ -123,6 +140,8 @@ class Completer(object):
         if tilde in prefix:
             home = os.path.expanduser(tilde)
             paths = {s.replace(home, tilde) for s in paths}
+        self._add_env(paths, prefix)
+        self._add_dots(paths, prefix)
         return paths
 
     def bash_complete(self, prefix, line, begidx, endidx):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -95,7 +95,6 @@ class Completer(object):
             rtn |= {s for s in ctx if s.startswith(prefix)}
         rtn |= {s for s in dir(builtins) if s.startswith(prefix)}
         rtn |= {s + space for s in builtins.aliases if s.startswith(prefix)}
-        self._add_env(rtn, prefix)
         rtn |= self.path_complete(prefix)
         return sorted(rtn)
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -81,7 +81,7 @@ class Completer(object):
                 if os.path.isdir(s.rstrip()):
                     s = s.rstrip() + slash
                 rtn.add(s)
-            if len(rtn) != 0:
+            if len(rtn) == 0:
                 rtn = self.path_complete(prefix)
             return sorted(rtn)
         elif cmd not in ctx and cmd not in XONSH_TOKENS:


### PR DESCRIPTION
This is an attempt to deal with the issue from #101, as well as some lingering issues from #68 (and now #181).  The completer now tries a little harder to decide whether to complete only paths, only Python, or both.

One downside is that `Cmd` seems to ignore the order in which the completions are given (I tried to provide a more sane ordering, but it was ignored).  Though, looking at the source for `Cmd`, I'm not sure where that is happening.  For example, reversing the order of the returned lists caused the return value of `xonsh.Shell.completedefault` to be reversed, but hitting tab a second time to show all completions leads to the options being presented in the normal (un-reversed) order.  So as of right now, strings come first, then `..`, then `.`, then capitalized names, then lower-case names.  This is far from ideal, but I don't know a way around it as of right now.