### PR TITLE
Prompt toolkit as alternative shell

### DIFF
--- a/docs/api/base_shell.rst
+++ b/docs/api/base_shell.rst
@@ -1,9 +1,10 @@
-.. _xonsh_shell:
+.. _xonsh_base_shell:
 
 ******************************************************
-Main Shell Command Prompt (``xonsh.shell``)
+Base Shell Class (``xonsh.base_shell``)
 ******************************************************
 
-.. automodule:: xonsh.shell
+.. automodule:: xonsh.base_shell
     :members:
+    :undoc-members:
     :inherited-members:

--- a/docs/api/history.rst
+++ b/docs/api/history.rst
@@ -1,9 +1,10 @@
-.. _xonsh_shell:
+.. _xonsh_history:
 
 ******************************************************
-Main Shell Command Prompt (``xonsh.shell``)
+History Object (``xonsh.history``)
 ******************************************************
 
-.. automodule:: xonsh.shell
+.. automodule:: xonsh.history
     :members:
+    :undoc-members:
     :inherited-members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -31,6 +31,11 @@ For those of you who want the gritty details.
     inspectors
     completer
     shell
+    base_shell
+    readline_shell
+    prompt_toolkit_shell
+    prompt_toolkit_completer
+    history
 
 
 **Helpers:**

--- a/docs/api/prompt_toolkit_completer.rst
+++ b/docs/api/prompt_toolkit_completer.rst
@@ -1,0 +1,10 @@
+.. _xonsh_prompt_toolkit_completer:
+
+*************************************************************
+Prompt Toolkit Completer (``xonsh.prompt_toolkit_completer``)
+*************************************************************
+
+.. automodule:: xonsh.prompt_toolkit_completer
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/api/prompt_toolkit_shell.rst
+++ b/docs/api/prompt_toolkit_shell.rst
@@ -1,9 +1,10 @@
-.. _xonsh_shell:
+.. _xonsh_prompt_toolkit_shell:
 
 ******************************************************
-Main Shell Command Prompt (``xonsh.shell``)
+Prompt Toolkit Shell (``xonsh.prompt_toolkit_shell``)
 ******************************************************
 
-.. automodule:: xonsh.shell
+.. automodule:: xonsh.prompt_toolkit_shell
     :members:
+    :undoc-members:
     :inherited-members:

--- a/docs/api/readline_shell.rst
+++ b/docs/api/readline_shell.rst
@@ -1,9 +1,10 @@
-.. _xonsh_shell:
+.. _xonsh_readline_shell:
 
 ******************************************************
-Main Shell Command Prompt (``xonsh.shell``)
+Readline Shell (``xonsh.readline_shell``)
 ******************************************************
 
-.. automodule:: xonsh.shell
+.. automodule:: xonsh.readline_shell
     :members:
+    :undoc-members:
     :inherited-members:

