### PR TITLE
Work-around a bug in "conda convert"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
   build:
-    - python >=3.4
+    - python 3.4
     - ply
   run:
-    - python >=3.4
+    - python 3.4
     - ply
 
 about:


### PR DESCRIPTION
This is temporary work-around for a bug in the conda-build packages

Removing (>=) in the version specification should allow conda convert to correctly convert conda packages build for linux can be converted to windows.