### PR TITLE
Fix prompt_toolkit autocompletion bug

### DIFF
--- a/xonsh/prompt_toolkit_completer.py
+++ b/xonsh/prompt_toolkit_completer.py
@@ -21,7 +21,7 @@ class PromptToolkitCompleter(Completer):
             begidx = 0
         else:
             begidx = space_pos + endidx + 1
-        prefix = line[begidx:endidx + 1]
+        prefix = line[begidx:endidx]
         completions = self.completer.complete(prefix,
                                               line,
                                               begidx,


### PR DESCRIPTION
There was a small bug that caused autocompletion to work properly only when started at the end of a line. 
Here is appropriately small fix.