--- a/tests/test_prompt_toolkit_tools.py
+++ b/tests/test_prompt_toolkit_tools.py
@@ -1,0 +1,43 @@
+"""Tests some tools function for prompt_toolkit integration."""
+from __future__ import unicode_literals, print_function
+
+import nose
+from nose.tools import assert_equal
+
+from xonsh.tools import FakeChar
+from xonsh.tools import format_prompt_for_prompt_toolkit
+
+
+def test_format_prompt_for_prompt_toolkit():
+    cases = [
+        ('root $ ', ['r', 'o', 'o', 't', ' ', '$', ' ']),
+        ('\001\033[0;31m\002>>',
+            [FakeChar('>', prefix='\001\033[0;31m\002'), '>']
+        ),
+        ('\001\033[0;31m\002>>\001\033[0m\002',
+            [FakeChar('>', prefix='\001\033[0;31m\002'),
+             FakeChar('>', suffix='\001\033[0m\002')]
+        ),
+        ('\001\033[0;31m\002>\001\033[0m\002',
+            [FakeChar('>',
+                      prefix='\001\033[0;31m\002',
+                      suffix='\001\033[0m\002')
+            ]
+        ),
+        ('\001\033[0;31m\002> $\001\033[0m\002',
+            [FakeChar('>', prefix='\001\033[0;31m\002'),
+             ' ',
+             FakeChar('$', suffix='\001\033[0m\002')]
+        ),
+        ('\001\033[0;31m\002\001\033[0;32m\002$> \001\033[0m\002',
+            [FakeChar('$', prefix='\001\033[0;31m\002\001\033[0;32m\002'),
+             '>',
+             FakeChar(' ', suffix='\001\033[0m\002')]
+        ),
+        ]
+    for test, ans in cases:
+        assert_equal(format_prompt_for_prompt_toolkit(test), ans)
+
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -1,0 +1,109 @@
+"""The base class for xonsh shell"""
+import sys
+import builtins
+import traceback
+
+from xonsh.execer import Execer
+from xonsh.tools import XonshError, escape_windows_title_string
+from xonsh.tools import ON_WINDOWS
+from xonsh.completer import Completer
+from xonsh.environ import multiline_prompt, format_prompt
+
+
+class BaseShell(object):
+    """The xonsh shell."""
+
+    def __init__(self, execer, ctx, **kwargs):
+        super().__init__(**kwargs)
+        self.execer = execer
+        self.ctx = ctx
+        self.completer = Completer()
+        self.buffer = []
+        self.need_more_lines = False
+        self.mlprompt = None
+
+    def emptyline(self):
+        """Called when an empty line has been entered."""
+        self.need_more_lines = False
+        self.default('')
+
+    def precmd(self, line):
+        """Called just before execution of line."""
+        return line if self.need_more_lines else line.lstrip()
+
+    def default(self, line):
+        """Implements code execution."""
+        line = line if line.endswith('\n') else line + '\n'
+        code = self.push(line)
+        if code is None:
+            return
+        try:
+            self.execer.exec(code, mode='single', glbs=self.ctx)  # no locals
+        except XonshError as e:
+            print(e.args[0], file=sys.stderr, end='')
+        except:
+            traceback.print_exc()
+        if builtins.__xonsh_exit__:
+            return True
+
+    def push(self, line):
+        """Pushes a line onto the buffer and compiles the code in a way that
+        enables multiline input.
+        """
+        code = None
+        self.buffer.append(line)
+        if self.need_more_lines:
+            return code
+        src = ''.join(self.buffer)
+        try:
+            code = self.execer.compile(src,
+                                       mode='single',
+                                       glbs=None,
+                                       locs=self.ctx)
+            self.reset_buffer()
+        except SyntaxError:
+            if line == '\n':
+                self.reset_buffer()
+                traceback.print_exc()
+                return None
+            self.need_more_lines = True
+        return code
+
+    def reset_buffer(self):
+        """Resets the line buffer."""
+        self.buffer.clear()
+        self.need_more_lines = False
+        self.mlprompt = None
+
+    def settitle(self):
+        """Sets terminal title."""
+        env = builtins.__xonsh_env__
+        term = env.get('TERM', None)
+        if term is None or term == 'linux':
+            return
+        if 'TITLE' in env:
+            t = env['TITLE']
+        else:
+            return
+        t = format_prompt(t)
+        if ON_WINDOWS and 'ANSICON' not in env:
+            t = escape_windows_title_string(t)
+            os.system('title {}'.format(t))
+        else:
+            sys.stdout.write("\x1b]2;{0}\x07".format(t))
+
+    @property
+    def prompt(self):
+        """Obtains the current prompt string."""
+        if self.need_more_lines:
+            if self.mlprompt is None:
+                self.mlprompt = multiline_prompt()
+            return self.mlprompt
+        env = builtins.__xonsh_env__
+        if 'PROMPT' in env:
+            p = env['PROMPT']
+            p = format_prompt(p)
+        else:
+            p = "set '$PROMPT = ...' $ "
+        self.settitle()
+        return p

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -186,6 +186,8 @@ BASE_ENV = {
     'LC_TIME': locale.setlocale(locale.LC_TIME),
     'LC_MONETARY': locale.setlocale(locale.LC_MONETARY),
     'LC_NUMERIC': locale.setlocale(locale.LC_NUMERIC),
+    'PROMPT_TOOLKIT_SHELL': False,
+    'HIGHLIGHTING_LEXER': None,
 }
 
 try:

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -1,0 +1,89 @@
+"""History object for use with prompt_toolkit."""
+import os
+
+from prompt_toolkit.history import History
+
+
+class LimitedFileHistory(History):
+    """History class that keeps entries in file with limit on number of those.
+
+    It handles only one-line entries.
+    """
+
+    def __init__(self):
+        """Initializes history object."""
+        super().__init__()
+        self.new_entries = []
+        self.old_history = []
+
+    def append(self, entry):
+        """Appends new entry to the history.
+
+        Entry sould be a one-liner.
+        """
+        super().append(entry)
+        self.new_entries.append(entry)
+
+    def read_history_file(self, filename):
+        """Reads history from given file into memory.
+
+        It first discards all history entries that were read by this function
+        before, and then tries to read entries from filename as history of
+        commands that happend before current session.
+        Entries that were appendend in current session are left unharmed.
+
+        Parameters
+        ----------
+        filename : str
+        Path to history file.
+        """
+        self.old_history = []
+        self._load(self.old_history, filename)
+        self.strings = self.old_history[:]
+        self.strings.extend(self.new_entries)
+
+
+    def save_history_to_file(self, filename, limit=-1):
+        """Saves history to file.
+
+        It first reads existing history file again, so nothing is overrided. If
+        combined number of entries from history file and current session
+        exceeds limit old entries are dropped.
+        Not thread safe.
+
+        Parameters
+        ----------
+        filename : str
+        Path to file to save history to.
+        limit : int
+        Limit on number of entries in history file. Negative values imply
+        unlimited history.
+        """
+        def write_list(lst, file):
+            text = ('\n'.join(lst)) + '\n'
+            file.write(text.encode('utf-8'))
+
+        if limit < 0:
+            with open(filename, 'ab') as hf:
+                write_list(new_entries, hf)
+            return
+
+        new_history = []
+        self._load(new_history, filename)
+
+        if len(new_history) + len(self.new_entries) <= limit:
+            with open(filename, 'ab') as hf:
+                write_list(self.new_entries, hf)
+        else:
+            new_history.extend(self.new_entries)
+            with open(filename, 'wb') as hf:
+                write_list(new_history[-limit:], hf)
+
+    def _load(self, store, filename):
+        """Loads content of file filename into list store."""
+        if os.path.exists(filename):
+            with open(filename, 'rb') as hf:
+                for line in hf:
+                    line = line.decode('utf-8')
+                    # Drop trailing newline
+                    store.append(line[:-1])

