### PR TITLE
allow grouping syntax to be part of subprocess expressions

### DIFF
--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -162,7 +162,7 @@ def handle_lparen(state, token, stream):
     """
     Function for handling ``(``
     """
-    state['pymode'].append((True, '(', ')', token.start))
+    state['pymode'].append((state['pymode'][-1][0], '(', ')', token.start))
     state['last'] = token
     yield _new_token('LPAREN', '(', token.start)
 
@@ -171,7 +171,7 @@ def handle_lbrace(state, token, stream):
     """
     Function for handling ``{``
     """
-    state['pymode'].append((True, '{', '}', token.start))
+    state['pymode'].append((state['pymode'][-1][0], '{', '}', token.start))
     state['last'] = token
     yield _new_token('LBRACE', '{', token.start)
 
@@ -180,7 +180,7 @@ def handle_lbracket(state, token, stream):
     """
     Function for handling ``[``
     """
-    state['pymode'].append((True, '[', ']', token.start))
+    state['pymode'].append((state['pymode'][-1][0], '[', ']', token.start))
     state['last'] = token
     yield _new_token('LBRACKET', '[', token.start)
 
@@ -202,10 +202,14 @@ def handle_rparen(state, token, stream):
     """
     Function for handling ``)``
     """
+    m = state['pymode'][-1][1]
     e = _end_delimiter(state, token)
     if e is None:
         state['last'] = token
-        yield _new_token('RPAREN', ')', token.start)
+        typ = 'RPAREN'
+        if m.startswith('$'):
+            typ = 'SUBPROC_END_RPAREN'
+        yield _new_token(typ, ')', token.start)
     else:
         yield _new_token('ERRORTOKEN', e, token.start)
 
@@ -226,10 +230,14 @@ def handle_rbracket(state, token, stream):
     """
     Function for handling ``]``
     """
+    m = state['pymode'][-1][1]
     e = _end_delimiter(state, token)
     if e is None:
         state['last'] = token
-        yield _new_token('RBRACKET', ']', token.start)
+        typ = 'RBRACKET'
+        if m.startswith('$'):
+            typ = 'SUBPROC_END_RBRACKET'
+        yield _new_token(typ, ']', token.start)
     else:
         yield _new_token('ERRORTOKEN', e, token.start)
 
@@ -418,6 +426,8 @@ class Lexer(object):
         'REGEXPATH',             # regex escaped with backticks
         'LPAREN', 'RPAREN',      # ( )
         'LBRACKET', 'RBRACKET',  # [ ]
+        'SUBPROC_END_RBRACKET',
+        'SUBPROC_END_RPAREN',
         'LBRACE', 'RBRACE',      # { }
         'AT',                    # @
         'QUESTION',              # ?

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1629,8 +1629,8 @@ class Parser(object):
                 | REGEXPATH
                 | DOLLAR_NAME
                 | DOLLAR_LBRACE test RBRACE
-                | DOLLAR_LPAREN subproc RPAREN
-                | DOLLAR_LBRACKET subproc RBRACKET
+                | DOLLAR_LPAREN subproc SUBPROC_END_RPAREN
+                | DOLLAR_LBRACKET subproc SUBPROC_END_RBRACKET
         """
         p1 = p[1]
         if len(p) == 2:
@@ -2235,8 +2235,8 @@ class Parser(object):
                         | DOLLAR_NAME
                         | AT_LPAREN test RPAREN
                         | DOLLAR_LBRACE test RBRACE
-                        | DOLLAR_LPAREN subproc RPAREN
-                        | DOLLAR_LBRACKET subproc RBRACKET
+                        | DOLLAR_LPAREN subproc SUBPROC_END_RPAREN
+                        | DOLLAR_LBRACKET subproc SUBPROC_END_RBRACKET
         """
         lenp = len(p)
         p1 = p[1]
@@ -2332,6 +2332,13 @@ class Parser(object):
                             | FALSE
                             | NUMBER
                             | STRING
+                            | LPAREN
+                            | RPAREN
+                            | LBRACE
+                            | RBRACE
+                            | LBRACKET
+                            | RBRACKET
+                            | COMMA
         """
         # Many tokens cannot be part of this list, such as $, ', ", ()
         # Use a string atom instead.


### PR DESCRIPTION
This PR allows for grouping syntax (parens, braces, brackets) to be part of a subprocess expression.  This should solve an issue with the `timeit` alias, and should also open the door for parenthesized subprocess expressions (so that we can eventually implement <tt>and</tt>, <tt>or</tt>, and <tt>not</tt> properly for subprocesses as we've discussed in the past).

@scopatz: this PR, if accepted, is intended to be merged with your `timeit` branch before merging that with `master`.