### PR TITLE
Fixing typos and end of line white space in docs

### DIFF
--- a/docs/devguide.rst
+++ b/docs/devguide.rst
@@ -3,9 +3,9 @@
 =================
 Developer's Guide
 =================
-Welcome to the xonsh developer's guide!  This is a place for developers to 
-place information that does not belong in the user's guide or the library 
-reference but is useful or necessary for the next people that come along to 
+Welcome to the xonsh developer's guide!  This is a place for developers to
+place information that does not belong in the user's guide or the library
+reference but is useful or necessary for the next people that come along to
 develop xonsh.
 
 .. note:: All code changes must go through the pull request review procedure.
@@ -19,7 +19,7 @@ ensure consistency throughout the code base.
 Rules to Write By
 ----------------------------------
 It is important to refer to things and concepts by their most specific name.
-When writing xonsh code or documentation please use technical terms 
+When writing xonsh code or documentation please use technical terms
 appropriately. The following rules help provide needed clarity.
 
 **********
@@ -34,7 +34,7 @@ Expectations
 ************
 * Code must have associated tests and adequate documentation.
 * User-interaction code (such as the Shell class) is hard to test.
-  Mechanism to test such constucts should be developed over time.
+  Mechanism to test such constructs should be developed over time.
 * Have *extreme* empathy for your users.
 * Be selfish. Since you will be writing tests you will be your first user.
 
@@ -44,20 +44,20 @@ Python Style Guide
 xonsh uses `PEP8`_ for all Python code. The following rules apply where `PEP8`_
 is open to interpretation.
 
-* Use absolute imports (``import xonsh.tools``) rather than explicit 
-  relative imports (``import .tools``). Implicit relative imports 
+* Use absolute imports (``import xonsh.tools``) rather than explicit
+  relative imports (``import .tools``). Implicit relative imports
   (``import tools``) are never allowed.
-* Use ``'single quotes'`` for string literals, and 
-  ``"""triple double quotes"""`` for docstrings. Double quotes are allowed to 
+* Use ``'single quotes'`` for string literals, and
+  ``"""triple double quotes"""`` for docstrings. Double quotes are allowed to
   prevent single quote escaping, e.g. ``"Y'all c'mon o'er here!"``
 * We use sphinx with the numpydoc extension to autogenerate API documentation. Follow
   the numpydoc standard for docstrings `described here <https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt>`_.
 * Simple functions should have simple docstrings.
-* Lines should be at most 80 characters long. The 72 and 79 character 
+* Lines should be at most 80 characters long. The 72 and 79 character
   recommendations from PEP8 are not required here.
 * All Python code should be compliant with Python 3.4+.  At some
   unforeseen date in the future, Python 2.7 support *may* be supported.
-* Tests should be written with nose using a procedural style. Do not use 
+* Tests should be written with nose using a procedural style. Do not use
   unittest directly or write tests in an object-oriented style.
 * Test generators make more dots and the dots must flow!
 
@@ -81,47 +81,47 @@ lexer and parser module tests::
 Happy testing!
 
 
-How to Document 
+How to Document
 ====================
-Documentation takes many forms. This will guide you through the steps of 
+Documentation takes many forms. This will guide you through the steps of
 successful documentation.
 
 ----------
 Docstrings
 ----------
-No matter what language you are writing in, you should always have 
-documentation strings along with you code. This is so important that it is 
-part of the style guide.  When writing in Python, your docstrings should be 
-in reStructured Text using the numpydoc format. 
+No matter what language you are writing in, you should always have
+documentation strings along with you code. This is so important that it is
+part of the style guide.  When writing in Python, your docstrings should be
+in reStructured Text using the numpydoc format.
 
 ------------------------
 Auto-Documentation Hooks
 ------------------------
-The docstrings that you have written will automatically be connected to the 
-website, once the appropriate hooks have been setup.  At this stage, all 
-documentation lives within xonsh's top-level ``docs`` directory. 
-We uses the sphinx tool to manage and generate the documentation, which 
+The docstrings that you have written will automatically be connected to the
+website, once the appropriate hooks have been setup.  At this stage, all
+documentation lives within xonsh's top-level ``docs`` directory.
+We uses the sphinx tool to manage and generate the documentation, which
 you can learn about from `the sphinx website <http://sphinx-doc.org/>`_.
