### PR TITLE
Env overhaul

### DIFF
--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1,4 +1,4 @@
-"""Tests the xonsh lexer."""
+"""Tests the xonsh builtins."""
 from __future__ import unicode_literals, print_function
 import os
 
@@ -6,36 +6,10 @@ import nose
 from nose.tools import assert_equal, assert_true, assert_not_in
 
 from xonsh import built_ins 
-from xonsh.built_ins import Env, reglob, regexpath, helper, superhelper, \
+from xonsh.built_ins import reglob, regexpath, helper, superhelper, \
     ensure_list_of_strs
+from xonsh.environ import Env
 
-def test_env_normal():
-    env = Env(VAR='wakka')
-    assert_equal('wakka', env['VAR'])
-
-def test_env_path_list():
-    env = Env(MYPATH=['wakka'])
-    assert_equal(['wakka'], env['MYPATH'])
-
-def test_env_path_str():
-    env = Env(MYPATH='wakka' + os.pathsep + 'jawaka')
-    assert_equal(['wakka', 'jawaka'], env['MYPATH'])
-
-def test_env_detype():
-    env = Env(MYPATH=['wakka', 'jawaka'])
-    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
-
-def test_env_detype_mutable_access_clear():
-    env = Env(MYPATH=['wakka', 'jawaka'])
-    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
-    env['MYPATH'][0] = 'woah'
-    assert_equal(None, env._detyped)
-    assert_equal({'MYPATH': 'woah' + os.pathsep + 'jawaka'}, env.detype())
-
-def test_env_detype_no_dict():
-    env = Env(YO={'hey': 42})
-    det = env.detype()
-    assert_not_in('YO', det)
 
 def test_reglob_tests():
     testfiles = reglob('test_.*')

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -1,0 +1,40 @@
+"""Tests the xonsh environment."""
+from __future__ import unicode_literals, print_function
+import os
+
+import nose
+from nose.tools import assert_equal, assert_true, assert_not_in
+
+from xonsh.environ import Env
+
+def test_env_normal():
+    env = Env(VAR='wakka')
+    assert_equal('wakka', env['VAR'])
+
+def test_env_path_list():
+    env = Env(MYPATH=['wakka'])
+    assert_equal(['wakka'], env['MYPATH'])
+
+def test_env_path_str():
+    env = Env(MYPATH='wakka' + os.pathsep + 'jawaka')
+    assert_equal(['wakka', 'jawaka'], env['MYPATH'])
+
+def test_env_detype():
+    env = Env(MYPATH=['wakka', 'jawaka'])
+    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
+
+def test_env_detype_mutable_access_clear():
+    env = Env(MYPATH=['wakka', 'jawaka'])
+    assert_equal({'MYPATH': 'wakka' + os.pathsep + 'jawaka'}, env.detype())
+    env['MYPATH'][0] = 'woah'
+    assert_equal(None, env._detyped)
+    assert_equal({'MYPATH': 'woah' + os.pathsep + 'jawaka'}, env.detype())
+
+def test_env_detype_no_dict():
+    env = Env(YO={'hey': 42})
+    det = env.detype()
+    assert_not_in('YO', det)
+
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,11 +1,15 @@
 """Tests the xonsh lexer."""
 from __future__ import unicode_literals, print_function
+import os
 
 import nose
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true, assert_false
 
 from xonsh.lexer import Lexer
-from xonsh.tools import subproc_toks, subexpr_from_unbalanced
+from xonsh.tools import subproc_toks, subexpr_from_unbalanced, is_int, \
+    always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
+    env_path_to_str
+    
 
 LEXER = Lexer()
 LEXER.build()
@@ -146,6 +150,55 @@ def test_subexpr_from_unbalanced_parens():
         obs = subexpr_from_unbalanced(expr, '(', ')')
         yield assert_equal, exp, obs
 
