### PR TITLE
windows: automated builds via appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,10 +1,9 @@
 version: 0.1.6.{build}
 os: Windows Server 2012 R2
 install:
-- C:\Python34\Scripts\pip install ply pyreadline nose
+- C:\Python34\Scripts\pip install ply pyreadline nose prompt_toolkit
 build_script:
 - C:\Python34\python setup.py install
 test_script:
-- cd tests
 - C:\Python34\Scripts\nosetests
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ xonsh
 .. image:: https://travis-ci.org/scopatz/xonsh.svg?branch=master
     :target: https://travis-ci.org/scopatz/xonsh
 
-.. image:: https://ci.appveyor.com/api/projects/status/9xooq2hmfcif8f6d/branch/master?svg=true
-    :target: https://ci.appveyor.com/project/rbrewer123/xonsh
+.. image:: https://ci.appveyor.com/api/projects/status/ufqtigii8ma3rctt/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/rbrewer123/xonsh-unq93
 
 .. image:: https://landscape.io/github/scopatz/xonsh/master/landscape.svg?style=flat
     :target: https://landscape.io/github/scopatz/xonsh/master

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ xonsh
 .. image:: https://travis-ci.org/scopatz/xonsh.svg?branch=master
     :target: https://travis-ci.org/scopatz/xonsh
 
+.. image:: https://ci.appveyor.com/api/projects/status/9xooq2hmfcif8f6d/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/rbrewer123/xonsh
+
 .. image:: https://landscape.io/github/scopatz/xonsh/master/landscape.svg?style=flat
     :target: https://landscape.io/github/scopatz/xonsh/master
     :alt: Code Health

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+version: 0.1.6.{build}
+os: Windows Server 2012 R2
+install:
+- C:\Python34\Scripts\pip install ply pyreadline nose
+build_script:
+- C:\Python34\python setup.py install
+test_script:
+- cd tests
+- C:\Python34\Scripts\nosetests
+


### PR DESCRIPTION
@scopatz mentioned Appveyor a few weeks back.  This changeset, when merged, should start reporting the xonsh build status on Windows via appveyor.com.  Currently it's using my appveyor account which was a snap to create by linking it to my github account.  @scopatz, if you'd like to run the main build status through your own Appveyor account that should be pretty easy.  After you create a xonsh project in appveyor, in the General tab you need to specify that it must use ``.appveyor.yml`` with the leading ``.``.  It's also handy to tell it to "skip branches without 'appveyor.yml'".  Then you'd need to update the xonsh ``README.rst`` to fetch the status from your account.