### PR TITLE
Completer Bugfix

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -18,7 +18,7 @@ from collections import Sequence, MutableMapping, Iterable, namedtuple, \
     MutableSequence, MutableSet
 
 from xonsh.tools import string_types, redirect_stdout, redirect_stderr
-from xonsh.tools import suggest_commands
+from xonsh.tools import suggest_commands, XonshError
 from xonsh.inspectors import Inspector
 from xonsh.environ import default_env
 from xonsh.aliases import DEFAULT_ALIASES, bash_aliases
@@ -445,8 +445,7 @@ def run_subproc(cmds, captured=True):
                 last_stdout = open(write_target, write_mode)
             except FileNotFoundError:
                 e = 'xonsh: {0}: no such file or directory'
-                print(e.format(write_target))
-                return
+                raise XonshError(e.format(write_target))
         else:
             last_stdout = PIPE
     last_cmd = cmds[-1]
@@ -465,7 +464,7 @@ def run_subproc(cmds, captured=True):
                 aliased_cmd = get_script_subproc_command(cmd[0], cmd[1:])
             except PermissionError:
                 e = 'xonsh: subprocess mode: permission denied: {0}'
-                raise PermissionError(e.format(cmd[0]))
+                raise XonshError(e.format(cmd[0]))
         elif alias is None:
             aliased_cmd = cmd
         elif callable(alias):
@@ -495,12 +494,12 @@ def run_subproc(cmds, captured=True):
                          stdout=stdout, **subproc_kwargs)
         except PermissionError:
             e = 'xonsh: subprocess mode: permission denied: {0}'
-            raise PermissionError(e.format(aliased_cmd[0]))
+            raise XonshError(e.format(aliased_cmd[0]))
         except FileNotFoundError:
             cmd = aliased_cmd[0]
             e = 'xonsh: subprocess mode: command not found: {0}'.format(cmd)
             e += '\n' + suggest_commands(cmd, ENV, builtins.aliases)
-            raise FileNotFoundError(e)
+            raise XonshError(e)
         procs.append(proc)
         prev = None
         if prev_is_proxy:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -465,8 +465,7 @@ def run_subproc(cmds, captured=True):
                 aliased_cmd = get_script_subproc_command(cmd[0], cmd[1:])
             except PermissionError:
                 e = 'xonsh: subprocess mode: permission denied: {0}'
-                print(e.format(cmd[0]))
-                return
+                raise PermissionError(e.format(cmd[0]))
         elif alias is None:
             aliased_cmd = cmd
         elif callable(alias):
@@ -495,14 +494,13 @@ def run_subproc(cmds, captured=True):
                          stdin=stdin,
                          stdout=stdout, **subproc_kwargs)
         except PermissionError:
-            cmd = aliased_cmd[0]
-            print('xonsh: subprocess mode: permission denied: {0}'.format(cmd))
-            return
+            e = 'xonsh: subprocess mode: permission denied: {0}'
+            raise PermissionError(e.format(aliased_cmd[0]))
         except FileNotFoundError:
             cmd = aliased_cmd[0]
-            print('xonsh: subprocess mode: command not found: {0}'.format(cmd))
-            print(suggest_commands(cmd, ENV, builtins.aliases), end='')
-            return
+            e = 'xonsh: subprocess mode: command not found: {0}'.format(cmd)
+            e += '\n' + suggest_commands(cmd, ENV, builtins.aliases)
+            raise FileNotFoundError(e)
         procs.append(proc)
         prev = None
         if prev_is_proxy:

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -8,6 +8,7 @@ from warnings import warn
 from argparse import Namespace
 
 from xonsh.execer import Execer
+from xonsh.tools import XonshError
 from xonsh.completer import Completer
 from xonsh.environ import xonshrc_context, multiline_prompt, format_prompt
 
@@ -128,6 +129,8 @@ class Shell(Cmd):
             return
         try:
             self.execer.exec(code, mode='single', glbs=self.ctx)  # no locals
+        except XonshError as e:
+            print(e.args[0], file=sys.stderr, end='')
         except:
             traceback.print_exc()
         if builtins.__xonsh_exit__:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -32,6 +32,10 @@ else:
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
 
+class XonshError(Exception):
+    pass
+
+
 def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
     """Excapsulates tokens in a source code line in a uncaptured
     subprocess $[] starting at a minimum column. If there are no tokens


### PR DESCRIPTION
This fixes an issue with #192 by causing invalid commands actually to cause an error to be thrown, including a modification to `Shell` to report those errors in a nicer way.