### PR TITLE
fix for vim/emacs not coming back from background

### DIFF
--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -19,7 +19,7 @@ except OSError:
 
 if ON_WINDOWS:
     def _continue(obj):
-        pass
+        return None
 
 
     def _kill(obj):
@@ -33,7 +33,7 @@ if ON_WINDOWS:
     def _set_pgrp(info):
         pass
 
-    def wait_for_active_job():
+    def wait_for_active_job(signal_to_send=None):
         """
         Wait for the active job to finish, to be killed by SIGINT, or to be
         suspended by ctrl-z.
@@ -58,7 +58,7 @@ if ON_WINDOWS:
 
 else:
     def _continue(obj):
-        os.kill(obj.pid, signal.SIGCONT)
+        return signal.SIGCONT
 
 
     def _kill(obj):
@@ -91,7 +91,7 @@ else:
             signal.pthread_sigmask(signal.SIG_SETMASK, oldmask)
 
 
-    def wait_for_active_job():
+    def wait_for_active_job(signal_to_send=None):
         """
         Wait for the active job to finish, to be killed by SIGINT, or to be
         suspended by ctrl-z.
@@ -107,7 +107,13 @@ else:
         pgrp = job['pgrp']
         obj.done = False
 
-        _give_terminal_to(pgrp)  # give the terminal over to the fg process
+        # give the terminal over to the fg process
+        _give_terminal_to(pgrp)
+        # if necessary, send the specified signal to this process
+        # (this hook  was added because vim, emacs, etc, seem to need to have
+        # the terminal when they receive SIGCONT from the "fg" command)
+        if signal_to_send is not None:
+            os.kill(obj.pid, signal_to_send)
         _, s = os.waitpid(obj.pid, os.WUNTRACED)
         if os.WIFSTOPPED(s):
             obj.done = True
@@ -235,7 +241,7 @@ def fg(args, stdin=None):
     job['bg'] = False
     job['status'] = 'running'
     print_one_job(act)
-    _continue(job['obj'])
+    wait_for_active_job(_continue(job['obj']))
 
 
 def bg(args, stdin=None):
@@ -265,4 +271,4 @@ def bg(args, stdin=None):
     job['bg'] = True
     job['status'] = 'running'
     print_one_job(act)
-    _continue(job['obj'])
+    wait_for_active_job(_continue(job['obj']))


### PR DESCRIPTION
This is an attempt to fix #265.  It isn't perfect (if you suspend vim, then kill the PID, then `fg` it, you are left with an unusable terminal), but I think it works better than before since that is an edge-case.