--- a/xonsh/prompt_toolkit_completer.py
+++ b/xonsh/prompt_toolkit_completer.py
@@ -1,0 +1,31 @@
+"""Completer implementation to use with prompt_toolkit."""
+from prompt_toolkit.completion import Completer, Completion
+
+class PromptToolkitCompleter(Completer):
+    """Simple prompt_toolkit Completer object.
+
+    It just redirects requests to normal Xonsh completer.
+    """
+
+    def __init__(self, completer, ctx):
+        """Takes instance of xonsh.completer.Completer and dict with context."""
+        self.completer = completer
+        self.ctx = ctx
+
+    def get_completions(self, document, complete_event):
+        """Returns a generator for list of completions."""
+        line = document.current_line
+        endidx = document.cursor_position_col
+        space_pos = document.find_backwards(' ')
+        if space_pos is None:
+            begidx = 0
+        else:
+            begidx = space_pos + endidx + 1
+        prefix = line[begidx:endidx + 1]
+        completions = self.completer.complete(prefix,
+                                              line,
+                                              begidx,
+                                              endidx,
+                                              self.ctx)
+        for comp in completions:
+            yield Completion(comp, -len(prefix))

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -1,0 +1,111 @@
+"""The prompt_toolkit based xonsh shell"""
+import os
+import builtins
+from warnings import warn
+
+from prompt_toolkit.shortcuts import create_cli, create_eventloop
+from pygments.token import Token
+
+from xonsh.base_shell import BaseShell
+from xonsh.history import LimitedFileHistory
+from xonsh.pyghooks import XonshLexer
+from xonsh.tools import format_prompt_for_prompt_toolkit
+from xonsh.prompt_toolkit_completer import PromptToolkitCompleter
+
+
+def setup_history():
+    """Creates history object."""
+    env = builtins.__xonsh_env__
+    hfile = env.get('XONSH_HISTORY_FILE',
+                    os.path.expanduser('~/.xonsh_history'))
+    history = LimitedFileHistory()
+    try:
+        history.read_history_file(hfile)
+    except PermissionError:
+        warn('do not have read permissions for ' + hfile, RuntimeWarning)
+    return history
+
+
+def teardown_history(history):
+    """Tears down the history object."""
+    env = builtins.__xonsh_env__
+    hsize = env.get('XONSH_HISTORY_SIZE', 8128)
+    hfile = env.get('XONSH_HISTORY_FILE',
+                    os.path.expanduser('~/.xonsh_history'))
+    try:
+        history.save_history_to_file(hfile, hsize)
+    except PermissionError:
+        warn('do not have write permissions for ' + hfile, RuntimeWarning)
+
+def get_user_input(get_prompt_tokens,
+                   history=None,
+                   lexer=None,
+                   completer=None):
+    """Customized function that mostly mimics promp_toolkit's get_input.
+
+    Main difference between this and prompt_toolkit's get_input() is that it
+    allows to pass get_tokens() function instead of text prompt.
+    """
+    eventloop = create_eventloop()
+
+    cli = create_cli(
+        eventloop,
+        lexer=lexer,
+        completer=completer,
+        history=history,
+        get_prompt_tokens=get_prompt_tokens)
+
+    try:
+        document = cli.read_input()
+
+        if document:
+            return document.text
+    finally:
+        eventloop.close()
+
+
+class PromptToolkitShell(BaseShell):
+    """The xonsh shell."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.history = setup_history()
+        self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
+
+    def __del__(self):
+        if self.history is not None:
+            teardown_history(self.history)
+
+    def cmdloop(self, intro=None):
+        """Enters a loop that reads and execute input from user."""
+        if intro:
+            print(intro)
+        while not builtins.__xonsh_exit__:
+            try:
+                line = get_user_input(
+                    get_prompt_tokens=self._get_prompt_tokens(),
+                    completer=self.pt_completer,
+                    history=self.history,
+                    lexer=self.lexer)
+                if not line:
+                    self.emptyline()
+                else:
+                    line = self.precmd(line)
+                    self.default(line)
+            except KeyboardInterrupt:
+                self.reset_buffer()
+            except EOFError:
+                break
+
+    def _get_prompt_tokens(self):
+        """Returns function to pass as prompt to prompt_toolkit."""
+        def get_tokens(cli):
+            return [(Token.Prompt,
+                     format_prompt_for_prompt_toolkit(self.prompt))]
+        return get_tokens
+
+    @property
+    def lexer(self):
+        """Obtains the current lexer."""
+        env = builtins.__xonsh_env__
+        return env['HIGHLIGHTING_LEXER']

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -1,0 +1,127 @@
+"""The readline based xonsh shell"""
+import os
+import builtins
+from cmd import Cmd
+from warnings import warn
+
+from xonsh.base_shell import BaseShell
+
+RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
+RL_CAN_RESIZE = False
+
+
+def setup_readline():
+    """Sets up the readline module and completion supression, if available."""
+    global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE
+    if RL_COMPLETION_SUPPRESS_APPEND is not None:
+        return
+    try:
+        import readline
+    except ImportError:
+        return
+    import ctypes
+    import ctypes.util
+    readline.set_completer_delims(' \t\n')
+    if not readline.__file__.endswith('.py'):
+        RL_LIB = lib = ctypes.cdll.LoadLibrary(readline.__file__)
+        try:
+            RL_COMPLETION_SUPPRESS_APPEND = ctypes.c_int.in_dll(
+                lib, 'rl_completion_suppress_append')
+        except ValueError:
+            # not all versions of readline have this symbol, ie Macs sometimes
+            RL_COMPLETION_SUPPRESS_APPEND = None
+        RL_CAN_RESIZE = hasattr(lib, 'rl_reset_screen_size')
+    # reads in history
+    env = builtins.__xonsh_env__
+    hf = env.get('XONSH_HISTORY_FILE', os.path.expanduser('~/.xonsh_history'))
+    if os.path.isfile(hf):
+        try:
+            readline.read_history_file(hf)
+        except PermissionError:
+            warn('do not have read permissions for ' + hf, RuntimeWarning)
+    hs = env.get('XONSH_HISTORY_SIZE', 8128)
+    readline.set_history_length(hs)
+    # sets up IPython-like history matching with up and down
+    readline.parse_and_bind('"\e[B": history-search-forward')
+    readline.parse_and_bind('"\e[A": history-search-backward')
+    # Setup Shift-Tab to indent
+    readline.parse_and_bind('"\e[Z": "{0}"'.format(env.get('INDENT', '')))
+
+    # handle tab completion differences found in libedit readline compatibility
+    # as discussed at http://stackoverflow.com/a/7116997
+    if readline.__doc__ and 'libedit' in readline.__doc__:
+        readline.parse_and_bind("bind ^I rl_complete")
+    else:
+        readline.parse_and_bind("tab: complete")
+
+
+def teardown_readline():
+    """Tears down up the readline module, if available."""
+    try:
+        import readline
+    except ImportError:
+        return
+    env = builtins.__xonsh_env__
+    hs = env.get('XONSH_HISTORY_SIZE', 8128)
+    readline.set_history_length(hs)
+    hf = env.get('XONSH_HISTORY_FILE', os.path.expanduser('~/.xonsh_history'))
+    try:
+        readline.write_history_file(hf)
+    except PermissionError:
+        warn('do not have write permissions for ' + hf, RuntimeWarning)
+
+
+def rl_completion_suppress_append(val=1):
+    """Sets the rl_completion_suppress_append varaiable, if possible.
+    A value of 1 (default) means to suppress, a value of 0 means to enable.
+    """
+    if RL_COMPLETION_SUPPRESS_APPEND is None:
+        return
+    RL_COMPLETION_SUPPRESS_APPEND.value = val
+
+
+
+class ReadlineShell(BaseShell, Cmd):
+    """The readline based xonsh shell."""
+
+    def __init__(self, completekey='tab', stdin=None, stdout=None, **kwargs):
+        super().__init__(completekey=completekey,
+                         stdin=stdin,
+                         stdout=stdout,
+                         **kwargs)
+        setup_readline()
+
+    def __del__(self):
+        teardown_readline()
+
+    def parseline(self, line):
+        """Overridden to no-op."""
+        return '', line, line
+
+    def completedefault(self, text, line, begidx, endidx):
+        """Implements tab-completion for text."""
+        rl_completion_suppress_append()  # this needs to be called each time
+        return self.completer.complete(text, line,
+                                       begidx, endidx,
+                                       ctx=self.ctx)
+
+    # tab complete on first index too
+    completenames = completedefault
+
+    def cmdloop(self, intro=None):
+        while not builtins.__xonsh_exit__:
+            try:
+                super().cmdloop(intro=intro)
+            except KeyboardInterrupt:
+                print()  # Gives a newline
+                self.reset_buffer()
+                intro = None
+    @property
+    def prompt(self):
+        """Obtains the current prompt string."""
+        global RL_LIB, RL_CAN_RESIZE
+        if RL_CAN_RESIZE:
+            # This is needed to support some system where line-wrapping doesn't
+            # work. This is a bug in upstream Python, or possibly readline.
+            RL_LIB.rl_reset_screen_size()
+        return super().prompt

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -1,99 +1,42 @@
 """The xonsh shell"""
-import os
-import sys
 import builtins
-import traceback
-from cmd import Cmd
-from warnings import warn
-from argparse import Namespace
 
 from xonsh.execer import Execer
-from xonsh.completer import Completer
-from xonsh.tools import XonshError, escape_windows_title_string
-from xonsh.tools import ON_WINDOWS
-from xonsh.environ import xonshrc_context, multiline_prompt, format_prompt
+from xonsh.environ import xonshrc_context
 
-RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
-RL_CAN_RESIZE = False
-
-
-def setup_readline():
-    """Sets up the readline module and completion supression, if available."""
-    global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE
-    if RL_COMPLETION_SUPPRESS_APPEND is not None:
-        return
+def is_prompt_toolkit_available():
+    """Checks if prompt_toolkit is available to import."""
     try:
-        import readline
+        import prompt_toolkit
+        return True
     except ImportError:
-        return
-    import ctypes
-    import ctypes.util
-    readline.set_completer_delims(' \t\n')
-    if not readline.__file__.endswith('.py'):
-        RL_LIB = lib = ctypes.cdll.LoadLibrary(readline.__file__)
-        try:
-            RL_COMPLETION_SUPPRESS_APPEND = ctypes.c_int.in_dll(
-                lib, 'rl_completion_suppress_append')
-        except ValueError:
-            # not all versions of readline have this symbol, ie Macs sometimes
-            RL_COMPLETION_SUPPRESS_APPEND = None
-        RL_CAN_RESIZE = hasattr(lib, 'rl_reset_screen_size')
-    # reads in history
-    env = builtins.__xonsh_env__
-    hf = env.get('XONSH_HISTORY_FILE', os.path.expanduser('~/.xonsh_history'))
-    if os.path.isfile(hf):
-        try:
-            readline.read_history_file(hf)
-        except PermissionError:
-            warn('do not have read permissions for ' + hf, RuntimeWarning)
-    hs = env.get('XONSH_HISTORY_SIZE', 8128)
-    readline.set_history_length(hs)
-    # sets up IPython-like history matching with up and down
-    readline.parse_and_bind('"\e[B": history-search-forward')
-    readline.parse_and_bind('"\e[A": history-search-backward')
-    # Setup Shift-Tab to indent
-    readline.parse_and_bind('"\e[Z": "{0}"'.format(env.get('INDENT', '')))
-
-    # handle tab completion differences found in libedit readline compatibility
-    # as discussed at http://stackoverflow.com/a/7116997
-    if readline.__doc__ and 'libedit' in readline.__doc__:
-        readline.parse_and_bind("bind ^I rl_complete")
-    else:
-        readline.parse_and_bind("tab: complete")
+        return False
 
 
-def teardown_readline():
-    """Tears down up the readline module, if available."""
-    try:
-        import readline
-    except ImportError:
-        return
-    env = builtins.__xonsh_env__
-    hs = env.get('XONSH_HISTORY_SIZE', 8128)
-    readline.set_history_length(hs)
-    hf = env.get('XONSH_HISTORY_FILE', os.path.expanduser('~/.xonsh_history'))
-    try:
-        readline.write_history_file(hf)
-    except PermissionError:
-        warn('do not have write permissions for ' + hf, RuntimeWarning)
+class Shell(object):
+    """Main xonsh shell.
 
