### PR TITLE
Fix For Quoted Args

### DIFF
--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -2331,6 +2331,7 @@ class Parser(object):
                             | TRUE
                             | FALSE
                             | NUMBER
+                            | STRING
         """
         # Many tokens cannot be part of this list, such as $, ', ", ()
         # Use a string atom instead.


### PR DESCRIPTION
This changeset allows string literals to be subproc atoms, which I believe this should fix #217.