### PR TITLE
More IO Redirection Options

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -69,7 +69,7 @@ class Env(MutableMapping):
             return self._detyped
         ctx = {}
         for key, val in self._d.items():
-            if callable(val):
+            if callable(val) or isinstance(val, (MutableMapping)):
                 continue
             if not isinstance(key, string_types):
                 key = str(key)

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -572,7 +572,8 @@ def run_subproc(cmds, captured=True):
                                               captured=captured,
                                               prev_proc=prev_proc,
                                               default_stdin=stdin,
-                                              stdout=stdout)
+                                              stdout=stdout,
+                                              stderr=stderr)
             continue
         subproc_kwargs = {}
         if os.name == 'posix':

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -510,7 +510,7 @@ class Parser(object):
         p1, p2 = p[1], p[2]
         p3 = p[3] if lenp > 3 else None
         p4 = p[4] if lenp > 4 else None
-        # skip p5 
+        # skip p5
         p6 = p[6] if lenp > 6 else None
         p7 = p[7] if lenp > 7 else None
         # skip p8
@@ -2174,7 +2174,9 @@ class Parser(object):
     def p_subproc_special_atom(self, p):
         """subproc_special_atom : PIPE
                                 | GT
+                                | LT
                                 | RSHIFT
+                                | SPREDIR
         """
         p[0] = p[1]
 

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -2209,11 +2209,9 @@ class Parser(object):
         elif lenp == 3:
             p0 = [self._subproc_cliargs(p1, lineno=lineno, col=col)]
         else:
-            if len(p1) > 1 and hasattr(p1[-2], 's') and p1[-2].s != '|':
-                msg = 'additional redirect following non-pipe redirect'
-                self._parse_error(msg, self.currloc(lineno=lineno, column=col))
+            p2 = p[2]
             cliargs = self._subproc_cliargs(p[3], lineno=lineno, col=col)
-            p0 = p1 + [p[2], cliargs]
+            p0 = p1 + [p2, cliargs]
         # return arguments list
         p[0] = p0
 

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -154,6 +154,10 @@ class Shell(Cmd):
                 traceback.print_exc()
                 return None
             self.need_more_lines = True
+        except:
+            self.reset_buffer()
+            traceback.print_exc()
+            return None
         return code
 
     def reset_buffer(self):


### PR DESCRIPTION
This changeset implements additional redirect capabilities (redirect stderr to file with `2>` and `2>>`, redirect both stdout and sterr to file with `&>` and `&>>`, grab stdin from file with `<`).  Not as fully-featured as bash's redirects, but it is something.

I also updated many of the error messages from xonsh to be printed to stderr instead of stdout.

Also fixes an unrelated bug with detyping `FORMATTER_DICT` (which I encountered along the way, and which we should fix even if this update is rejected) in built_ins.py, line 72.

The code is not very pretty right now (and so is not yet ready to be merged, I think, until I make another formatting pass), but it seems to be functional.  I'd be glad for any feedback if you have a chance to try it out, @scopatz.