-
-def rl_completion_suppress_append(val=1):
-    """Sets the rl_completion_suppress_append varaiable, if possible.
-    A value of 1 (default) means to suppress, a value of 0 means to enable.
+    Initializes execution environment and decides if prompt_toolkit or
+    readline version of shell should be used.
     """
-    if RL_COMPLETION_SUPPRESS_APPEND is None:
-        return
-    RL_COMPLETION_SUPPRESS_APPEND.value = val
 
+    def __init__(self, ctx=None, **kwargs):
+        self._init_environ(ctx)
+        env = builtins.__xonsh_env__
+        if is_prompt_toolkit_available() and env['PROMPT_TOOLKIT_SHELL']:
+            from xonsh.prompt_toolkit_shell import PromptToolkitShell
+            self.shell = PromptToolkitShell(execer=self.execer,
+                                            ctx=self.ctx, **kwargs)
+        else:
+            from xonsh.readline_shell import ReadlineShell
+            self.shell = ReadlineShell(execer=self.execer,
+                                       ctx=self.ctx, **kwargs)
 
-class Shell(Cmd):
-    """The xonsh shell."""
+    def __getattr__(self, attr):
+        """Delegates calls to appropriate shell instance."""
+        return getattr(self.shell, attr)
 
-    def __init__(self, completekey='tab', stdin=None, stdout=None, ctx=None):
-        super(Shell, self).__init__(completekey=completekey,
-                                    stdin=stdin,
-                                    stdout=stdout)
+    def _init_environ(self, ctx):
         self.execer = Execer()
         env = builtins.__xonsh_env__
         if ctx is not None:
