### PR TITLE
Add prompt output for mercurial repository branches and bookmarks

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -228,6 +228,8 @@ def ensure_hg(func):
         if path == []:
             return
 
+        kwargs['root'] = os.path.sep.join(path)
+
         # step out completely if hg is not installed
         if locate_binary('hg', kwargs['cwd']) is None:
             return
@@ -290,11 +292,9 @@ def call_hg_command(command, cwd):
 
 
 @ensure_hg
-def get_hg_branch(cwd=None):
+def get_hg_branch(cwd=None, root=None):
     branch = None
     active_bookmark = None
-
-    root = call_hg_command(['root'], cwd)
 
     if root is not None:
         root = root.strip(os.linesep)
@@ -340,7 +340,7 @@ def git_dirty_working_directory(cwd):
 
 
 @ensure_hg
-def hg_dirty_working_directory(cwd=None):
+def hg_dirty_working_directory(cwd=None, root=None):
     id = call_hg_command(['identify', '--id'], cwd)
     if id is None:
         return False

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -297,20 +297,24 @@ def get_hg_branch(cwd=None, root=None):
     active_bookmark = None
 
     if root is not None:
-        root = root.strip(os.linesep)
         branch_path = os.path.sep.join([root, '.hg', 'branch'])
         bookmark_path = os.path.sep.join([root, '.hg', 'bookmarks.current'])
+
         if os.path.exists(branch_path):
             with open(branch_path, 'r') as branch_file:
-                branch = branch_file.read().strip(os.linesep)
+                branch = branch_file.read()
+        else:
+            branch = call_hg_command(['branch'], cwd)
+
         if os.path.exists(bookmark_path):
             with open(bookmark_path, 'r') as bookmark_file:
-                active_bookmark = bookmark_file.read().strip(os.linesep)
+                active_bookmark = bookmark_file.read()
 
     if active_bookmark is not None:
-        return "{0}, {1}".format(branch, active_bookmark)
+        return "{0}, {1}".format(
+            *(b.strip(os.linesep) for b in (branch, active_bookmark)))
 
-    return branch
+    return branch.strip(os.linesep)
 
 
 def current_branch(pad=True):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -341,7 +341,7 @@ def git_dirty_working_directory(cwd):
 
 @ensure_hg
 def hg_dirty_working_directory(cwd=None, root=None):
-    id = call_hg_command(['identify', '--id'], cwd)
+    id = call_hg_command(['identify', '--id'], cwd).strip(os.linesep)
     if id is None:
         return False
     return id.endswith('+')


### PR DESCRIPTION
This expands the existing default prompt to output hg branch and bookmark information.  I've also taken the opportunity to generalize the existing prompt logic that deal with VCS information so it should be easier to add support for e.g. SVN in the future if anyone wants or needs it.

~~I've implemented this using the python bindings to the mercurial command server (python-hglib on pypi):~~

~~http://mercurial.selenic.com/wiki/PythonHglib~~

~~This is an LGPL library so no worries about mercurial being GPL.~~

~~This functionality depends on installing an optional package from pypi. Arguably, it's one that hg users will likely have installed, but it does add a new soft dependency.  I don't know how sensitive xonsh is to adding dependencies from pypi.~~

I'm happy to bikeshed the inclusion of bookmark information or the way I'm displaying it.

By the way, xonsh is awesome! Now that yt works under python3 I can use yt inside of xonsh :+1: