### PR TITLE
Subprocess mode: grouping, `and`, and `or` 

### DIFF
--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -24,8 +24,8 @@ def leftmostname(node):
     """Attempts to find the first name in the tree."""
     if isinstance(node, Name):
         rtn = node.id
-    elif isinstance(node, (BinOp, Compare)):
-        rtn = leftmostname(node.left)
+    elif isinstance(node, BoolOp):
+        rtn = leftmostname(node.values[0])
     elif isinstance(node, (Attribute, Subscript, Starred, Expr)):
         rtn = leftmostname(node.value)
     elif isinstance(node, Call):

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -142,7 +142,7 @@ class CtxAwareTransformer(NodeTransformer):
         inscope = self.is_in_scope(body)
         if not inscope:
             node.body = self.try_subproc_toks(body)
-            node.body[0] = self.visit(node.body[0])
+            node.body = self.visit(node.body)
         return node
 
     def visit_Expr(self, node):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -538,17 +538,24 @@ def run_subproc(cmds, captured=True):
 
 
 def subproc_captured(*cmds):
-    """Runs a subprocess, capturing the output. Returns the stdout
-    that was produced as a str.
+    """Runs a subprocess, capturing the output.  Returns the stdout that was
+    produced as a str.
     """
     return run_subproc(cmds, captured=True)
 
 
 def subproc_uncaptured(*cmds):
-    """Runs a subprocess, without capturing the output. Returns the stdout
-    that was produced as a str.
+    """Runs a subprocess, without capturing the output.  Returns ``True`` if
+    the process completed successfully, and ``False`` otherwise.
     """
     return run_subproc(cmds, captured=False)
+
+
+def subproc_noreturn(*cmds):
+    """Runs a subprocess, without capturing the output.  Always returns
+    ``None``.
+    """
+    run_subproc(cmds, captured=False)
 
 
 def ensure_list_of_strs(x):
@@ -583,6 +590,7 @@ def load_builtins(execer=None):
         del builtins.quit
     builtins.__xonsh_subproc_captured__ = subproc_captured
     builtins.__xonsh_subproc_uncaptured__ = subproc_uncaptured
+    builtins.__xonsh_subproc_noreturn__ = subproc_noreturn
     builtins.__xonsh_execer__ = execer
     builtins.__xonsh_all_jobs__ = {}
     builtins.__xonsh_active_job__ = None
@@ -621,6 +629,7 @@ def unload_builtins():
              '__xonsh_pyquit__',
              '__xonsh_subproc_captured__',
              '__xonsh_subproc_uncaptured__',
+             '__xonsh_subproc_noreturn__',
              '__xonsh_execer__',
              'evalx',
              'execx',

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -531,6 +531,10 @@ def run_subproc(cmds, captured=True):
             return output
     elif last_stdout not in (PIPE, None, sys.stdout):
         last_stdout.close()
+    out = prev_proc.returncode
+    if not isinstance(out, bool):
+        out = out == 0
+    return out
 
 
 def subproc_captured(*cmds):

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -124,7 +124,9 @@ class Execer(object):
                                 stacklevel=stacklevel)
         if code is None:
             return None  # handles comment only input
-        return exec(code, glbs, locs)
+        e = exec(code, glbs, locs)
+        self.ctxtransformer.forced_subproc = False
+        return e
 
     def _find_next_break(self, line, mincol):
         if mincol >= 1:
@@ -179,6 +181,7 @@ class Execer(object):
                     input = '\n'.join(lines)
                     continue
                 maxcol = self._find_next_break(line, last_error_col)
