### PR TITLE
Attempt to fix #188

### DIFF
--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -162,11 +162,9 @@ class Execer(object):
                     last_error_line = last_error_col = -1
                     input = '\n'.join(lines)
                     continue
-                maxcol = line.find(';', last_error_col)
-                maxcol = None if maxcol < 0 else maxcol + 1
                 sbpline = subproc_toks(line,
                                        returnline=True,
-                                       maxcol=maxcol,
+                                       maxcol=None,
                                        lexer=self.parser.lexer)
                 if sbpline is None:
                     # subprocess line had no valid tokens, likely because

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -162,9 +162,19 @@ class Execer(object):
                     last_error_line = last_error_col = -1
                     input = '\n'.join(lines)
                     continue
+                maxcol = None
+                self.parser.lexer.input(line)
+                for tok in self.parser.lexer:
+                    if tok.lexpos < last_error_col:
+                        continue
+                    if tok.type == 'SEMI':
+                        maxcol = tok.lexpos
+                        break
+                if maxcol is not None:
+                    maxcol += 1
                 sbpline = subproc_toks(line,
                                        returnline=True,
-                                       maxcol=None,
+                                       maxcol=maxcol,
                                        lexer=self.parser.lexer)
                 if sbpline is None:
                     # subprocess line had no valid tokens, likely because

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -132,10 +132,8 @@ class Execer(object):
         self.parser.lexer.input(line)
         for tok in self.parser.lexer:
             if tok.type == 'SEMI':
-                maxcol = tok.lexpos
+                maxcol = tok.lexpos + mincol + 1
                 break
-        if maxcol is not None:
-            maxcol += mincol + 1
         return maxcol
 
     def _parse_ctx_free(self, input, mode='exec'):


### PR DESCRIPTION
This may not be the most elegant solution, but I think it is robust in that it should only consider "standalone" semicolons as terminators for commands (should fix #188).