### PR TITLE
Favor runnable extensions on Windows

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -207,14 +207,17 @@ def _get_runnable_name(fname):
     for d in builtins.__xonsh_env__['PATH']:
         if os.path.isdir(d):
             files = os.listdir(d)
-            if fname in files:
-                return os.path.join(d, fname)
+
             if ON_WINDOWS:
                 PATHEXT = builtins.__xonsh_env__.get('PATHEXT', [])
                 for dirfile in files:
                     froot, ext = os.path.splitext(dirfile)
                     if fname == froot and ext.upper() in PATHEXT:
                         return os.path.join(d, dirfile)
+
+            if fname in files:
+                return os.path.join(d, fname)
+
     return None
 
 


### PR DESCRIPTION
`xonsh` favors extensionless files with shebangs on Windows which
is causing certain issues when some packages come with both Linux
and Windows runnables where the Linux version is extensionless.

This patch favors files ending with any extension listed in
`PATHEXT` over extensionless files on Windows.

Fixes the issue mentioned in here:
https://groups.google.com/d/msg/xonsh/nYraaPmewP0/as6d5TrrBU8J