-If you want to generate the documentaion, first xonsh itself must be installed 
+If you want to generate the documentation, first xonsh itself must be installed
 and then you may run the following command from the ``docs`` dir:
 
 .. code-block:: bash
 
     ~/xonsh/docs $ make html
 
-For each new 
-module, you will have to supply the appropriate hooks. This should be done the 
-first time that the module appears in a pull request.  From here, call the 
+For each new
+module, you will have to supply the appropriate hooks. This should be done the
+first time that the module appears in a pull request.  From here, call the
 new module ``mymod``.  The following explains how to add hooks.
 
 ------------------------
 Python Hooks
 ------------------------
-Python documentation lives in the ``docs/api`` directory.  
+Python documentation lives in the ``docs/api`` directory.
 First, create a file in this directory that represents the new module called
-``mymod.rst``.  
+``mymod.rst``.
 The ``docs/api`` directory matches the structure of the ``xonsh/`` directory.
-So if your module is in a sub-package, you'll need to go into the sub-package's 
+So if your module is in a sub-package, you'll need to go into the sub-package's
 directory before creating ``mymod.rst``.
 The contents of this file should be as follows:
 
@@ -140,12 +140,12 @@ The contents of this file should be as follows:
     .. automodule:: xonsh.mymod
         :members:
 
-This will discover all of the docstrings in ``mymod`` and create the 
-appropriate webpage. Now, you need to hook this page up to the rest of the 
+This will discover all of the docstrings in ``mymod`` and create the
+appropriate webpage. Now, you need to hook this page up to the rest of the
 website.
 
