### PR TITLE
Aliases as Environment Variable

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -167,6 +167,9 @@ They can be seen in the table below:
 ================== ============================= ================================
 variable           default                       description
 ================== ============================= ================================
+ALIASES            xonsh.aliases.DEFAULT_ALIASES A dictionary containing aliases.
+                                                 See `Aliases`_ below for more
+                                                 information.
 PROMPT             xonsh.environ.DEFAULT_PROMPT  The prompt text.  May contain
                                                  keyword arguments which are
                                                  auto-formatted (see `Customizing
@@ -708,14 +711,26 @@ xonsh code you want to use the ``compilex()``, ``evalx()``, and ``execx()``
 functions. If you don't know what these do, you probably don't need them.
 
 
+Up, Down, Tab
+==============
+The up and down keys search history matching from the start of the line,
+much like they do in the IPython shell.
+
+Tab completion is present as well. In Python-mode you are able to complete
+based on the variable names in the current builtins, globals, and locals,
+as well as xonsh languages keywords & operator, files & directories, and
+environment variable names. In subprocess-mode, you additionally complete
+on any file names on your ``$PATH``, alias keys, and full BASH completion
+for the commands themselves.
+
 Aliases
 ==============================
-Another important xonsh built-in is the ``aliases`` mapping.  This is
+An important environment variable is the ``$ALIASES`` mapping.  This is
 like a dictionary that effects how subprocess commands are run.  If you are
 familiar with the BASH ``alias`` built-in, this is similar.  Alias command
 matching only occurs for the first element of a subprocess command.
 
-The keys of ``aliases`` are strings that act as commands in subprocess-mode.
+The keys of ``$ALIASES`` are strings that act as commands in subprocess-mode.
 The values are lists of strings, where the first element is the command and
 the rest are the arguments. You can also set the value to a string, in which
 case it will be converted to a list automatically with ``shlex.split``.
@@ -732,7 +747,7 @@ For example, here are some of the default aliases:
         }
 
 If you were to run ``ls dir/`` with the aliases above in effect (by running
-``aliases.update(DEFAULT_ALIASES)``), it would reduce to
+``$ALIASES.update(DEFAULT_ALIASES)``), it would reduce to
 ``["ls", "--color=auto", "-v", "dir/"]`` before being executed.
 
 Lastly, if an alias value is a function (or other callable), then this
@@ -776,24 +791,12 @@ built-in mapping.  Here is an example using a function value:
 
 .. code-block:: xonshcon
 
-    >>> aliases['banana'] = lambda args, stdin=None: ('My spoon is tooo big!', None)
+    >>> $ALIASES['banana'] = lambda args, stdin=None: ('My spoon is tooo big!', None)
     >>> banana
     'My spoon is tooo big!'
 
 Aliasing is a powerful way that xonsh allows you to seamlessly interact to
 with Python and subprocess.
-
-Up, Down, Tab
-==============
-The up and down keys search history matching from the start of the line,
-much like they do in the IPython shell.
-
-Tab completion is present as well. In Python-mode you are able to complete
-based on the variable names in the current builtins, globals, and locals,
-as well as xonsh languages keywords & operator, files & directories, and
-environment variable names. In subprocess-mode, you additionally complete
-on any file names on your ``$PATH``, alias keys, and full BASH completion
-for the commands themselves.
 
 Customizing the Prompt
 ======================

--- a/tests/sample.xsh
+++ b/tests/sample.xsh
@@ -1,5 +1,5 @@
 # I am a test module.
-aliases['echo'] = lambda args, stdin=None: print(' '.join(args))
+$ALIASES['echo'] = lambda args, stdin=None: print(' '.join(args))
 
 $WAKKA = "jawaka"
 x = $(echo "hello mom" $WAKKA)

--- a/tests/xpack/sample.xsh
+++ b/tests/xpack/sample.xsh
@@ -1,5 +1,5 @@
 # I am a test module.
-aliases['echo'] = lambda args, stdin=None: print(' '.join(args))
+$ALIASES['echo'] = lambda args, stdin=None: print(' '.join(args))
 
 $WAKKA = "jawaka"
 x = $(echo "hello mom" $WAKKA)

--- a/tests/xpack/sub/sample.xsh
+++ b/tests/xpack/sub/sample.xsh
@@ -1,5 +1,5 @@
 # I am a test module.
-aliases['echo'] = lambda args, stdin=None: print(' '.join(args))
+$ALIASES['echo'] = lambda args, stdin=None: print(' '.join(args))
 
 $WAKKA = "jawaka"
 x = $(echo "hello mom" $WAKKA)

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -323,7 +323,7 @@ def run_subproc(cmds, captured=True):
             continue
         stdout = last_stdout if cmd is last_cmd else PIPE
         uninew = cmd is last_cmd
-        alias = builtins.aliases.get(cmd[0], None)
+        alias = ENV.get('ALIASES', {}).get(cmd[0], None)
         if callable(alias):
             aliased_cmd = alias
         else:
@@ -373,7 +373,7 @@ def run_subproc(cmds, captured=True):
             except FileNotFoundError:
                 cmd = aliased_cmd[0]
                 e = 'xonsh: subprocess mode: command not found: {0}'.format(cmd)
-                e += '\n' + suggest_commands(cmd, ENV, builtins.aliases)
+                e += '\n' + suggest_commands(cmd, ENV, ENV.get('ALIASES', {}))
                 raise XonshError(e)
         procs.append(proc)
         prev = None
@@ -460,8 +460,8 @@ def load_builtins(execer=None):
     builtins.evalx = None if execer is None else execer.eval
     builtins.execx = None if execer is None else execer.exec
     builtins.compilex = None if execer is None else execer.compile
-    builtins.default_aliases = builtins.aliases = Aliases(DEFAULT_ALIASES)
-    builtins.aliases.update(bash_aliases())
+    ENV['ALIASES'] = Aliases(DEFAULT_ALIASES)
+    ENV['ALIASES'].update(bash_aliases())
     BUILTINS_LOADED = True
 
 
@@ -494,7 +494,6 @@ def unload_builtins():
              'evalx',
              'execx',
              'compilex',
-             'default_aliases',
              '__xonsh_all_jobs__',
              '__xonsh_active_job__',
              '__xonsh_ensure_list_of_strs__', ]

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -73,6 +73,8 @@ class Completer(object):
         rtn : list of str
             Possible completions of prefix, sorted alphabetically.
         """
+        env = builtins.__xonsh_env__
+        aliases = env.get('ALIASES', {})
         space = ' '  # intern some strings for faster appending
         slash = '/'
         dot = '.'
@@ -114,7 +116,7 @@ class Completer(object):
             else:
                 rtn |= {s for s in ctx if s.startswith(prefix)}
         rtn |= {s for s in dir(builtins) if s.startswith(prefix)}
-        rtn |= {s + space for s in builtins.aliases if s.startswith(prefix)}
+        rtn |= {s + space for s in aliases if s.startswith(prefix)}
         rtn |= self.path_complete(prefix)
         return sorted(rtn)
 
@@ -273,13 +275,15 @@ class Completer(object):
         return attrs
 
     def _all_commands(self):
-        path = builtins.__xonsh_env__.get('PATH', [])
+        env = builtins.__xonsh_env__
+        aliases = env.get('ALIASES', {})
+        path = env.get('PATH', [])
         # did PATH change?
         path_hash = hash(tuple(path))
         cache_valid = path_hash == self._path_checksum
         self._path_checksum = path_hash
         # did aliases change?
-        al_hash = hash(tuple(sorted(builtins.aliases.keys())))
+        al_hash = hash(tuple(sorted(aliases.keys())))
         self._alias_checksum = al_hash
         cache_valid = cache_valid and al_hash == self._alias_checksum
         pm = self._path_mtime
@@ -295,6 +299,6 @@ class Completer(object):
         allcmds = set()
         for d in filter(os.path.isdir, path):
             allcmds |= set(os.listdir(d))
-        allcmds |= set(builtins.aliases.keys())
+        allcmds |= set(aliases.keys())
         self._cmds_cache = frozenset(allcmds)
         return self._cmds_cache

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -304,7 +304,7 @@ def suggest_commands(cmd, env, aliases):
 
         cmd = cmd.lower()
         suggested = {}
-        for a in builtins.aliases:
+        for a in aliases:
             if a not in suggested:
                 if levenshtein(a.lower(), cmd, thresh) < thresh:
                     suggested[a] = 'Alias'


### PR DESCRIPTION
This changeset is a reorganization of the code to store aliases in an environment variable (`$ALIASES`) instead of in the global namespace.  I think I caught all the places we would need to make this change.

I am not sure whether there was a reason to have the aliases live where they currently do, but it "feels right" to me to have them in the environment (away from the Python execution).  Non-trivial downside, of course, is that everyone has to rewrite their `.xonshrc`...

Happy to discuss more or to make changes as necessary.