### PR TITLE
Update prompt to display different color branch name if git is dirty

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -810,6 +810,8 @@ By default, the following variables are available for use:
   * ``cwd``: The current working directory
   * ``curr_branch``: The name of the current git branch (preceded by space),
     if any.
+  * ``git_dirty_color``: ``{BOLD_GREEN}`` if the current git branch is clean,
+    otherwise ``{BOLD_RED}``
 
 You can also color your prompt easily by inserting keywords such as ``{GREEN}``
 or ``{BOLD_BLUE}``.  Colors have the form shown below:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -810,7 +810,7 @@ By default, the following variables are available for use:
   * ``cwd``: The current working directory
   * ``curr_branch``: The name of the current git branch (preceded by space),
     if any.
-  * ``git_dirty_color``: ``{BOLD_GREEN}`` if the current git branch is clean,
+  * ``branch_color``: ``{BOLD_GREEN}`` if the current git branch is clean,
     otherwise ``{BOLD_RED}``
 
 You can also color your prompt easily by inserting keywords such as ``{GREEN}``

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -42,10 +42,10 @@ def ensure_git(func):
 
 
 @ensure_git
-def git_current_branch(cwd=None, pad=True):
+def current_branch(cwd=None, pad=True):
     """Gets the branch for a current working directory. Returns None
     if the cwd is not a repository.  This currently only works for git,
-    bust should be extended in the future.
+    but should be extended in the future.
     """
     branch = None
     prompt_scripts = ['/usr/lib/git-core/git-sh-prompt',
@@ -83,9 +83,11 @@ def git_current_branch(cwd=None, pad=True):
 
 
 @ensure_git
-def git_dirty(cwd=None):
+def branch_dirty(cwd=None):
     """Returns a boolean as to whether there are uncommitted files on the
-    current branch of a git repository (if there is one)"""
+    current branch of a git repository (if there is one).  Currently only
+    supports git, but could be extended in the future.
+    """
     try:
         cmd = ['git', 'status', '--porcelain']
         s = subprocess.check_output(cmd,
@@ -97,12 +99,14 @@ def git_dirty(cwd=None):
         return False
 
 
-def git_dirty_color():
-    return TERM_COLORS['BOLD_RED'] if git_dirty() else TERM_COLORS['BOLD_GREEN']
+def branch_color():
+    """Return red if the current branch is dirty, otherwise green"""
+    return (TERM_COLORS['BOLD_RED'] if branch_dirty() else
+            TERM_COLORS['BOLD_GREEN'])
 
 
 DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
-                  '{cwd}{git_dirty_color}{curr_branch} '
+                  '{cwd}{branch_color}{curr_branch} '
                   '{BOLD_BLUE}${NO_COLOR} ')
 DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
 
@@ -125,8 +129,8 @@ else:
 FORMATTER_DICT = dict(user=os.environ.get(USER, '<user>'),
                       hostname=socket.gethostname().split('.', 1)[0],
                       cwd=lambda: _replace_home(builtins.__xonsh_env__['PWD']),
-                      curr_branch=git_current_branch,
-                      git_dirty_color=git_dirty_color,
+                      curr_branch=current_branch,
+                      branch_color=branch_color,
                       **TERM_COLORS)
 
 _formatter = string.Formatter()

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -8,38 +8,46 @@ import string
 import builtins
 import subprocess
 from warnings import warn
+from functools import wraps
 
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC
 from xonsh.dirstack import _get_cwd
 
 
-def current_branch(cwd=None, pad=True):
+def ensure_git(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # getting the branch was slow on windows, disabling for now.
+        if ON_WINDOWS:
+            return ''
+
+        # Get cwd or bail
+        kwargs['cwd'] = kwargs.get('cwd', _get_cwd())
+        if kwargs['cwd'] is None:
+            return
+
+        # step out completely if git is not installed
+        try:
+            binary_location = subprocess.check_output(['which', 'git'],
+                                                      cwd=kwargs['cwd'],
+                                                      stderr=subprocess.PIPE,
+                                                      universal_newlines=True)
+            if not binary_location:
+                return
+        except subprocess.CalledProcessError:
+            return
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@ensure_git
+def git_current_branch(cwd=None, pad=True):
     """Gets the branch for a current working directory. Returns None
     if the cwd is not a repository.  This currently only works for git,
     bust should be extended in the future.
     """
     branch = None
-
-    if ON_WINDOWS:
-        # getting the branch was slow on windows, disabling for now.
-        return ''
-    
-    cwd = _get_cwd() if cwd is None else cwd
-    if cwd is None:
-        return ''
-
-    # step out completely if git is not installed
-    try:
-        binary_location = subprocess.check_output(['which', 'git'],
-                                                  cwd=cwd,
-                                                  stderr=subprocess.PIPE,
-                                                  universal_newlines=True)
-        if not binary_location:
-            return branch
-    except subprocess.CalledProcessError:
-        return branch
-
     prompt_scripts = ['/usr/lib/git-core/git-sh-prompt',
                       '/usr/local/etc/bash_completion.d/git-prompt.sh']
 
@@ -74,8 +82,28 @@ def current_branch(cwd=None, pad=True):
     return branch or ''
 
 
+@ensure_git
+def git_dirty(cwd=None):
+    """Returns a boolean as to whether there are uncommitted files on the
+    current branch of a git repository (if there is one)"""
+    try:
+        cmd = ['git', 'status', '--porcelain']
+        s = subprocess.check_output(cmd,
+                                    stderr=subprocess.PIPE,
+                                    cwd=cwd,
+                                    universal_newlines=True)
+        return bool(s)
+    except subprocess.CalledProcessError:
+        return False
+
+
+def git_dirty_color():
+    return TERM_COLORS['BOLD_RED'] if git_dirty() else TERM_COLORS['BOLD_GREEN']
+
+
 DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
-                  '{cwd}{BOLD_RED}{curr_branch} {BOLD_BLUE}${NO_COLOR} ')
+                  '{cwd}{git_dirty_color}{curr_branch} '
+                  '{BOLD_BLUE}${NO_COLOR} ')
 DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
 
 
@@ -92,12 +120,13 @@ if ON_WINDOWS:
     USER = 'USERNAME'
 else:
     USER = 'USER'
-            
+
 
 FORMATTER_DICT = dict(user=os.environ.get(USER, '<user>'),
                       hostname=socket.gethostname().split('.', 1)[0],
                       cwd=lambda: _replace_home(builtins.__xonsh_env__['PWD']),
-                      curr_branch=lambda: current_branch(),
+                      curr_branch=git_current_branch,
+                      git_dirty_color=git_dirty_color,
                       **TERM_COLORS)
 
 _formatter = string.Formatter()
@@ -220,7 +249,7 @@ def default_env(env=None):
     if ON_WINDOWS:
         # Windows default prompt doesn't work.
         ctx['PROMPT'] = DEFAULT_PROMPT
-        
+
         # remove these bash variables which only cause problems.
         for ev in ['HOME', 'OLDPWD']:
             if ev in ctx:
@@ -236,7 +265,7 @@ def default_env(env=None):
                 del ctx[ev]
 
         ctx['PWD'] = _get_cwd()
-        
+
 
     if env is not None:
         ctx.update(env)


### PR DESCRIPTION
Maybe it's a little presumptuous for my first PR to the project to modify something as fundamental as the default prompt, but I find it incredibly informative to know from the prompt whether the current git repository is clean or dirty.

This PR sets changes the color of the `curr_branch` to be green if git is clean, or red if there are uncommitted files, and updates the documentation with the added `$FORMATTER_DICT` setting.

![git is clean](http://www.american-buddha.com/ghostbust.127d.gif)