+                self.ctxtransformer.forced_subproc = True
                 sbpline = subproc_toks(line,
                                        returnline=True,
                                        maxcol=maxcol,

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -246,7 +246,7 @@ def handle_lparen(state, token, stream):
     """
     Function for handling ``(``
     """
-    state['pymode'].append((True, '(', ')', token.start))
+    state['pymode'].append((state['pymode'][-1][0], '(', ')', token.start))
     state['last'] = token
     yield _new_token('LPAREN', '(', token.start)
 
@@ -255,7 +255,7 @@ def handle_lbrace(state, token, stream):
     """
     Function for handling ``{``
     """
-    state['pymode'].append((True, '{', '}', token.start))
+    state['pymode'].append((state['pymode'][-1][0], '{', '}', token.start))
     state['last'] = token
     yield _new_token('LBRACE', '{', token.start)
 
@@ -264,7 +264,7 @@ def handle_lbracket(state, token, stream):
     """
     Function for handling ``[``
     """
-    state['pymode'].append((True, '[', ']', token.start))
+    state['pymode'].append((state['pymode'][-1][0], '[', ']', token.start))
     state['last'] = token
     yield _new_token('LBRACKET', '[', token.start)
 
@@ -282,40 +282,28 @@ def _end_delimiter(state, token):
         return 'Unmatched "{}" at line {}, column {}'.format(s, l, c)
 
 
-def handle_rparen(state, token, stream):
-    """
-    Function for handling ``)``
-    """
-    e = _end_delimiter(state, token)
-    if e is None:
-        state['last'] = token
-        yield _new_token('RPAREN', ')', token.start)
-    else:
-        yield _new_token('ERRORTOKEN', e, token.start)
+def _make_delimiter_handler(name, ender):
+    def handler(state, token, stream):
+        m = state['pymode'][-1][1]
+        e = _end_delimiter(state, token)
+        if e is None:
+            state['last'] = token
+            typ = name
+            if m.startswith('$'):
+                typ = "SUBPROC_END_{}".format(name)
+            yield _new_token(typ, ender, token.start)
+        else:
+            yield _new_token('ERRORTOKEN', e, token.start)
+    return handler
 
+handle_rparen = _make_delimiter_handler('RPAREN', ')')
+"""Function for handling ``)``"""
 
-def handle_rbrace(state, token, stream):
-    """
-    Function for handling ``}``
-    """
-    e = _end_delimiter(state, token)
-    if e is None:
-        state['last'] = token
-        yield _new_token('RBRACE', '}', token.start)
-    else:
-        yield _new_token('ERRORTOKEN', e, token.start)
+handle_rbrace = _make_delimiter_handler('RBRACE', '}')
+"""Function for handling ``}``"""
 
-
-def handle_rbracket(state, token, stream):
-    """
-    Function for handling ``]``
-    """
-    e = _end_delimiter(state, token)
-    if e is None:
-        state['last'] = token
-        yield _new_token('RBRACKET', ']', token.start)
-    else:
-        yield _new_token('ERRORTOKEN', e, token.start)
+handle_rbracket = _make_delimiter_handler('RBRACKET', ']')
+"""Function for handling ``]``"""
 
 
 def handle_error_space(state, token, stream):
@@ -508,6 +496,9 @@ class Lexer(object):
         'LPAREN', 'RPAREN',      # ( )
         'LBRACKET', 'RBRACKET',  # [ ]
         'LBRACE', 'RBRACE',      # { }
+        'SUBPROC_END_RPAREN',    # ) matched with $(
+        'SUBPROC_END_RBRACKET',  # ] matched with $[
+        'SUBPROC_END_RBRACE',    # } matched with ${
         'AT',                    # @
         'QUESTION',              # ?
         'DOUBLE_QUESTION',       # ??

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1636,7 +1636,7 @@ class Parser(object):
         if len(p) == 2:
             # plain-old atoms
             bt = '`'
-            if isinstance(p1, (ast.Num, ast.Str, ast.Bytes)):
+            if isinstance(p1, (ast.Num, ast.Str, ast.Bytes, ast.Call)):
                 pass
             elif p1 == 'True':
                 p1 = ast.NameConstant(value=True,
@@ -2119,9 +2119,12 @@ class Parser(object):
                             lineno=lineno,
                             col=col)
         elif p1 == '$[':
-            p0 = xonsh_call('__xonsh_subproc_uncaptured__', p2,
-                            lineno=lineno,
-                            col=col)
+            if isinstance(p2, ast.Call):
+                p0 = p2
+            else:
+                p0 = xonsh_call('__xonsh_subproc_uncaptured__', p2,
+                                lineno=lineno,
+                                col=col)
         else:
             assert False
         return p0
@@ -2195,7 +2198,9 @@ class Parser(object):
         col = self.col
         lenp = len(p)
         p1 = p[1]
-        if lenp == 2:
+        if isinstance(p1, str):
+            p0 = [ast.Str(s=p1, lineno=lineno, col_offset=col)]
+        elif lenp == 2:
             p0 = [self._subproc_cliargs(p1, lineno=lineno, col=col)]
         elif p[2] == '&':
             p0 = p1 + [ast.Str(s=p[2], lineno=lineno, col_offset=col)]
@@ -2227,6 +2232,7 @@ class Parser(object):
                         | REGEXPATH
                         | DOLLAR_NAME
                         | GT
+                        | SUBSHELL_COMMAND
                         | LT
                         | RSHIFT
                         | IOREDIRECT

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1628,9 +1628,9 @@ class Parser(object):
                 | FALSE
                 | REGEXPATH
                 | DOLLAR_NAME
-                | DOLLAR_LBRACE test RBRACE
-                | DOLLAR_LPAREN subproc RPAREN
-                | DOLLAR_LBRACKET subproc RBRACKET
+                | DOLLAR_LBRACE test SUBPROC_END_RBRACE
+                | DOLLAR_LPAREN subproc SUBPROC_END_RPAREN
+                | DOLLAR_LBRACKET subproc SUBPROC_END_RBRACKET
         """
         p1 = p[1]
         if len(p) == 2:
@@ -2231,9 +2231,9 @@ class Parser(object):
                         | RSHIFT
                         | IOREDIRECT
                         | AT_LPAREN test RPAREN
-                        | DOLLAR_LBRACE test RBRACE
-                        | DOLLAR_LPAREN subproc RPAREN
-                        | DOLLAR_LBRACKET subproc RBRACKET
+                        | DOLLAR_LBRACE test SUBPROC_END_RBRACE
+                        | DOLLAR_LPAREN subproc SUBPROC_END_RPAREN
+                        | DOLLAR_LBRACKET subproc SUBPROC_END_RBRACKET
         """
         lenp = len(p)
         p1 = p[1]


### PR DESCRIPTION
This changeset allows grouping of subprocess-mode commands with parentheses, `and`, and `or`.  For example: `mkdir test and ls test` and `(mkdir test) and (ls test)` should both work.  This also subsumes PRs #240 and #250 (which are ready for a look but haven't yet been accepted).

More complicated groupings also work:
`(mkdir test and ls test) or ls test`
`mkdir test and (ls test or ls test)`
and so does combining these things with pipes or IO redirects.

~~There is one remaining issue that I know of: this code modifies `subproc_uncaptured` to return `True` or `False`, depending on whether the subprocess call succeeded.  I would like for this value to print _only if_ the user explicitly typed the `$[` and `]` characters, but not to print if the user just typed the command that goes between them (i.e., if xonsh inserted those tokens itself).  @scopatz, do you know whether that is possible?  I have tried a few different things (without any luck), and I will keep hacking away when I have time.~~ I think I got it!

No docs ~~or tests~~ yet, and only a few tests, because I wanted to make sure that this is a direction we actually want to go.

Aside from those issues, I think things are working.  That said, I have only done a little bit of testing myself, but more eyes would be appreciated.