@@ -103,123 +46,3 @@ class Shell(Cmd):
             self.ctx = xonshrc_context(rcfile=rc, execer=self.execer)
         builtins.__xonsh_ctx__ = self.ctx
         self.ctx['__name__'] = '__main__'
-        self.completer = Completer()
-        self.buffer = []
-        self.need_more_lines = False
-        self.mlprompt = None
-        setup_readline()
-
-    def __del__(self):
-        teardown_readline()
-
-    def emptyline(self):
-        """Called when an empty line has been entered."""
-        self.need_more_lines = False
-        self.default('')
-
-    def parseline(self, line):
-        """Overridden to no-op."""
-        return '', line, line
-
-    def precmd(self, line):
-        return line if self.need_more_lines else line.lstrip()
-
-    def default(self, line):
-        """Implements code execution."""
-        line = line if line.endswith('\n') else line + '\n'
-        code = self.push(line)
-        if code is None:
-            return
-        try:
-            self.execer.exec(code, mode='single', glbs=self.ctx)  # no locals
-        except XonshError as e:
-            print(e.args[0], file=sys.stderr, end='')
-        except:
-            traceback.print_exc()
-        if builtins.__xonsh_exit__:
-            return True
-
-    def push(self, line):
-        """Pushes a line onto the buffer and compiles the code in a way that
-        enables multiline input.
-        """
-        code = None
-        self.buffer.append(line)
-        if self.need_more_lines:
-            return code
-        src = ''.join(self.buffer)
-        try:
-            code = self.execer.compile(src,
-                                       mode='single',
-                                       glbs=None,
-                                       locs=self.ctx)
-            self.reset_buffer()
-        except SyntaxError:
-            if line == '\n':
-                self.reset_buffer()
-                traceback.print_exc()
-                return None
-            self.need_more_lines = True
-        return code
-
-    def reset_buffer(self):
-        """Resets the line buffer."""
-        self.buffer.clear()
-        self.need_more_lines = False
-        self.mlprompt = None
-
-    def completedefault(self, text, line, begidx, endidx):
-        """Implements tab-completion for text."""
-        rl_completion_suppress_append()  # this needs to be called each time
-        return self.completer.complete(text, line,
-                                       begidx, endidx,
-                                       ctx=self.ctx)
-
-    # tab complete on first index too
-    completenames = completedefault
-
-    def cmdloop(self, intro=None):
-        while not builtins.__xonsh_exit__:
-            try:
-                super(Shell, self).cmdloop(intro=intro)
-            except KeyboardInterrupt:
-                print()  # Gives a newline
-                self.reset_buffer()
-                intro = None
-
-    def settitle(self):
-        env = builtins.__xonsh_env__
-        term = env.get('TERM', None)
-        if term is None or term == 'linux':
-            return
-        if 'TITLE' in env:
-            t = env['TITLE']
-        else:
-            return
-        t = format_prompt(t)
-        if ON_WINDOWS and 'ANSICON' not in env:
-            t = escape_windows_title_string(t)
-            os.system('title {}'.format(t))
-        else:
-            sys.stdout.write("\x1b]2;{0}\x07".format(t))
-
-    @property
-    def prompt(self):
-        """Obtains the current prompt string."""
-        global RL_LIB, RL_CAN_RESIZE
-        if RL_CAN_RESIZE:
-            # This is needed to support some system where line-wrapping doesn't
-            # work. This is a bug in upstream Python, or possibly readline.
-            RL_LIB.rl_reset_screen_size()
-        if self.need_more_lines:
-            if self.mlprompt is None:
-                self.mlprompt = multiline_prompt()
-            return self.mlprompt
-        env = builtins.__xonsh_env__
-        if 'PROMPT' in env:
-            p = env['PROMPT']
-            p = format_prompt(p)
-        else:
-            p = "set '$PROMPT = ...' $ "
-        self.settitle()
-        return p

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -383,3 +383,72 @@ def escape_windows_title_string(s):
 
     s = s.replace('/?', '/.')
     return s
