### PR TITLE
Hiding traceback in the shell

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -164,73 +164,80 @@ useful to have more sophisticated types, like functions, in the environment.
 There are handful of environment variables that xonsh considers special.
 They can be seen in the table below:
 
-================== ============================= ================================
-variable           default                       description
-================== ============================= ================================
-PROMPT             xonsh.environ.DEFAULT_PROMPT  The prompt text.  May contain
-                                                 keyword arguments which are
-                                                 auto-formatted (see `Customizing
-                                                 the Prompt`_ below).
-MULTILINE_PROMPT   ``'.'``                       Prompt text for 2nd+ lines of
-                                                 input, may be str or
-                                                 function which returns a str.
-TITLE              xonsh.environ.DEFAULT_TITLE   The title text for the window
-                                                 in which xonsh is running.
-                                                 Formatted in the same manner
-                                                 as PROMPT (see `Customizing the
-                                                 Prompt`_ below).
-FORMATTER_DICT     xonsh.environ.FORMATTER_DICT  Dictionary containing variables
-                                                 to be used when formatting PROMPT
-                                                 and TITLE (see `Customizing the
-                                                 Prompt`_ below).
-XONSHRC            ``'~/.xonshrc'``              Location of run control file
-XONSH_HISTORY_SIZE 8128                          Number of items to store in the
-                                                 history.
-XONSH_HISTORY_FILE ``'~/.xonsh_history'``        Location of history file
-XONSH_INTERACTIVE                                ``True`` if xonsh is running
-                                                 interactively, and ``False``
-                                                 otherwise.
-BASH_COMPLETIONS   ``[] or ['/etc/...']``        This is a list of strings that
-                                                 specifies where the BASH
-                                                 completion files may be found.
-                                                 The default values are platform
-                                                 dependent, but sane.  To
-                                                 specify an alternate list,
-                                                 do so in the run control file.
-SUGGEST_COMMANDS   ``True``                      When a user types an invalid
-                                                 command, xonsh will try to offer
-                                                 suggestions of similar valid
-                                                 commands if this is ``True``.
-SUGGEST_THRESHOLD  ``3``                         An error threshold.  If the
-                                                 Levenshtein distance between the
-                                                 entered command and a valid
-                                                 command is less than this value,
-                                                 the valid command will be
-                                                 offered as a suggestion.
-SUGGEST_MAX_NUM    ``5``                         xonsh will show at most this
-                                                 many suggestions in response to
-                                                 an invalid command.  If
-                                                 negative, there is no limit to
-                                                 how many suggestions are shown.
-SHELL_TYPE         ``'readline'``                Which shell is used.
-                                                 Currently two shell types are
-                                                 supported: ``'readline'`` that
-                                                 is backed by python's readline
-                                                 module and ``'prompt_toolkit'``
-                                                 that uses external library of
-                                                 the same name. For using
-                                                 prompt_toolkit shell you need
-                                                 to have `prompt_toolkit
-                                                 <https://github.com/jonathanslenders/python-prompt-toolkit>`_
-                                                 library installed. To specify
-                                                 which shell should be used, do
-                                                 so in the run control file.
-CDPATH             ``[]``                        A list of paths to be used as
-                                                 roots for a `cd`, breaking
-                                                 compatibility with bash, xonsh
-                                                 always prefer an existing
-                                                 relative path.
-================== ============================= ================================
+==================== ============================= ================================
+variable             default                       description
+==================== ============================= ================================
+PROMPT               xonsh.environ.DEFAULT_PROMPT  The prompt text.  May contain
+                                                   keyword arguments which are
+                                                   auto-formatted (see `Customizing
+                                                   the Prompt`_ below).
+MULTILINE_PROMPT     ``'.'``                       Prompt text for 2nd+ lines of
+                                                   input, may be str or
+                                                   function which returns a str.
+TITLE                xonsh.environ.DEFAULT_TITLE   The title text for the window
+                                                   in which xonsh is running.
+                                                   Formatted in the same manner
+                                                   as PROMPT (see `Customizing the
+                                                   Prompt`_ below).
+FORMATTER_DICT       xonsh.environ.FORMATTER_DICT  Dictionary containing variables
+                                                   to be used when formatting PROMPT
+                                                   and TITLE (see `Customizing the
+                                                   Prompt`_ below).
+XONSHRC              ``'~/.xonshrc'``              Location of run control file
+XONSH_HISTORY_SIZE   8128                          Number of items to store in the
+                                                   history.
+XONSH_HISTORY_FILE   ``'~/.xonsh_history'``        Location of history file
+XONSH_INTERACTIVE                                  ``True`` if xonsh is running
+                                                   interactively, and ``False``
+                                                   otherwise.
+BASH_COMPLETIONS     ``[] or ['/etc/...']``        This is a list of strings that
+                                                   specifies where the BASH
+                                                   completion files may be found.
+                                                   The default values are platform
+                                                   dependent, but sane.  To
+                                                   specify an alternate list,
+                                                   do so in the run control file.
+SUGGEST_COMMANDS     ``True``                      When a user types an invalid
+                                                   command, xonsh will try to offer
+                                                   suggestions of similar valid
+                                                   commands if this is ``True``.
+SUGGEST_THRESHOLD    ``3``                         An error threshold.  If the
+                                                   Levenshtein distance between the
+                                                   entered command and a valid
+                                                   command is less than this value,
+                                                   the valid command will be
+                                                   offered as a suggestion.
+SUGGEST_MAX_NUM      ``5``                         xonsh will show at most this
+                                                   many suggestions in response to
+                                                   an invalid command.  If
+                                                   negative, there is no limit to
+                                                   how many suggestions are shown.
+SHELL_TYPE           ``'readline'``                Which shell is used.
+                                                   Currently two shell types are
+                                                   supported: ``'readline'`` that
+                                                   is backed by python's readline
+                                                   module and ``'prompt_toolkit'``
+                                                   that uses external library of
+                                                   the same name. For using
+                                                   prompt_toolkit shell you need
+                                                   to have `prompt_toolkit
+                                                   <https://github.com/jonathanslenders/python-prompt-toolkit>`_
+                                                   library installed. To specify
+                                                   which shell should be used, do
+                                                   so in the run control file.
+CDPATH               ``[]``                        A list of paths to be used as
+                                                   roots for a `cd`, breaking
+                                                   compatibility with bash, xonsh
+                                                   always prefer an existing
+                                                   relative path.
+XONSH_SHOW_TRACEBACK Not defined                   Controls if a traceback is shown when 
+                                                   exceptions occur in the shell.  
+                                                   Set ``'True'`` to always show 
+                                                   or ``'False'`` to always hide.
+                                                   If undefined then traceback is 
+                                                   hidden but a notice is shown on 
+                                                   how to enable the traceback.
+==================== ============================= ================================
 
 Environment Lookup with ``${}``
 ================================

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -43,7 +43,7 @@ class BaseShell(object):
         except XonshError as e:
             print(e.args[0], file=sys.stderr)
         except:
