### PR TITLE
Added config file for binstar build service

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,19 @@
+package: xonsh
+
+platform: 
+ - linux-64
+
+engine:
+ - python=3
+
+script:
+  - conda build recipe
+
+after_success:
+   - conda convert -p all /opt/miniconda/conda-bld/linux-64/xonsh-*.tar.bz2 -o /opt/miniconda/conda-bld
+
+after_failure:
+   - echo "Build failed!"
+
+build_targets:
+   - /opt/miniconda/conda-bld/*/*.tar.bz2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,8 +3,7 @@ package:
   version: {{ environ['GIT_DESCRIBE_TAG'] }}
 
 source:
-#  git_url: ../
-  git_url: https://github.com/scopatz/xonsh.git
+   path: ../
 
 build:
   script: python setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,8 @@ package:
   version: {{ environ['GIT_DESCRIBE_TAG'] }}
 
 source:
-  git_url: ../
+#  git_url: ../
+  git_url: https://github.com/scopatz/xonsh.git
 
 build:
   script: python setup.py install


### PR DESCRIPTION
I thought it would be nice to automate the creation of the conda builds on Anaconda.org (formerly binstar.org)

This PR adds a config file to use the free build server on anaconda.org. 

It builds using the linux-64 worker on Anaconda.org, then converts the conda packages to osx-64, linux-32, win-32, win-64. 

@scopatz : To make it work you need to configure the build server for your account.

With "binstar-build" client installed run this command:
binstar-build save  https://github.com/scopatz/xonsh

Then go to http://anaconda.org/scopatz/xonsh/settings/ci and make it look like this:
![image](https://cloud.githubusercontent.com/assets/1038978/8873449/01996558-3207-11e5-9e57-fcf7f3fe6d65.png)

You may need to enable the webhook to github. 

That should ensure that new conda builds are added to your "dev" channel on Anaconda.org every time you push something to master. You can, of course, configure it as you like. 