### PR TITLE
Remove the Python version restriction from the conda recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ build:
 
 requirements:
   build:
-    - python 3.4*
+    - python
     - ply
   run:
-    - python 3.4*
+    - python
     - ply
 
 about:


### PR DESCRIPTION
conda build adds this to the package automatically.