### PR TITLE
Temporary work-around for bug in conda-build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
   build:
-    - python >=3.4
+    - python 3.4*
     - ply
   run:
-    - python >=3.4
+    - python 3.4*
     - ply
 
 about:


### PR DESCRIPTION
Removing (>=) in the version specification should allow conda convert to correctly convert conda packages build for linux can be converted to windows.