### PR TITLE
bash completions: use set() with `declare -F`

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -236,10 +236,10 @@ class Completer(object):
         if len(inp) == 0:
             self.bash_complete_files = {}
             return
-        inp.append('shopt -s extdebug')
-        declare_f = 'declare -F '
-        inp += [declare_f + f for f in self.bash_complete_funcs.values()]
-        inp.append('shopt -u extdebug\n')
+        if self.bash_complete_funcs:
+            inp.append('shopt -s extdebug')
+            inp.append('declare -F ' + ' '.join([f for f in set(self.bash_complete_funcs.values())]))
+            inp.append('shopt -u extdebug\n')
         out = subprocess.check_output(['bash'], input='\n'.join(inp),
                                       universal_newlines=True)
         func_files = {}


### PR DESCRIPTION
This changes `_load_bash_complete_files` to get the definition for each
bash completion function only once, and uses a single call to `declare
-F`.

The output of `complete -p`, which is used in
`completer._load_bash_complete_funcs` is rather large on my system, with a lot of duplicates, especially from 

Most of it appears to come from ubuntu-dev-tools's
``/etc/bash_completion.d/pbuilder-dist`, where a list of aliases is
being setup:

    [ "$have" ] && _pbuilder-aliases()
    {
        local distro builder arch
        for distro in $(ubuntu-distro-info --all; debian-distro-info --all) stable testing unstable; do
            for builder in pbuilder cowbuilder; do
                echo "$builder-$distro"
                for arch in i386 amd64 armel armhf; do
                    echo "$builder-$distro-$arch"
                done
            done
        done
        return 0
    }
    [ "$have" ] && complete -F _pbuilder-dist -o filenames pbuilder-dist cowbuilder-dist $(_pbuilder-aliases)