### PR TITLE
Update to conda recipe 

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,1 @@
+python setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
 build:
   script: python setup.py install
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  entry_points:
+    - xonsh = xonsh.main:main
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: xonsh
-  version: "0.1.6"
+  version: {{ environ['GIT_DESCRIBE_TAG'] }}
 
 source:
-  fn: xonsh.tar.gz
-  url: https://github.com/scopatz/xonsh/archive/master.tar.gz
+  git_url: ../
 
 build:
   script: python setup.py install
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 requirements:
   build:


### PR DESCRIPTION
Update the conda recipe to build directly from the git repository, and use the tags in git to create the right version number. Also added some fixes to make build work on windows. 