### PR TITLE
windows: use PATHEXT to find runnable files and skip shebang parsing

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -208,8 +208,16 @@ def _get_runnable_name(fname):
     if os.path.isfile(fname) and fname != os.path.basename(fname):
         return fname
     for d in builtins.__xonsh_env__['PATH']:
-        if os.path.isdir(d) and fname in os.listdir(d):
-            return os.path.join(d, fname)
+        if os.path.isdir(d):
+            files = os.listdir(d)
+            if fname in files:
+                return os.path.join(d, fname)
+            if ON_WINDOWS:
+                PATHEXT = builtins.__xonsh_env__.get('PATHEXT', [])
+                for dirfile in files:
+                    froot, ext = os.path.splitext(dirfile)
+                    if fname == froot and ext.upper() in PATHEXT:
+                        return os.path.join(d, dirfile)
     return None
 
 
@@ -251,6 +259,13 @@ def get_script_subproc_command(fname, args):
     # if the file is a binary, we should call it directly
     if _is_binary(fname):
         return [fname] + args
+
+    if ON_WINDOWS:
+        # Windows can execute various filetypes directly
+        # as given in PATHEXT
+        _, ext = os.path.splitext(fname)
+        if ext.upper() in builtins.__xonsh_env__.get('PATHEXT', []):
+            return [fname] + args
 
     # find interpreter
     with open(fname, 'rb') as f:


### PR DESCRIPTION
On Windows, xonsh couldn't find some files to run, especially script files ending in .cmd.  In addition, the shebang parsing defaults to using xonsh as the interpreter if it is a text file with no '#!' in the first line.  This caused '.cmd' files to be run by xonsh instead of the Windows cmd.exe.

This patch enables xonsh to use the PATHEXT environment variable to determine which files Windows can run directly.  Also, when a file is in PATHEXT, it skips shebang parsing for that file since Windows will be able to run the file directly.

(The above issues were manifesting when attempting to run 'ack' as installed from chocolatey.org, which provides an 'ack.cmd' file to run it).