-Go into the ``index.rst`` file in ``docs/xonsh`` or other subdirectory and add 
-``mymod`` to the appropriate ``toctree`` (which stands for table-of-contents 
+Go into the ``index.rst`` file in ``docs/xonsh`` or other subdirectory and add
+``mymod`` to the appropriate ``toctree`` (which stands for table-of-contents
 tree). Note that every sub-package has its own ``index.rst`` file.
 
 
@@ -160,20 +160,20 @@ Building the website/documentation requires the following dependencies:
 -----------------------------------
 Procedure for modifying the website
 -----------------------------------
-The xonsh website source files are located in the ``docs`` directory. 
-A developer first makes necessary changes, then rebuilds the website locally 
+The xonsh website source files are located in the ``docs`` directory.
+A developer first makes necessary changes, then rebuilds the website locally
 by executing the command::
 
     $ make html
 
 This will generate html files for the website in the ``_build/html/`` folder.
-The developer may view the local changes by opening these files with their 
+The developer may view the local changes by opening these files with their
 favorite browser, e.g.::
 
     $ google-chrome _build/html/index.html
 
 Once the developer is satisfied with the changes, the changes should be
-commited and pull-requested per usual. Once the pull request is accepted, the
+committed and pull-requested per usual. Once the pull request is accepted, the
 developer can push their local changes directly to the website by::
 
     $ make push-root
@@ -181,34 +181,34 @@ developer can push their local changes directly to the website by::
 Branches and Releases
 =============================
 Mainline xonsh development occurs on the ``master`` branch. Other branches
-may be used for feature developmeent (topical branches) or to represent
+may be used for feature development (topical branches) or to represent
 past and upcoming releases.
 
 All releases should have a release candidate ('-rc1') that comes out 2 - 5 days
-prior to the scheduled release.  During this time, no changes should occur to 
-a special release branch ('vX.X.X-release').  
+prior to the scheduled release.  During this time, no changes should occur to
+a special release branch ('vX.X.X-release').
 
-The release branch is there so that development can continue on the 
-develop branch while the release candidates (rc) are out and under review.  
-This is because otherwise any new developments would have to wait until 
-post-release to be merged into develop to prevent them from accidentally 
-getting released early.    
+The release branch is there so that development can continue on the
+develop branch while the release candidates (rc) are out and under review.
+This is because otherwise any new developments would have to wait until
+post-release to be merged into develop to prevent them from accidentally
+getting released early.
 
-As such, the 'vX.X.X-release' branch should only exist while there are 
+As such, the 'vX.X.X-release' branch should only exist while there are
 release candidates out.  They are akin to a temporary second level of staging,
-and so everything that is in this branch should also be part of master.  
+and so everything that is in this branch should also be part of master.
 
-Every time a new release candidate comes out the vX.X.X-release should be 
-tagged with the name 'X.X.X-rcX'.  There should be a 2 - 5 day period of time 
-in between release candidates.  When the full and final release happens, the 
+Every time a new release candidate comes out the vX.X.X-release should be
+tagged with the name 'X.X.X-rcX'.  There should be a 2 - 5 day period of time
+in between release candidates.  When the full and final release happens, the
 'vX.X.X-release' branch is merged into master and then deleted.
 
-If you have a new fix that needs to be in the next release candidate, you 
+If you have a new fix that needs to be in the next release candidate, you
 should make a topical branch and then pull request it into the release branch.
-After this has been accepted, the topical branch should be merged with 
+After this has been accepted, the topical branch should be merged with
 master as well.
 
-The release branch must be quiet and untouched for 2 - 5 days prior to the 
+The release branch must be quiet and untouched for 2 - 5 days prior to the
 full release.
 
 The release candidate procedure here only applies to major and minor releases.
@@ -220,32 +220,32 @@ Checklist
 ------------------
 When releasing xonsh, make sure to do the following items in order:
 
-1. Review **ALL** issues in the issue tracker, reassigning or closing them as 
+1. Review **ALL** issues in the issue tracker, reassigning or closing them as
    needed.
 2. Ensure that all issues in this release's milestone have been closed. Moving issues
-   to the next release's milestone is a perfectly valid strategy for 
-   completing this milestone. 
-3. Perform maintainence tasks for this project, see below.
+   to the next release's milestone is a perfectly valid strategy for
+   completing this milestone.
+3. Perform maintenance tasks for this project, see below.
 4. Write and commit the release notes.
-5. Review the current state of documentation and make approriate updates.
+5. Review the current state of documentation and make appropriate updates.
 6. Bump the version (in code, documentation, etc.) and commit the change.
-7. If this is a release candidate, tag the release branch with a name that 
-   matches that of the release: 
+7. If this is a release candidate, tag the release branch with a name that
+   matches that of the release:
 
    * If this is the first release candidate, create a release branch called
-     'vX.X.X-release' off of develop.  Tag this branch with the name 
+     'vX.X.X-release' off of develop.  Tag this branch with the name
      'X.X.X-rc1'.
-   * If this is the second or later release candidate, tag the release branch 
+   * If this is the second or later release candidate, tag the release branch
      with the name 'X.X.X-rcX'.
 
-8. If this is the full and final release (and not a release candidate), 
-   merge the release branch into the master branch.  Next, tag the master 
+8. If this is the full and final release (and not a release candidate),
+   merge the release branch into the master branch.  Next, tag the master
    branch with the name 'X.X.X'. Finally, delete the release branch.
 9. Push the tags upstream
 10. Update release information on the website.
 
 --------------------
-Maintainence Tasks
+Maintenance Tasks
 --------------------
 None currently.
 
@@ -280,7 +280,7 @@ To perform the release, run these commands for the following tasks:
 
 Document History
 ===================
-Portions of this page have been forked from the PyNE documentation, 
+Portions of this page have been forked from the PyNE documentation,
 Copyright 2011-2015, the PyNE Development Team. All rights reserved.
 
 .. _PEP8: http://www.python.org/dev/peps/pep-0008/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,10 +5,10 @@ Ok, so, maybe no one actually asked them.
 
 1. Why xonsh?
 -------------
-The idea for xonsh first struck while I was reviewing the BASH chapter 
+The idea for xonsh first struck while I was reviewing the BASH chapter
 (written by my co-author `Katy Huff <http://katyhuff.github.io/>`_)
 of `Effective Computation in Physics <http://physics.codes/>`_. In the book
-we spend a bunch of time describing important, but complex ideas, such 
+we spend a bunch of time describing important, but complex ideas, such
 as piping. However, we don't even touch on more 'basic' aspects of the BASH
 language, such as if-statements or loops. Even though I have been using BASH
 for well over a decade, I am not even sure I *know how*
@@ -16,13 +16,13 @@ to add two numbers together in it or consistently create an array. This is
 normal.
 
 If the tool is so bad, then maybe we need a new tool. So xonsh is really meant
-to solve the problem that other shells don't "fit your brain." 
-In some programing situations this is OK because of what you get 
+to solve the problem that other shells don't "fit your brain."
+In some programing situations this is OK because of what you get
 (an optimizing compiler, type safety, provable correctness, register access).
 But a shell that doesn't fit your brain is only a liability.
 
-Coincidentally, within the week, `an article floated to the top of Hacker News <http://stephen-brennan.com/2015/01/16/write-a-shell-in-c/>`_ 
-that teaches you how to write a shell in C. So I thought, "It can't be 
+Coincidentally, within the week, `an article floated to the top of Hacker News <http://stephen-brennan.com/2015/01/16/write-a-shell-in-c/>`_
+that teaches you how to write a shell in C. So I thought, "It can't be
 that hard..."
 
 And thus, `again <http://exofrills.org>`_, I entered the danger zone.
@@ -31,63 +31,63 @@ And thus, `again <http://exofrills.org>`_, I entered the danger zone.
 2. Why not another exotic shell, such as ``fish``?
 -----------------------------------------------------
 While many other alternative shells have an amazing suite of features
-as well as much improved syntax of traditional options, none of them 
-are quite a beautiful as Python.  In xonsh, you get the best of all possible
-worlds. A syntax that already fits your brain and any features that you 
+as well as much improved syntax of traditional options, none of them
+are quite as beautiful as Python.  In xonsh, you get the best of all possible
+worlds. A syntax that already fits your brain and any features that you
 desire.
 
 
 3. Why not just use the IPython command line interface?
 -------------------------------------------------------
-There are two serious drawbacks to this approach - though believe me I have 
-tried it. 
+There are two serious drawbacks to this approach - though believe me I have
+tried it.
 
-The first is that typing ``!`` before every subprocess command is 
-extremely tedious.  I think that this is because it is a prefix operator and 
-thus gets in the way of what you are trying to do right as you start to try 
-to do it. Making ``!`` a postfix operator could address some of this, but 
+The first is that typing ``!`` before every subprocess command is
+extremely tedious.  I think that this is because it is a prefix operator and
+thus gets in the way of what you are trying to do right as you start to try
+to do it. Making ``!`` a postfix operator could address some of this, but
 would probably end up being annoying, though not nearly as jarring.
 
 The second reason is that tab completion of subprocess commands after an ``!``
-does not work. This is a deal breaker for day-to-day use. 
+does not work. This is a deal breaker for day-to-day use.
 
 
 4. So how does this all work?
 -----------------------------
-We use `PLY <http://www.dabeaz.com/ply/ply.html>`_ to tokenize and parse 
+We use `PLY <http://www.dabeaz.com/ply/ply.html>`_ to tokenize and parse
 xonsh code. This is heavily inspired by how `pycparser <https://github.com/eliben/pycparser>`_
 used this PLY. From our parser, we construct an abstract syntax tree (AST)
-only using nodes found in the Python ``ast`` standard library module. 
+only using nodes found in the Python ``ast`` standard library module.
 This allows us to compile and execute the AST using the normal Python tools.
 
-Of course, xonsh has special builtins, so the proper context 
-(builtins, globals, and locals) must be set up prior to actually executing 
-any code. However, the AST can be constructed completely independently of 
-any context...mostly.  
+Of course, xonsh has special builtins, so the proper context
+(builtins, globals, and locals) must be set up prior to actually executing
+any code. However, the AST can be constructed completely independently of
+any context...mostly.
 
-While the grammar of the xonsh language is context-free, it was convienent 
-to write the executer in a way that is slightly context sensitive. This is 
-because certain expressions are ambiguious as to whether they belong to 
-Python-mode or subprocess-mode. For example, most people will look at 
-``ls -l`` and see a listing command.  However, if ``ls`` and ``l`` were 
-Python variables, this could be transformed to the equivalent (Python) 
-expressions ``ls - l`` or ``ls-l``.  Neither of which are valid listing 
+While the grammar of the xonsh language is context-free, it was convenient
+to write the executer in a way that is slightly context sensitive. This is
+because certain expressions are ambiguous as to whether they belong to
+Python-mode or subprocess-mode. For example, most people will look at
+``ls -l`` and see a listing command.  However, if ``ls`` and ``l`` were
+Python variables, this could be transformed to the equivalent (Python)
+expressions ``ls - l`` or ``ls-l``.  Neither of which are valid listing
 commands.
 
-What xonsh does to overcome such ambiquity is to check if the left-most 
+What xonsh does to overcome such ambiguity is to check if the left-most
 name (``ls`` above) is in the present Python context. If it is, then it takes
 the line to be valid xonsh as written. If the left-most name cannot be found,
-then xonsh assumes that the left-most name is an external command. It thus 
-attempts to parse the line after wrapping it in an uncaptured subprocess 
-call ``$[]``.  If wrapped version successfully pasres, the ``$[]`` version 
+then xonsh assumes that the left-most name is an external command. It thus
+attempts to parse the line after wrapping it in an uncaptured subprocess
+call ``$[]``.  If wrapped version successfully parses, the ``$[]`` version
 stays. Otherwise the original line is retained.
 
-All of the context sensitive parsing occurs as an AST transformation prior to 
+All of the context sensitive parsing occurs as an AST transformation prior to
 any code is executed.  This ensures that code will never be partially executed
 before failing.
 
-It is critical to note that the context sensitive parsing is a convienece
-meant for humans.  If ambiguity remains or exactness is required, simply 
+It is critical to note that the context sensitive parsing is a convenience
+meant for humans.  If ambiguity remains or exactness is required, simply
 manually use the ``$[]`` or ``$()`` operators on your code.
 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -484,7 +484,7 @@ Input/Output Redirection
 xonsh also allows you to redirect ``stdin``, ``stdout``, and/or ``stderr``.
 This allows you to control where the output of a command is sent, and where
 it receives its input from.  xonsh has its own syntax for these operations,
-but, for campatability purposes, xonsh also support Bash-like syntax.
+but, for compatibility purposes, xonsh also support Bash-like syntax.
 
 The basic operations are "write to" (``>``), "append to" (``>>``), and "read
 from" (``<``).  The details of these are perhaps best explained through
@@ -502,7 +502,7 @@ exist:
     >>> COMMAND > output.txt
     >>> COMMAND out> output.txt
     >>> COMMAND o> output.txt
-    >>> COMMAND 1> output.txt # included for Bash compatability
+    >>> COMMAND 1> output.txt # included for Bash compatibility
 
 These can be made to append to ``output.txt`` instead of overwriting its contents
 by replacing ``>`` with ``>>`` (note that ``>>`` will still create the file if it
@@ -519,7 +519,7 @@ exist:
 
     >>> COMMAND err> errors.txt
     >>> COMMAND e> errors.txt
-    >>> COMMAND 2> errors.txt # included for Bash compatability
+    >>> COMMAND 2> errors.txt # included for Bash compatibility
 
 As above, replacing ``>`` with ``>>`` will cause the error output to be
 appended to ``errors.txt``, rather than replacing its contents.
@@ -535,7 +535,7 @@ that task:
 
     >>> COMMAND all> combined.txt
     >>> COMMAND a> combined.txt
-    >>> COMMAND &> combined.txt # included for Bash compatability
+    >>> COMMAND &> combined.txt # included for Bash compatibility
 
 It is also possible to explicitly merge stderr into stdout so that error
 messages are reported to the same location as regular output.  You can do this
@@ -547,7 +547,7 @@ with the following syntax:
     >>> COMMAND err>o
     >>> COMMAND e>out
     >>> COMMAND e>o
-    >>> COMMAND 2>&1 # included for Bash compatability
+    >>> COMMAND 2>&1 # included for Bash compatibility
 
 This merge can be combined with other redirections, including pipes (see the
 section on `Pipes`_ above):
@@ -841,7 +841,7 @@ must have the following signature:
         # Note: that you have access to the xonsh
         # built-ins if you 'import builtins'.  For example, if you need the
         # environment, you could do to following:
-        import bulitins
+        import builtins
         env = builtins.__xonsh_env__
 
         # The return value of the function can either be None,


### PR DESCRIPTION
As this is only docs, I thought I start helping with some cleanup of typos.