### PR TITLE
fix issue where prompt_toolkit is always preferred

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,7 +8,7 @@ from nose.tools import assert_equal, assert_true, assert_false
 from xonsh.lexer import Lexer
 from xonsh.tools import subproc_toks, subexpr_from_unbalanced, is_int, \
     always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
-    env_path_to_str, escape_windows_title_string
+    env_path_to_str, escape_windows_title_string, convert_bool, is_bool
 
 LEXER = Lexer()
 LEXER.build()
@@ -151,7 +151,12 @@ def test_subexpr_from_unbalanced_parens():
 
 def test_is_int():
     yield assert_true, is_int(42)
+    yield assert_true, is_int(True)
     yield assert_false, is_int('42')
+
+def test_is_bool():
+    yield assert_true, is_int(True)
+    yield assert_false, is_int('True')
 
 def test_always_true():
     yield assert_true, always_true(42)
@@ -213,6 +218,11 @@ def test_escape_windows_title_string():
         obs = escape_windows_title_string(st)
         yield assert_equal, esc, obs
 
+
+def test_convert_bool():
+    cases = [(True, 'True'), (False, 'False'), (False, '1'), (False, 'cat'), (False, 'dog')]
+    for c,s in cases:
+        yield assert_equal, c, convert_bool(s)
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -155,8 +155,8 @@ def test_is_int():
     yield assert_false, is_int('42')
 
 def test_is_bool():
-    yield assert_true, is_int(True)
-    yield assert_false, is_int('True')
+    yield assert_true, is_bool(True)
+    yield assert_false, is_bool('True')
 
 def test_always_true():
     yield assert_true, always_true(42)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -15,7 +15,7 @@ from collections import MutableMapping, MutableSequence, MutableSet, \
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, string_types, is_int,\
     always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
-    env_path_to_str
+    env_path_to_str, is_bool, convert_bool
 from xonsh.dirstack import _get_cwd
 
 LOCALE_CATS = {
@@ -53,6 +53,7 @@ DEFAULT_ENSURERS = {
     'LC_MONETARY': (always_false, locale_convert('LC_MONETARY'), ensure_string),
     'LC_TIME': (always_false, locale_convert('LC_TIME'), ensure_string),
     'XONSH_HISTORY_SIZE': (is_int, int, str),
+    'PROMPT_TOOLKIT_SHELL': (is_bool, convert_bool, str),
     }
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -394,6 +394,16 @@ def is_int(x):
     return isinstance(x, int)
 
 
+def is_bool(x):
+    """Tests if something is a boolean"""
+    return isinstance(x, bool)
+
+
+def convert_bool(s):
+    """Converts a string of 'True' or 'False' into a boolean"""
+    return s == 'True'
+
+
 def always_true(x):
     """Returns True"""
     return True


### PR DESCRIPTION
This took me forever to track down.  `PROMPT_TOOLKIT_SHELL` is detyped as `"False"` (a string), whose boolean value is `True`.  So the shell was passing to the `if env['PROMPT_TOOLKIT_SHELL']` under certain conditions, even if `PROMPT_TOOLKIT_SHELL` was set to `False`.  This patch should fix, I believe.