-            traceback.print_exc()
+            _print_exception()
         if builtins.__xonsh_exit__:
             return True
 
@@ -65,9 +65,13 @@ class BaseShell(object):
         except SyntaxError:
             if line == '\n':
                 self.reset_buffer()
-                traceback.print_exc()
+                _print_exception()
                 return None
             self.need_more_lines = True
+        except:
+            self.reset_buffer()
+            _print_exception()
+            return None
         return code
 
     def reset_buffer(self):
@@ -108,3 +112,14 @@ class BaseShell(object):
             p = "set '$PROMPT = ...' $ "
         self.settitle()
         return p
+        
+def _print_exception():
+    """Print exceptions with/without traceback."""
+    if not 'XONSH_SHOW_TRACEBACK' in builtins.__xonsh_env__:
+        sys.stderr.write('xonsh: For full traceback set: '
+                         '$XONSH_SHOW_TRACEBACK=True\n')
+    if builtins.__xonsh_env__.get('XONSH_SHOW_TRACEBACK', False):
+        traceback.print_exc()
+    else:
+        type, value, exc_traceback = sys.exc_info()
+        sys.stderr.write(''.join(traceback.format_exception_only(type, value)))

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -121,5 +121,6 @@ def _print_exception():
     if builtins.__xonsh_env__.get('XONSH_SHOW_TRACEBACK', False):
         traceback.print_exc()
     else:
-        type, value, exc_traceback = sys.exc_info()
-        sys.stderr.write(''.join(traceback.format_exception_only(type, value)))
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        exception_only =  traceback.format_exception_only(exc_type, exc_value)
+        sys.stderr.write(''.join(exception_only))


### PR DESCRIPTION
Hi 

This one is for discussion. I find it a bit annoying to get full tracebacks when working in the shell. If I just try a few things that fail and my screen is complely full of junk. 

So I thought that it may be an idea to hide the traceback by default, and only show the exception. 

This pull request implements that idea. Let me know what you think.

------------------------------------------
The functionality can be controlled with the environment variable $XONSH_SHOW_TRACEBACK

If the variable is not set, the default is to hide the traceback but with an extra notice that the traceback can be enabled:
mel@home ~ $x = {foo:1, bar}
xonsh: For full traceback set: $XONSH_SHOW_TRACEBACK=True
ValueError: Dict doesn't have the same number of keys as values
mel@home ~ $