### PR TITLE
Add option to run xonsh in prompt_toolkit mode from command line.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -212,6 +212,19 @@ SUGGEST_MAX_NUM    ``5``                         xonsh will show at most this
                                                  an invalid command.  If
                                                  negative, there is no limit to
                                                  how many suggestions are shown.
+SHELL_TYPE         ``'readline'``                Which shell is used.
+                                                 Currently two shell types are
+                                                 supported: ``'readline'`` that
+                                                 is backed by python's readline
+                                                 module and ``'prompt_toolkit'``
+                                                 that uses external library of
+                                                 the same name. For using
+                                                 prompt_toolkit shell you need
+                                                 to have `prompt_toolkit
+                                                 <https://github.com/jonathanslenders/python-prompt-toolkit>`_
+                                                 library installed. To specify
+                                                 which shell should be used, do
+                                                 so in the run control file.
 ================== ============================= ================================
 
 Environment Lookup with ``${}``

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -446,7 +446,7 @@ BASE_ENV = {
     'LC_TIME': locale.setlocale(locale.LC_TIME),
     'LC_MONETARY': locale.setlocale(locale.LC_MONETARY),
     'LC_NUMERIC': locale.setlocale(locale.LC_NUMERIC),
-    'PROMPT_TOOLKIT_SHELL': False,
+    'SHELL_TYPE': 'readline',
     'HIGHLIGHTING_LEXER': None,
 }
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -40,12 +40,22 @@ parser.add_argument('args',
                          ' by script-file',
                     nargs='*',
                     default=[])
+parser.add_argument('--shell_type',
+                    help='What kind of shell should be used. '
+                         'Possible options: readline, prompt_toolkit. '
+                         'Warning! If set this overrides $SHELL_TYPE variable.',
+                    dest='shell_type',
+                    choices=['readline', 'prompt_toolkit'],
+                    default=None)
 
 
 def main(argv=None):
     """Main entry point for xonsh cli."""
     args = parser.parse_args()
-    shell = Shell() if not args.norc else Shell(ctx={})
+    shell_kwargs = {'shell_type': args.shell_type}
+    if args.norc:
+        shell_kwargs['ctx'] = {}
+    shell = Shell(**shell_kwargs)
     from xonsh import imphooks
     env = builtins.__xonsh_env__
     if args.defines is not None:


### PR DESCRIPTION
Simply adding possibility to run xonsh in "prompt toolkit mode" from command line, as @scopatz mentioned in #229 .
One can now simply run xonsh like that:
```
xonsh --prompt_toolkit_shell
```
to run it in prompt_toolkit mode.