### PR TITLE
Completer Update

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -5,8 +5,8 @@ import re
 import builtins
 import subprocess
 
-from xonsh.tools import subexpr_from_unbalanced
 from xonsh.built_ins import iglobpath
+from xonsh.tools import subexpr_from_unbalanced, all_command_names
 
 RE_DASHF = re.compile(r'-F\s+(\w+)')
 RE_ATTR = re.compile(r'(\S+(\..+)*)\.(\w*)$')
@@ -72,6 +72,7 @@ class Completer(object):
         dot = '.'
         ctx = ctx or {}
         cmd = line.split(' ', 1)[0]
+        allcmds = all_command_names()
         if begidx == 0:
             # the first thing we're typing; could be python or subprocess, so
             # anything goes.
@@ -85,11 +86,11 @@ class Completer(object):
             if len(rtn) == 0:
                 rtn = self.path_complete(prefix)
             return sorted(rtn)
-        elif cmd not in ctx and cmd not in XONSH_TOKENS:
+        elif cmd not in ctx and cmd in allcmds:
             # subproc mode; do path completions
             return sorted(self.path_complete(prefix))
         else:
-            # if we're here, we're definitely python?
+            # if we're here, we're not a command, but could be anything else
             rtn = set()
         rtn |= {s for s in XONSH_TOKENS if s.startswith(prefix)}
         if ctx is not None:

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -271,13 +271,18 @@ class Completer(object):
         al_hash = hash(tuple(builtins.aliases.keys()))
         self._alias_checksum = al_hash
         cache_valid = cache_valid and al_hash == self._alias_checksum
+        pm = self._path_mtime
         if cache_valid:
             for d in filter(os.path.isdir, path):
                 m = os.stat(d).st_mtime
-                if m > self._path_mtime:
-                    self._path_mtime = m
+                if m > pm:
+                    pm = m
                     cache_valid = False
-                    break
+                    # run through everything the first time to get the highest
+                    # mtime for the cache, to avoid rebuilding multiple times
+                    if self._path_mtime != -1:
+                        break
+        self._path_mtime = pm
         if cache_valid:
             return self._cmds_cache
         allcmds = set()

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -76,7 +76,7 @@ class Completer(object):
         if begidx == 0:
             # the first thing we're typing; could be python or subprocess, so
             # anything goes.
-            rtn = self.cmd_complete(prefix)
+            rtn = self.cmd_complete(prefix, allcmds)
         elif cmd in self.bash_complete_funcs:
             rtn = set()
             for s in self.bash_complete(prefix, line, begidx, endidx):
@@ -115,17 +115,10 @@ class Completer(object):
         if prefix == '..':
             paths.add('../')
 
-    def cmd_complete(self, cmd):
+    def cmd_complete(self, cmd, valid):
         """Completes a command name based on what is on the $PATH"""
-        path = builtins.__xonsh_env__.get('PATH', None)
-        if path is None:
-            return set()
-        cmds = set()
         space = ' '
-        for d in path:
-            if os.path.isdir(d):
-                cmds |= {s + space for s in os.listdir(d) if s.startswith(cmd)}
-        return cmds
+        return {s + space for s in valid if s.startswith(cmd)}
 
     def path_complete(self, prefix):
         """Completes based on a path name."""

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -265,23 +265,21 @@ class Completer(object):
 
     def _all_commands(self):
         path = builtins.__xonsh_env__.get('PATH', None) or []
+        # did PATH change?
         path_hash = hash(tuple(path))
         cache_valid = path_hash == self._path_checksum
         self._path_checksum = path_hash
+        # did aliases change?
         al_hash = hash(tuple(builtins.aliases.keys()))
         self._alias_checksum = al_hash
         cache_valid = cache_valid and al_hash == self._alias_checksum
         pm = self._path_mtime
-        if cache_valid:
-            for d in filter(os.path.isdir, path):
-                m = os.stat(d).st_mtime
-                if m > pm:
-                    pm = m
-                    cache_valid = False
-                    # run through everything the first time to get the highest
-                    # mtime for the cache, to avoid rebuilding multiple times
-                    if self._path_mtime != -1:
-                        break
+        # did the contents of any directory in PATH change?
+        for d in filter(os.path.isdir, path):
+            m = os.stat(d).st_mtime
+            if m > pm:
+                pm = m
+                cache_valid = False
         self._path_mtime = pm
         if cache_valid:
             return self._cmds_cache

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -41,7 +41,7 @@ class Completer(object):
         self._path_checksum = None
         self._alias_checksum = None
         self._path_mtime = -1
-        self._cmds_cache = None
+        self._cmds_cache = frozenset()
         try:
             # FIXME this could be threaded for faster startup times
             self._load_bash_complete_funcs()

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -264,13 +264,13 @@ class Completer(object):
         return attrs
 
     def _all_commands(self):
-        path = builtins.__xonsh_env__.get('PATH', None) or []
+        path = builtins.__xonsh_env__.get('PATH', [])
         # did PATH change?
         path_hash = hash(tuple(path))
         cache_valid = path_hash == self._path_checksum
         self._path_checksum = path_hash
         # did aliases change?
-        al_hash = hash(tuple(builtins.aliases.keys()))
+        al_hash = hash(tuple(sorted(builtins.aliases.keys())))
         self._alias_checksum = al_hash
         cache_valid = cache_valid and al_hash == self._alias_checksum
         pm = self._path_mtime
@@ -284,9 +284,8 @@ class Completer(object):
         if cache_valid:
             return self._cmds_cache
         allcmds = set()
-        for d in path:
-            if os.path.isdir(d):
-                allcmds |= set(os.listdir(d))
+        for d in filter(os.path.isdir, path):
+            allcmds |= set(os.listdir(d))
         allcmds |= set(builtins.aliases.keys())
         self._cmds_cache = frozenset(allcmds)
         return self._cmds_cache

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -289,6 +289,17 @@ class redirect_stderr(_RedirectStream):
     _stream = "stderr"
 
 
+def all_command_names():
+    """Return a set containing all valid commands from PATH and aliases"""
+    path = builtins.__xonsh_env__.get('PATH', None) or []
+    allcmds = set()
+    for d in path:
+        if os.path.isdir(d):
+            allcmds |= set(os.listdir(d))
+    allcmds |= set(builtins.aliases.keys())
+    return allcmds
+
+
 def suggest_commands(cmd, env, aliases):
     """Suggests alternative commands given an environment and aliases."""
     if env.get('SUGGEST_COMMANDS', True):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -289,17 +289,6 @@ class redirect_stderr(_RedirectStream):
     _stream = "stderr"
 
 
-def all_command_names():
-    """Return a set containing all valid commands from PATH and aliases"""
-    path = builtins.__xonsh_env__.get('PATH', None) or []
-    allcmds = set()
-    for d in path:
-        if os.path.isdir(d):
-            allcmds |= set(os.listdir(d))
-    allcmds |= set(builtins.aliases.keys())
-    return allcmds
-
-
 def suggest_commands(cmd, env, aliases):
     """Suggests alternative commands given an environment and aliases."""
     if env.get('SUGGEST_COMMANDS', True):


### PR DESCRIPTION
Modify the completer by changing when it calls `path_complete` as discussed in #192.

This change makes it so that `attr_complete` is called in the following cases, rather than `path_complete`:

`x = "cat".<TAB>`
and
`{"cat": "dog".<TAB>`