### PR TITLE
small fix from ProcProxy changes

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -479,8 +479,7 @@ def run_subproc(cmds, captured=True):
         return
     if prev_is_proxy:
         prev_proc.wait()
-    else:
-        wait_for_active_job()
+    wait_for_active_job()
     if write_target is None:
         # get output
         output = ''


### PR DESCRIPTION
The first of hopefully not too many :)

We want to wait for the active job regardless of whether the command we have just run is a Python function or not (this fixes an issue where `fg`, for example, would go into the first branch, and we would not end up actually waiting for the job that we had just `fg`-ed to finish).