+
+
+class FakeChar(str):
+    """Class that holds a single char and escape sequences that surround it.
+
+    It is used as a workaround for the fact that prompt_toolkit doesn't display
+    colorful prompts correctly.
+    It behaves like normal string created with prefix + char + suffix, but has
+    two differences:
+
+    * len() always returns 2
+
+    * iterating over instance of this class is the same as iterating over
+      the single char - prefix and suffix are ommited.
+    """
+    def __new__(cls, char, prefix='', suffix=''):
+        return str.__new__(cls, prefix + char + suffix)
+
+    def __init__(self, char, prefix='', suffix=''):
+        self.char = char
+        self.prefix = prefix
+        self.suffix = suffix
+        self.length = 2
+        self.iterated = False
+
+    def __len__(self):
+        return self.length
+
+    def __iter__(self):
+        return iter(self.char)
+
+
+RE_HIDDEN_MAX = re.compile('(\001.*?\002)+')
+
+
+def format_prompt_for_prompt_toolkit(prompt):
+    """Uses workaround for passing a string with color sequences.
+
+    Returns list of characters of the prompt, where some characters can be not
+    normal characters but FakeChars - objects that consists of one printable
+    character and escape sequences surrounding it.
+    Returned list can be later passed as a prompt to prompt_toolkit.
+    If prompt contains no printable characters returns equivalent of empty
+    string.
+    """
+    def append_escape_seq(lst, suffix):
+        last = lst.pop()
+        if isinstance(last, FakeChar):
+            lst.append(FakeChar(last.char, prefix=last.prefix, suffix=suffix))
+        else:
+            lst.append(FakeChar(last, suffix=suffix))
+    pos = 0
+    match = RE_HIDDEN_MAX.search(prompt, pos)
+    if match and match.group(0) == prompt:
+        return ['']
+    formatted_prompt = []
+    while match:
+        formatted_prompt.extend(list(prompt[pos:match.start()]))
+        pos = match.end()
+        if not formatted_prompt:
+            formatted_prompt.append(FakeChar(prompt[pos],
+                                             prefix=match.group(0)))
+            pos += 1
+        else:
+            append_escape_seq(formatted_prompt, match.group(0))
+        match = RE_HIDDEN_MAX.search(prompt, pos)
+
+    formatted_prompt.extend(list(prompt[pos:]))
+    return formatted_prompt


