### PR TITLE
"source" alias

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -47,6 +47,12 @@ def source_bash(args, stdin=None):
     return
 
 
+def source_alias(args, stdin=None):
+    """Executes the contents of the provided files in the current context."""
+    for fname in args:
+        execx(open(fname).read(), 'exec', builtins.__xonsh_ctx__)
+
+
 def xexec(args, stdin=None):
     """
     Replaces current process with command specified and passes in the
@@ -99,6 +105,7 @@ DEFAULT_ALIASES = {
     'exit': exit,
     'quit': exit,
     'xexec': xexec,
+    'source': source_alias,
     'timeit': timeit_alias,
     'source-bash': source_bash,
     'scp-resume': ['rsync', '--partial', '-h', '--progress', '--rsh=ssh'],


### PR DESCRIPTION
Implementation of the `source` alias as discussed in #262.