### PR TITLE
aliases: fixed bash aliases with single quotes

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -82,8 +82,15 @@ def bash_aliases():
     aliases = {}
     for key, value in items:
         try:
-            key = key[6:]
-            value = value.strip('\'')
+            key = key[6:]  # lstrip 'alias '
+
+            # undo bash's weird quoting of single quotes (sh_single_quote)
+            value = value.replace('\'\\\'\'', '\'')
+
+            # strip one single quote at the start and end of value
+            if value[0] == '\'' and value[-1] == '\'':
+                value = value[1:-1]
+
             value = shlex.split(value)
         except ValueError as exc:
             warn('could not parse Bash alias "{0}": {1!r}'.format(key, exc),


### PR DESCRIPTION
The old code for parsing bash alias values did not work for aliases that contain single quotes.

For example,

the following lines in `.bashrc`

    alias foo="ls '-l'"
    alias bar="ls '-l' -a"

lead to the following output of `bash alias -p`

    alias foo='ls '\''-l'\'''
    alias bar='ls '\''-l'\'' -a'

Note that all single quotes are weirdly escaped. The behavior is not documented, and thinking about why those escapes happen like this makes my head hurt, but the [source](http://git.savannah.gnu.org/cgit/bash.git/tree/lib/sh/shquote.c#n88) proves that this is the only replacement that happens.

Anyways, because of this, xonsh's current code passes invalid input to `shlex.split`:

    aliases.py:90: RuntimeWarning: could not parse Bash alias "foo": ValueError('No escaped character',)
    aliases.py:90: RuntimeWarning: could not parse Bash alias "bar": ValueError('No closing quotation',)

Also, `value.strip('\'')` can remove multiple instances of `'`, leading to invalid input to `shlex.split`.