+def test_is_int():
+    yield assert_true, is_int(42)
+    yield assert_false, is_int('42')
+
+def test_always_true():
+    yield assert_true, always_true(42)
+    yield assert_true, always_true('42')
+
+def test_always_false():
+    yield assert_false, always_false(42)
+    yield assert_false, always_false('42')
+
+def test_ensure_string():
+    cases = [
+        (42, '42'),
+        ('42', '42'),
+        ]
+    for inp, exp in cases:
+        obs = ensure_string(inp)
+        yield assert_equal, exp, obs
+
+def test_is_env_path():
+    cases = [
+        ('/home/wakka', False),
+        (['/home/jawaka'], True),
+        ]
+    for inp, exp in cases:
+        obs = is_env_path(inp)
+        yield assert_equal, exp, obs
+
+def test_str_to_env_path():
+    cases = [
+        ('/home/wakka', ['/home/wakka']),
+        ('/home/wakka' + os.pathsep + '/home/jawaka', 
+         ['/home/wakka', '/home/jawaka']),
+        ]
+    for inp, exp in cases:
+        obs = str_to_env_path(inp)
+        yield assert_equal, exp, obs
+
+def test_env_path_to_str():
+    cases = [
+        (['/home/wakka'], '/home/wakka'),
+        (['/home/wakka', '/home/jawaka'], 
+         '/home/wakka' + os.pathsep + '/home/jawaka'),
+        ]
+    for inp, exp in cases:
+        obs = env_path_to_str(inp)
+        yield assert_equal, exp, obs
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -6,7 +6,6 @@ import re
 import sys
 import shlex
 import signal
-import locale
 import inspect
 import builtins
 import subprocess
@@ -20,7 +19,7 @@ from collections import Sequence, MutableMapping, Iterable, namedtuple, \
 from xonsh.tools import string_types
 from xonsh.tools import suggest_commands, XonshError
 from xonsh.inspectors import Inspector
-from xonsh.environ import default_env
+from xonsh.environ import Env, default_env
 from xonsh.aliases import DEFAULT_ALIASES, bash_aliases
 from xonsh.jobs import add_job, wait_for_active_job
 from xonsh.proc import ProcProxy, SimpleProcProxy
@@ -28,123 +27,6 @@ from xonsh.proc import ProcProxy, SimpleProcProxy
 ENV = None
 BUILTINS_LOADED = False
 INSPECTOR = Inspector()
-LOCALE_CATS = {
-    'LC_CTYPE': locale.LC_CTYPE,
-    'LC_MESSAGES': locale.LC_MESSAGES,
-    'LC_COLLATE': locale.LC_COLLATE,
-    'LC_NUMERIC': locale.LC_NUMERIC,
-    'LC_MONETARY': locale.LC_MONETARY,
-    'LC_TIME': locale.LC_TIME
-}
-
-
-class Env(MutableMapping):
-    """A xonsh environment, whose variables have limited typing
-    (unlike BASH). Most variables are, by default, strings (like BASH).
-    However, the following rules also apply based on variable-name:
-
-    * PATH: any variable whose name ends in PATH is a list of strings.
-    * XONSH_HISTORY_SIZE: this variable is an int.
-    * LC_* (locale categories): locale catergory names get/set the Python
-      locale via locale.getlocale() and locale.setlocale() functions.
-
-    An Env instance may be converted to an untyped version suitable for
-    use in a subprocess.
-    """
-
-    _arg_regex = re.compile(r'ARG(\d+)')
-
-    def __init__(self, *args, **kwargs):
-        """If no initial environment is given, os.environ is used."""
-        self._d = {}
-        if len(args) == 0 and len(kwargs) == 0:
-            args = (os.environ, )
-        for key, val in dict(*args, **kwargs).items():
-            self[key] = val
-        self._detyped = None
-        self._orig_env = None
-
-    def detype(self):
-        if self._detyped is not None:
-            return self._detyped
-        ctx = {}
-        for key, val in self._d.items():
-            if callable(val) or isinstance(val, MutableMapping):
-                continue
-            if not isinstance(key, string_types):
-                key = str(key)
-            if 'PATH' in key:
-                val = os.pathsep.join(val)
-            elif not isinstance(val, string_types):
-                val = str(val)
-            ctx[key] = val
-        self._detyped = ctx
-        return ctx
-
-    def replace_env(self):
-        """Replaces the contents of os.environ with a detyped version
-        of the xonsh environement.
-        """
-        if self._orig_env is None:
-            self._orig_env = dict(os.environ)
-        os.environ.clear()
-        os.environ.update(self.detype())
-
-    def undo_replace_env(self):
-        """Replaces the contents of os.environ with a detyped version
-        of the xonsh environement.
-        """
-        if self._orig_env is not None:
-            os.environ.clear()
-            os.environ.update(self._orig_env)
-            self._orig_env = None
-
-    #
-    # Mutable mapping interface
-    #
-
-    def __getitem__(self, key):
-        m = self._arg_regex.match(key)
-        if (m is not None) and (key not in self._d) and ('ARGS' in self._d):
-            args = self._d['ARGS']
-            ix = int(m.group(1))
-            if ix >= len(args):
-                e = "Not enough arguments given to access ARG{0}."
-                raise IndexError(e.format(ix))
-            return self._d['ARGS'][ix]
-        val = self._d[key]
-        if isinstance(val, (MutableSet, MutableSequence, MutableMapping)):
-            self._detyped = None
-        return self._d[key]
-
-    def __setitem__(self, key, val):
-        if isinstance(key, string_types) and 'PATH' in key:
-            val = val.split(os.pathsep) if isinstance(val, string_types) \
-                  else val
-        elif key == 'XONSH_HISTORY_SIZE' and not isinstance(val, int):
-            val = int(val)
-        elif key in LOCALE_CATS:
-            locale.setlocale(LOCALE_CATS[key], val)
-            val = locale.setlocale(LOCALE_CATS[key])
-        self._d[key] = val
-        self._detyped = None
-
-    def __delitem__(self, key):
-        del self._d[key]
-        self._detyped = None
-
-    def __iter__(self):
-        yield from self._d
-
-    def __len__(self):
-        return len(self._d)
-
-    def __str__(self):
-        return str(self._d)
-
-    def __repr__(self):
-        return '{0}.{1}({2})'.format(self.__class__.__module__,
-                                     self.__class__.__name__, self._d)
 
 
 class Aliases(MutableMapping):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -40,6 +40,9 @@ def locale_convert(key):
     return lc_converter
 
 Ensurer = namedtuple('Ensurer', ['validate', 'convert', 'detype'])
