### PR TITLE
Catch cases where the commands launched by subprocess are not found. 

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -76,7 +76,7 @@ def bash_aliases():
                                     input='alias',
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True)
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         s = ''
     items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
     aliases = {}

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -51,7 +51,7 @@ class Completer(object):
             # or we could make this lazy
             self._load_bash_complete_files()
             self.have_bash = True
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             self.have_bash = False
 
     def complete(self, prefix, line, begidx, endidx, ctx=None):

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -270,8 +270,6 @@ def get_git_branch(cwd=None):
                 branch = s
         except (subprocess.CalledProcessError, FileNotFoundError):
             pass
-        except OSError:
-            pass
 
     return branch
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -184,7 +184,7 @@ def locate_binary(name, cwd):
                                                   universal_newlines=True)
         if not binary_location:
             return
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return
 
     return binary_location
@@ -254,7 +254,7 @@ def get_git_branch(cwd=None):
                                                  input=_input,
                                                  stderr=subprocess.PIPE,
                                                  universal_newlines=True) or None
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, FileNotFoundError):
                 continue
 
     # fall back to using the git binary if the above failed
@@ -268,7 +268,9 @@ def get_git_branch(cwd=None):
             s = s.strip()
             if len(s) > 0:
                 branch = s
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+        except OSError:
             pass
 
     return branch
@@ -286,9 +288,9 @@ def call_hg_command(command, cwd):
                                     cwd=cwd,
                                     universal_newlines=True,
                                     env=hg_env)
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         pass
-
+        
     return s
 
 
@@ -340,9 +342,8 @@ def git_dirty_working_directory(cwd=None):
                                     cwd=cwd,
                                     universal_newlines=True)
         return bool(s)
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
-
 
 @ensure_hg
 def hg_dirty_working_directory(cwd=None, root=None):
@@ -478,8 +479,9 @@ def bash_env():
                                     env=currenv,
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True)
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         s = ''
+        
     items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
     env = dict(items)
     return env


### PR DESCRIPTION
subprocess.CalledProcessError is only raised if the command is found but returns a non-zero exit code. 

This will allow the code to work on windows where the bash command is not on the path. The reason it hasn't been a problem for users is that most people have MsysGit installed on windows, and that adds the bash command to the path. 