### PR TITLE
Add possibility to insert indent in prompt_toolkit shell.

### DIFF
--- a/xonsh/prompt_toolkit_key_bindings.py
+++ b/xonsh/prompt_toolkit_key_bindings.py
@@ -1,0 +1,36 @@
+"""Key bindings for prompt_toolkit xonsh shell."""
+import builtins
+
+from prompt_toolkit.filters import Filter
+from prompt_toolkit.keys import Keys
+
+
+class TabShouldInsertIndentFilter(Filter):
+    """
+    Filter that is intended to check if <Tab> should insert indent instead of
+    starting autocompletion.
+    It basically just checks if there are only whitespaces before the cursor -
+    if so indent should be inserted, otherwise autocompletion.
+    """
+    def __call__(self, cli):
+        before_cursor = cli.current_buffer.document.current_line_before_cursor
+
+        return bool(not before_cursor or before_cursor.isspace())
+
+
+def load_xonsh_bindings(key_bindings_manager):
+    """
+    Load custom key bindings.
+    """
+    handle = key_bindings_manager.registry.add_binding
+    env = builtins.__xonsh_env__
+
+    @handle(Keys.Tab, filter=TabShouldInsertIndentFilter())
+    def _(event):
+        """
+        If there are only whitespaces before current cursor position insert
+        indent instead of autocompleting.
+        """
+        event.cli.current_buffer.insert_text(env['INDENT'])
+
+

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -4,6 +4,7 @@ import builtins
 from warnings import warn
 
 from prompt_toolkit.shortcuts import create_cli, create_eventloop
+from prompt_toolkit.key_binding.manager import KeyBindingManager
 from pygments.token import Token
 
 from xonsh.base_shell import BaseShell
@@ -11,6 +12,7 @@ from xonsh.pyghooks import XonshLexer
 from xonsh.tools import format_prompt_for_prompt_toolkit
 from xonsh.prompt_toolkit_completer import PromptToolkitCompleter
 from xonsh.prompt_toolkit_history import LimitedFileHistory
+from xonsh.prompt_toolkit_key_bindings import load_xonsh_bindings
 
 
 def setup_history():
@@ -40,6 +42,7 @@ def teardown_history(history):
 def get_user_input(get_prompt_tokens,
                    history=None,
                    lexer=None,
+                   key_bindings_registry=None,
                    completer=None):
     """Customized function that mostly mimics promp_toolkit's get_input.
 
@@ -53,7 +56,8 @@ def get_user_input(get_prompt_tokens,
         lexer=lexer,
         completer=completer,
         history=history,
-        get_prompt_tokens=get_prompt_tokens)
+        get_prompt_tokens=get_prompt_tokens,
+        key_bindings_registry=key_bindings_registry)
 
     try:
         document = cli.read_input()
@@ -71,6 +75,9 @@ class PromptToolkitShell(BaseShell):
         super().__init__(**kwargs)
         self.history = setup_history()
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
+        self.key_bindings_manager = KeyBindingManager()
+        load_xonsh_bindings(self.key_bindings_manager)
+
 
     def __del__(self):
         if self.history is not None:
@@ -86,6 +93,7 @@ class PromptToolkitShell(BaseShell):
                     get_prompt_tokens=self._get_prompt_tokens(),
                     completer=self.pt_completer,
                     history=self.history,
+                    key_bindings_registry=self.key_bindings_manager.registry,
                     lexer=self.lexer)
                 if not line:
                     self.emptyline()


### PR DESCRIPTION
I have been playing a bit with this, and decided that when you use this kind of autocompletion that prompt_toolkit provides (that is autocompletion in a box) it is highly unintuitive for Shift-Tab to insert sudden indentation instead of simply going back in autocompletions list. I guess it is common behavior that if some key iterates forward (Tab in this case) then Shift plus the key should iterate backward.
So I decided to make Tab the key for indentation (it is just more intuitive), and now it behaves like this:
 - if there are only whitespaces before cursor position Tab inserts indent
 - otherwise it starts autocompletion.

Surely I can map <Shift-TAB> to behave like this (that it inserts indent only if there are only whitespaces) if you think that would be better, or maybe just reproduce behavior from readline shell, overriding default Shift-TAB completely.
Let me know what works better for you!