### PR TITLE
Lazy JSON File

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -38,6 +38,7 @@ For those of you who want the gritty details.
     :maxdepth: 1
 
     tools
+    lazyjson
     openpy
     main
     pyghooks

--- a/docs/api/lazyjson.rst
+++ b/docs/api/lazyjson.rst
@@ -1,0 +1,10 @@
+.. _xonsh_lazyjson:
+
+******************************************
+Lazy JSON Files (``xonsh.lazyjson``)
+******************************************
+
+.. automodule:: xonsh.lazyjson
+    :members:
+    :undoc-members:
+

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -1,11 +1,12 @@
 """Tests lazy json functionality."""
 from __future__ import unicode_literals, print_function
+from io import StringIO
 
 import nose
 from nose.tools import assert_equal
 assert_equal.__self__.maxDiff = None
 
-from xonsh.lazyjson import index
+from xonsh.lazyjson import index, dump, LazyJSON
 
 def test_index_int():
     exp = {'offsets': 0, 'sizes': 2}
@@ -59,6 +60,13 @@ def test_index_dict_dict_int():
     s, obs = index({'wakka': {'jawaka': 42}})
     assert_equal(exp, obs)
 
+def test_lazy_load_index():
+    f = StringIO()
+    dump({'wakka': 42}, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal({'wakka': 10, '__total__': 0}, lj.offsets)
+    assert_equal({'wakka': 2, '__total__': 14}, lj.sizes)
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -1,0 +1,27 @@
+"""Tests lazy json functionality."""
+from __future__ import unicode_literals, print_function
+
+import nose
+from nose.tools import assert_equal
+
+from xonsh.lazyjson import index
+
+def test_index_int():
+    exp = {'offset': 0, 'size': 2}
+    s, obs = index(42)
+    assert_equal(exp, obs)
+
+def test_index_str():
+    exp = {'offset': 0, 'size': 7}
+    s, obs = index('wakka')
+    assert_equal(exp, obs)
+
+def test_index_list_ints():
+    exp = {'offset': [1, 3], 'size': [1, 2]}
+    s, obs = index([1, 42])
+    print(s)
+    assert_equal(exp, obs)
+
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -146,6 +146,18 @@ def test_lazy_dict():
     assert_equal(1, len(lj))
     assert_equal({'wakka': 42}, lj.load())
 
+def test_lazy_dict_dict_int():
+    x = {'wakka': {'jawaka': 42}}
+    f = StringIO()
+    dump(x, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal(['wakka'], list(lj.keys()))
+    assert_is_instance(lj['wakka'], Node)
+    assert_equal(42, lj['wakka']['jawaka'])
+    assert_equal(1, len(lj))
+    assert_equal(x, lj.load())
+
 
 
 if __name__ == '__main__':

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -17,10 +17,25 @@ def test_index_str():
     assert_equal(exp, obs)
 
 def test_index_list_ints():
-    exp = {'offset': [1, 3], 'size': [1, 2]}
+    exp = {'offset': [1, 4], 'size': [1, 2]}
     s, obs = index([1, 42])
-    print(s)
     assert_equal(exp, obs)
+
+def test_index_list_str():
+    exp = {'offset': [1, 10], 'size': [7, 8]}
+    s, obs = index(['wakka', 'jawaka'])
+    assert_equal(exp, obs)
+
+def test_index_list_str_int():
+    exp = {'offset': [1, 10], 'size': [7, 2]}
+    s, obs = index(['wakka', 42])
+    assert_equal(exp, obs)
+
+def test_index_list_int_str():
+    exp = {'offset': [1, 5, 14], 'size': [2, 7, 8]}
+    s, obs = index([42, 'wakka', 'jawaka'])
+    assert_equal(exp, obs)
+
 
 
 if __name__ == '__main__':

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals, print_function
 from io import StringIO
 
 import nose
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_is_instance
 assert_equal.__self__.maxDiff = None
 
-from xonsh.lazyjson import index, dump, LazyJSON
+from xonsh.lazyjson import index, dump, LazyJSON, Node
 
 def test_index_int():
     exp = {'offsets': 0, 'sizes': 2}
@@ -67,6 +67,86 @@ def test_lazy_load_index():
     lj = LazyJSON(f)
     assert_equal({'wakka': 10, '__total__': 0}, lj.offsets)
     assert_equal({'wakka': 2, '__total__': 14}, lj.sizes)
+
+def test_lazy_int():
+    f = StringIO()
+    dump(42, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal(42, lj.load())
+
+def test_lazy_str():
+    f = StringIO()
+    dump('wakka', f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal('wakka', lj.load())
+
+def test_lazy_list_ints():
+    x = [0, 1, 6, 28, 496, 8128]
+    f = StringIO()
+    dump(x, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal(28, lj[3])
+    assert_equal(x[:2:-2], lj[:2:-2])
+    assert_equal(x, [_ for _ in lj])
+    assert_equal(x, lj.load())
+def test_lazy_list_ints():
+    x = [0, 1, 6, 28, 496, 8128]
+    f = StringIO()
+    dump(x, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal(28, lj[3])
+    assert_equal(x[:2:-2], lj[:2:-2])
+    assert_equal(x, [_ for _ in lj])
+    assert_equal(x, lj.load())
+
+def test_lazy_list_str():
+    x = ['I', 'have', 'seen', 'the', 'wind', 'blow']
+    f = StringIO()
+    dump(x, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal('the', lj[3])
+    assert_equal(x[:2:-2], lj[:2:-2])
+    assert_equal(x, [_ for _ in lj])
+    assert_equal(x, lj.load())
+
+def test_lazy_list_ints():
+    x = [0, 1, 6, 28, 496, 8128]
+    f = StringIO()
+    dump(x, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal(28, lj[3])
+    assert_equal(x[:2:-2], lj[:2:-2])
+    assert_equal(x, [_ for _ in lj])
+    assert_equal(x, lj.load())
+
+def test_lazy_list_list_ints():
+    x = [[0, 1], [6, 28], [496, 8128]]
+    f = StringIO()
+    dump(x, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_is_instance(lj[1], Node)
+    assert_equal(28, lj[1][1])
+    assert_equal([6, 28], lj[1].load())
+    assert_equal(x, lj.load())
+
+def test_lazy_dict():
+    f = StringIO()
+    dump({'wakka': 42}, f)
+    f.seek(0)
+    lj = LazyJSON(f)
+    assert_equal(['wakka'], list(lj.keys()))
+    assert_equal(42, lj['wakka'])
+    assert_equal(1, len(lj))
+    assert_equal({'wakka': 42}, lj.load())
+
+
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -3,39 +3,61 @@ from __future__ import unicode_literals, print_function
 
 import nose
 from nose.tools import assert_equal
+assert_equal.__self__.maxDiff = None
 
 from xonsh.lazyjson import index
 
 def test_index_int():
-    exp = {'offset': 0, 'size': 2}
+    exp = {'offsets': 0, 'sizes': 2}
     s, obs = index(42)
     assert_equal(exp, obs)
 
 def test_index_str():
-    exp = {'offset': 0, 'size': 7}
+    exp = {'offsets': 0, 'sizes': 7}
     s, obs = index('wakka')
     assert_equal(exp, obs)
 
 def test_index_list_ints():
-    exp = {'offset': [1, 4], 'size': [1, 2]}
+    exp = {'offsets': [1, 4, 0], 'sizes': [1, 2, 8]}
     s, obs = index([1, 42])
     assert_equal(exp, obs)
 
 def test_index_list_str():
-    exp = {'offset': [1, 10], 'size': [7, 8]}
+    exp = {'offsets': [1, 10, 0], 'sizes': [7, 8, 20]}
     s, obs = index(['wakka', 'jawaka'])
     assert_equal(exp, obs)
 
 def test_index_list_str_int():
-    exp = {'offset': [1, 10], 'size': [7, 2]}
+    exp = {'offsets': [1, 10, 0], 'sizes': [7, 2, 14]}
     s, obs = index(['wakka', 42])
     assert_equal(exp, obs)
 
 def test_index_list_int_str():
-    exp = {'offset': [1, 5, 14], 'size': [2, 7, 8]}
+    exp = {'offsets': [1, 5, 14, 0], 'sizes': [2, 7, 8, 24]}
     s, obs = index([42, 'wakka', 'jawaka'])
     assert_equal(exp, obs)
 
+def test_index_dict_int():
+    exp = {'offsets': {'wakka': 10, '__total__': 0}, 
+           'sizes': {'wakka': 2, '__total__': 14}}
+    s, obs = index({'wakka': 42})
+    assert_equal(exp, obs)
+
+def test_index_dict_str():
+    exp = {'offsets': {'wakka': 10, '__total__': 0}, 
+           'sizes': {'wakka': 8, '__total__': 20}}
+    s, obs = index({'wakka': 'jawaka'})
+    assert_equal(exp, obs)
+
+def test_index_dict_dict_int():
+    exp = {'offsets': {'wakka': {'jawaka': 21, '__total__': 10},
+                      '__total__': 0,
+                      },
+           'sizes': {'wakka': {'jawaka': 2, '__total__': 15}, 
+                    '__total__': 27}
+           }
+    s, obs = index({'wakka': {'jawaka': 42}})
+    assert_equal(exp, obs)
 
 
 if __name__ == '__main__':

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -1,6 +1,7 @@
 """Implements a lazy JSON file class that wraps around json data."""
 from __future__ import print_function, unicode_literals
 from collections import Mapping, Sequence
+from contextlib import contextmanager
 try:
     import simplejson as json
 except ImportError:
@@ -9,11 +10,7 @@ except ImportError:
 from xonsh.tools import string_types
 
 
-class LazyJSON(object):
-    """Represents a lazy json file."""
-
-
-def _to_json_with_size(obj, offset=0):
+def _to_json_with_size(obj, offset=0, sort_keys=False):
     if isinstance(obj, string_types):
         s = json.dumps(obj)
         o = offset
@@ -23,26 +20,31 @@ def _to_json_with_size(obj, offset=0):
         j = offset + 1
         o = {}
         size = {}
-        for key, val in obj.items():
-            s_k, o_k, n_k, size_k = _to_json_with_size(key, offset=j)
+        items = sorted(obj.items()) if sort_keys else obj.items()
+        for key, val in items:
+            s_k, o_k, n_k, size_k = _to_json_with_size(key, offset=j, 
+                                                       sort_keys=sort_keys)
             s += s_k + ': '
             j += n_k + 2
-            s_v, o_v, n_v, size_v = _to_json_with_size(val, offset=j)
-            o[key] = j
+            s_v, o_v, n_v, size_v = _to_json_with_size(val, offset=j,
+                                                       sort_keys=sort_keys)
+            o[key] = o_v
             size[key] = size_v
-            s += s_x + ', '
-            j += n_x + 2
+            s += s_v + ', '
+            j += n_v + 2
         s = s[:-2]
         s += '}\n'
         n = len(s)
-        
+        o['__total__'] = offset
+        size['__total__'] = n
     elif isinstance(obj, Sequence):
         s = '['
         j = offset + 1
         o = []
         size = []
         for x in obj:
-            s_x, o_x, n_x, size_x = _to_json_with_size(x, offset=j)
+            s_x, o_x, n_x, size_x = _to_json_with_size(x, offset=j,
+                                                       sort_keys=sort_keys)
             o.append(j)
             size.append(size_x)
             s += s_x + ', '
@@ -50,21 +52,94 @@ def _to_json_with_size(obj, offset=0):
         s = s[:-2]
         s += ']\n'
         n = len(s)
+        o.append(offset)
+        size.append(n)
     else:
-        s = json.dumps(obj)
+        s = json.dumps(obj, sort_keys=sort_keys)
         o = offset
         n = size = len(s)
     return s, o, n, size
 
 
-def index(obj):
+def index(obj, sort_keys=False):
     """Creates an index for a JSON file."""
-    index = {}
-    s, index['offset'], _, index['size'] = _to_json_with_size(obj)
-    return s, index
+    idx = {}
+    json_obj = _to_json_with_size(obj, sort_keys=sort_keys)
+    s, idx['offsets'], _, idx['sizes'] = json_obj
+    return s, idx
 
 
-def dumps(obj):
-    """"""
-    
-    
+JSON_FORMAT = \
+"""{{"locs": [{iloc:>10}, {ilen:>10}, {dloc:>10}, {dlen:>10}],
+ "index": {index},
+ "data": {data}
+}}
+"""
+
+def dumps(obj, sort_keys=False):
+    """Dumps an object to JSON with an index."""
+    data, idx = index(obj, sort_keys=sort_keys)
+    jdx = json.dumps(idx, sort_keys=sort_keys)
+    iloc = 69
+    ilen = len(jdx)
+    dloc = iloc + ilen + 11
+    dlen = len(data)
+    s = JSON_FORMAT.format(index=jdx, data=data, iloc=iloc, ilen=ilen, 
+                           dloc=dloc, dlen=dlen)
+    return s
+
+
+def dump(obj, fp, sort_keys=False):
+    """Dumps an object to JSON file."""
+    s = dumps(obj, sort_keys=sort_keys)
+    fp.write(s)
+
+
+
+#class Node(Mapping, Sequence):
+
+#class LazyJSON(Node):
+class LazyJSON(object):
+    """Represents a lazy json file."""
+
+    def __init__(self, f, reopen=True):
+        """Parameters
+        ----------
+        f : file handle or str
+            JSON file to open.
+        reopen : bool
+            Whether new file handle should be opened for each load.
+        """
+        self._f = f
+        self.reopen = reopen
+        if not reopen and isinstance(f, string_types):
+            self._f = open(f, 'r')
+        self._load_index()
+
+    def __del__(self):
+        if not self.reopen:
+            self._f.close()
+
+    @contextmanager
+    def _open(self, *args, **kwargs):
+        if self.reopen and isinstance(self._f, string_types):
+            f = open(self._f, *args, **kwargs)
+            yield f
+            f.close()
+        else:
+            yield self._f
+
+    def _load_index(self):
+        """Loads the index from the start of the file."""
+        with self._open as f:
+            # read in the location data
+            f.seek(9)
+            locs = f.read(48)
+            locs = json.loads(locs)
+            self.iloc, self.ilen, self.dloc, self.dlen = locs
+            # read in the index
+            f.seek(self.iloc)
+            idx = f.read(self.ilen)
+            idx = json.loads(idx)
+        self.offsets = idx['offsets']
+        self.sizes = idx['sizes']

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -47,7 +47,7 @@ def _to_json_with_size(obj, offset=0, sort_keys=False):
         for x in obj:
             s_x, o_x, n_x, size_x = _to_json_with_size(x, offset=j,
                                                        sort_keys=sort_keys)
-            o.append(j)
+            o.append(o_x)
             size.append(size_x)
             s += s_x + ', '
             j += n_x + 2
@@ -121,6 +121,9 @@ class Node(Mapping, Sequence):
         elif self.is_sequence:
             offset = self.offsets[-1]
             size = self.sizes[-1]
+        elif isinstance(self.offsets, int):
+            offset = self.offsets
+            size = self.sizes
         return self._load_or_node(offset, size)
 
     def _load_or_node(self, offset, size):
@@ -178,7 +181,6 @@ class Node(Mapping, Sequence):
 
 
 class LazyJSON(Node):
-#class LazyJSON(object):
     """Represents a lazy json file."""
 
     def __init__(self, f, reopen=True):

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -1,0 +1,83 @@
+"""Implements a lazy JSON file class that wraps around json data."""
+from __future__ import print_function, unicode_literals
+from collections import Mapping, Sequence
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+from xonsh.tools import string_types
+
+
+class LazyJSON(object):
+    """Represents a lazy json file."""
+
+
+
+def _update_offset(o_x, j):
+    if isinstance(o_x, string_types):
+        offset = o_x + j
+    elif isinstance(o_x, Mapping):
+        offset = {k: _update_offset(v, j) for k, v in o_x.items()}
+    elif isinstance(o_x, Sequence):
+        offset = [_update_offset(o, j) for o in o_x]
+    else:
+        offset = o_x + j
+    return offset
+
+
+def _to_json_with_size(obj, offset=0):
+    if isinstance(obj, string_types):
+        s = json.dumps(obj)
+        o = offset
+        n = size = len(s.encode())  # size in bytes
+    elif isinstance(obj, Mapping):
+        s = '{'
+        j = offset + 1
+        o = {}
+        size = {}
+        for key, val in obj.items():
+            s_k, o_k, n_k, size_k = _to_json_with_size(key, offset=j)
+            s += s_k + ': '
+            j += n_k + 2
+            s_v, o_v, n_v, size_v = _to_json_with_size(val, offset=j)
+            o[key] = _update_offset(o_v, j)
+            size[key] = size_v
+            s += s_x + ', '
+            j += n_x + 2
+        s = s[:-2]
+        s += '}\n'
+        n = len(s)
+        
+    elif isinstance(obj, Sequence):
+        s = '['
+        j = offset + 1
+        o = []
+        size = []
+        for x in obj:
+            s_x, o_x, n_x, size_x = _to_json_with_size(x, offset=j)
+            o.append(_update_offset(o_x, j))
+            size.append(size_x)
+            s += s_x + ', '
+            j += n_x + 2
+        s = s[:-2]
+        s += ']\n'
+        n = len(s)
+    else:
+        s = json.dumps(obj)
+        o = offset
+        n = size = len(s)
+    return s, o, n, size
+
+
+def index(obj):
+    """Creates an index for a JSON file."""
+    index = {}
+    s, index['offset'], _, index['size'] = _to_json_with_size(obj)
+    return s, index
+
+
+def dumps(obj):
+    """"""
+    
+    

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -13,19 +13,6 @@ class LazyJSON(object):
     """Represents a lazy json file."""
 
 
-
-def _update_offset(o_x, j):
-    if isinstance(o_x, string_types):
-        offset = o_x + j
-    elif isinstance(o_x, Mapping):
-        offset = {k: _update_offset(v, j) for k, v in o_x.items()}
-    elif isinstance(o_x, Sequence):
-        offset = [_update_offset(o, j) for o in o_x]
-    else:
-        offset = o_x + j
-    return offset
-
-
 def _to_json_with_size(obj, offset=0):
     if isinstance(obj, string_types):
         s = json.dumps(obj)
@@ -41,7 +28,6 @@ def _to_json_with_size(obj, offset=0):
             s += s_k + ': '
             j += n_k + 2
             s_v, o_v, n_v, size_v = _to_json_with_size(val, offset=j)
-            #o[key] = _update_offset(o_v, j)
             o[key] = j
             size[key] = size_v
             s += s_x + ', '
@@ -57,7 +43,6 @@ def _to_json_with_size(obj, offset=0):
         size = []
         for x in obj:
             s_x, o_x, n_x, size_x = _to_json_with_size(x, offset=j)
-            #o.append(_update_offset(o_x, j))
             o.append(j)
             size.append(size_x)
             s += s_x + ', '

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -41,7 +41,8 @@ def _to_json_with_size(obj, offset=0):
             s += s_k + ': '
             j += n_k + 2
             s_v, o_v, n_v, size_v = _to_json_with_size(val, offset=j)
-            o[key] = _update_offset(o_v, j)
+            #o[key] = _update_offset(o_v, j)
+            o[key] = j
             size[key] = size_v
             s += s_x + ', '
             j += n_x + 2
@@ -56,7 +57,8 @@ def _to_json_with_size(obj, offset=0):
         size = []
         for x in obj:
             s_x, o_x, n_x, size_x = _to_json_with_size(x, offset=j)
-            o.append(_update_offset(o_x, j))
+            #o.append(_update_offset(o_x, j))
+            o.append(j)
             size.append(size_x)
             s += s_x + ', '
             j += n_x + 2

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -102,6 +102,15 @@ class Node(Mapping, Sequence):
     """A proxy node for JSON nodes. Acts as both sequence and mapping."""
 
     def __init__(self, offsets, sizes, root):
+        """Parameters
+        ----------
+        offsets : dict, list, or int
+            offsets of cooresponding data structure, in bytes
+        sizes : dict, list, or int
+            sizes of cooresponding data structure, in bytes
+        root : weakref.proxy of LazyJSON
+            weakref back to root node, which should be a LazyJSON object.
+        """
         self.offsets = offsets
         self.sizes = sizes
         self.root = root
@@ -181,7 +190,9 @@ class Node(Mapping, Sequence):
 
 
 class LazyJSON(Node):
-    """Represents a lazy json file."""
+    """Represents a lazy json file. Can be used like a normal Python 
+    dict or list.
+    """
 
     def __init__(self, f, reopen=True):
         """Parameters

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -131,7 +131,7 @@ class LazyJSON(object):
 
     def _load_index(self):
         """Loads the index from the start of the file."""
-        with self._open as f:
+        with self._open() as f:
             # read in the location data
             f.seek(9)
             locs = f.read(48)


### PR DESCRIPTION
Here are some tools for representing lazily loadable JSON files. This has a lot of potential use for history objects as discussed in #213.  @aig787, this one is for you, but @wrywerytwreywery will have to merge.  If you could both take a look that'd be great!

I haven't gone through the work of making all of the output as pretty as possible because I don't want this to block the progress on the history object any longer.  Sorry this took me so long to get around to.  

The basic idea is that for any `obj` that is JSON convertible, you can use the module as follows:

```python
from xonsh.lazyjson import dump, LazyJSON

obj = {....}

with open('/path/to/file', 'w') as f:
    dump(obj, f)  # writes the JSON file with an index inserted

# only reads in the index info
lj = LazyJSON('/path/to/file')  

# each indexing op will return a proxy Node instance if op 
# would give dict or list, otherwise reads value from file.
lj[x][y][z]

# full data structures can be read in manually
lj.load()
lj[x].load()
```