+Ensurer.__doc__ = """Named tuples whose elements are functions that 
+represent environment variable validation, conversion, detyping.
+"""
 
 DEFAULT_ENSURERS = {
     re.compile('\w*PATH'): (is_env_path, str_to_env_path, env_path_to_str), 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -20,6 +20,13 @@ parser.add_argument('--no-rc',
                     dest='norc',
                     action='store_true',
                     default=False)
+parser.add_argument('-D',
+                    dest='defines',
+                    help='define an environment variable, in the form of '
+                         '-DNAME=VAL. May be used many times.',
+                    metavar='ITEM',
+                    nargs='*',
+                    default=None)
 parser.add_argument('file',
                     metavar='script-file',
                     help='If present, execute the script in script-file'
@@ -40,6 +47,8 @@ def main(argv=None):
     shell = Shell() if not args.norc else Shell(ctx={})
     from xonsh import imphooks
     env = builtins.__xonsh_env__
+    if args.defines is not None:
+        env.update([x.split('=', 1) for x in args.defines])
     env['XONSH_INTERACTIVE'] = False
     if args.command is not None:
         # run a single command and exit

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -21,7 +21,7 @@ import re
 import sys
 import builtins
 import platform
-from collections import OrderedDict
+from collections import OrderedDict, Sequence
 
 if sys.version_info[0] >= 3:
     string_types = (str, bytes)
@@ -371,3 +371,48 @@ def suggestion_sort_helper(x, y):
     inx = len([i for i in x if i not in y])
     iny = len([i for i in y if i not in x])
     return lendiff + inx + iny
+
+#
+# Validators and contervers
+#
+
+def is_int(x):
+    """Tests if something is an integer"""
+    return isinstance(x, int)
+
+def always_true(x):
+    """Returns True"""
+    return True
+
+def always_false(x):
+    """Returns False"""
+    return False
+
+def ensure_string(x):
+    """Returns a string if x is not a string, and x if it alread is."""
+    if isinstance(x, string_types):
+        return x
+    else:
+        return str(x)
+
+def is_env_path(x):
+    """This tests if something is an environment path, ie a list of strings."""
+    if isinstance(x, string_types):
+        return False
+    else:
+        return isinstance(x, Sequence) and \
+               all([isinstance(a, string_types) for a in x])
+
+def str_to_env_path(x):
+    """Converts a string to an environment path, ie a list of strings, 
+    splitting on the OS separator.
+    """
+    try:
+        return x.split(os.pathsep)
+    except:
+        import pdb; pdb.set_trace()
+
+def env_path_to_str(x):
+    """Converts an environment path to a string by joining on the OS separator.
+    """
+    return os.pathsep.join(x)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -407,10 +407,7 @@ def str_to_env_path(x):
     """Converts a string to an environment path, ie a list of strings, 
     splitting on the OS separator.
     """
-    try:
-        return x.split(os.pathsep)
-    except:
-        import pdb; pdb.set_trace()
+    return x.split(os.pathsep)
 
 def env_path_to_str(x):
     """Converts an environment path to a string by joining on the OS separator.


### PR DESCRIPTION
This PR does a few important things all related to the Env class:

1. It moves it to the environ module
2. It abstracts the notion of validating that an environment variable is well formed, converting a non-well-formed value, and detyping based on the name/key of the variable.
3. It adds the capability to set env vars from the command line with the `-D` flag.

Adding new keys and patterns to the validation should be easy.