### PR DESCRIPTION
Sorry that it took so long, but here is the first version of xonsh using prompt_toolkit.
First of all it introduces a new env variable: $PROMPT_TOOLKIT_SHELL and prompt_toolkit version of xonsh is launched only if this one is set to True and prompt_toolkit can be imported. Otherwise it runs readline version. This variable is by default set to False.
Prompt_toolkit shell also introduces another variable: $LEXER which specifies what lexer should be used to highlight syntax (None by default).
So, for example, following ~/.xonshrc will make xonsh use prompt_toolkit version of the shell with syntax highlighting:
```
$PROMPT_TOOLKIT_SHELL = True
from xonsh.pyghooks import XonshLexer
$LEXER = XonshLexer
```
Completion also works and generally it has most of the functionality of readline shell. 
Among things not yet done there is indentation: in readline shell <Shift-TAB> is used for it, but here this is already binded to iterating the list of possible completions in reversed order.
I can easily rebind it (for scrolling through a list of completions you can also use Ctrl-N and Ctrl-P like in vim for example) or I can use normal <TAB> for indentation - I would detect if situation indicates that indent is needed or rather autocompletion.
Another thing: I can probably change appearance of autocompletion options although I am not yet sure to what extend.
Also, is there a place where all environment variables are declared together with their default values? It seems a bit error prone if each time you want to get a variable you need to provide default by yourself.
Maybe it would be also good idea to change name $PROMPT_TOOLKIT_SHELL to something like $ADVANCED_SHELL or $ENHANCED_SHELL.
Now I am waiting for your opinions ;)