### PR TITLE
Add support for CDPATH

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -225,6 +225,11 @@ SHELL_TYPE         ``'readline'``                Which shell is used.
                                                  library installed. To specify
                                                  which shell should be used, do
                                                  so in the run control file.
+CDPATH             ``[]``                        A list of paths to be used as
+                                                 roots for a `cd`, breaking
+                                                 compatibility with bash, xonsh
+                                                 always prefer an existing
+                                                 relative path.
 ================== ============================= ================================
 
 Environment Lookup with ``${}``

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -1,0 +1,61 @@
+"""Testing dirstack"""
+from __future__ import unicode_literals, print_function
+
+from contextlib import contextmanager
+from functools import wraps
+import os
+import builtins
+
+from nose.tools import assert_equal, assert_not_equal
+import nose
+
+from xonsh import dirstack
+from xonsh.environ import Env
+from xonsh.built_ins import load_builtins
+
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+PARENT = os.path.dirname(HERE)
+
+@contextmanager
+def chdir(adir):
+    old_dir = os.getcwd()
+    os.chdir(adir)
+    yield
+    os.chdir(old_dir)
+
+@contextmanager
+def xonsh_env(env):
+    load_builtins()
+    old_env = builtins.__xonsh_env__
+    builtins.__xonsh_env__ = env
+    yield
+    builtins.__xonsh_env__ = old_env
+
+def test_simple():
+    load_builtins()
+    with chdir(PARENT):
+        assert_not_equal(os.getcwd(), HERE)
+        dirstack.cd(["tests"])
+        assert_equal(os.getcwd(), HERE)
+
+def test_cdpath_simple():
+    with xonsh_env(Env(CDPATH=PARENT)):
+        with chdir(os.path.normpath("/")):
+            assert_not_equal(os.getcwd(), HERE)
+            dirstack.cd(["tests"])
+            assert_equal(os.getcwd(), HERE)
+
+def test_cdpath_collision():
+    with xonsh_env(Env(CDPATH=PARENT)):
+        sub_tests = os.path.join(HERE, "tests")
+        if not os.path.exists(sub_tests):
+            os.mkdir(sub_tests)
+        with chdir(HERE):
+            assert_equal(os.getcwd(), HERE)
+            dirstack.cd(["tests"])
+            assert_equal(os.getcwd(), os.path.join(HERE, "tests"))
+
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -134,6 +134,13 @@ class Completer(object):
         if prefix == '..':
             paths.add('../')
 
+    def _add_cdpaths(self, paths, prefix):
+        """Completes current prefix using CDPATH"""
+        env = builtins.__xonsh_env__
+        for cdp in env.get("CDPATH", []):
+            for s in iglobpath(os.path.join(cdp, prefix) + '*'):
+                paths.add(s)
+
     def cmd_complete(self, cmd):
         """Completes a command name based on what is on the $PATH"""
         space = ' '
@@ -163,7 +170,8 @@ class Completer(object):
             paths = {s.replace(home, tilde) for s in paths}
         self._add_env(paths, prefix)
         self._add_dots(paths, prefix)
-        return paths
+        self._add_cdpaths(paths, prefix)
+        return {os.path.normpath(s) for s in paths}
 
     def bash_complete(self, prefix, line, begidx, endidx):
         """Attempts BASH completion."""


### PR DESCRIPTION
CDPATH works like PATH for `cd`, no CDPATH is like CDPATH=. but more prefixes can be added.