### PR TITLE
Prevent os.path.normpath() from removing current dir

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -35,6 +35,13 @@ for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 """
 
 
+def _normpath(p):
+    # Prevent normpath() from removing initial ‘./’
+    if p.startswith('./'):
+        return './' + os.path.normpath(p[2:])
+    return os.path.normpath(p)
+
+
 class Completer(object):
     """This provides a list of optional completions for the xonsh shell."""
 
@@ -173,7 +180,7 @@ class Completer(object):
         self._add_dots(paths, prefix)
         if cdpath:
             self._add_cdpaths(paths, prefix)
-        return {os.path.normpath(s) for s in paths}
+        return {_normpath(s) for s in paths}
 
     def bash_complete(self, prefix, line, begidx, endidx):
         """Attempts BASH completion."""

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -37,8 +37,9 @@ for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 
 def _normpath(p):
     # Prevent normpath() from removing initial ‘./’
-    if p.startswith('./'):
-        return './' + os.path.normpath(p[2:])
+    here = os.curdir + os.sep
+    if p.startswith(here):
+        return os.path.join(os.curdir, os.path.normpath(p[len(here):]))
     return os.path.normpath(p)
 
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -35,12 +35,6 @@ for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 """
 
 
-def _normpath(p):
-    if p.startswith('./'):
-        return './' + os.path.normpath(p)
-    return os.path.normpath(p)
-
-
 class Completer(object):
     """This provides a list of optional completions for the xonsh shell."""
 
@@ -179,7 +173,7 @@ class Completer(object):
         self._add_dots(paths, prefix)
         if cdpath:
             self._add_cdpaths(paths, prefix)
-        return {_normpath(s) for s in paths}
+        return {os.path.normpath(s) for s in paths}
 
     def bash_complete(self, prefix, line, begidx, endidx):
         """Attempts BASH completion."""

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -35,6 +35,12 @@ for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 """
 
 
+def _normpath(p):
+    if p.startswith('./'):
+        return './' + os.path.normpath(p)
+    return os.path.normpath(p)
+
+
 class Completer(object):
     """This provides a list of optional completions for the xonsh shell."""
 
@@ -173,7 +179,7 @@ class Completer(object):
         self._add_dots(paths, prefix)
         if cdpath:
             self._add_cdpaths(paths, prefix)
-        return {os.path.normpath(s) for s in paths}
+        return {_normpath(s) for s in paths}
 
     def bash_complete(self, prefix, line, begidx, endidx):
         """Attempts BASH completion."""


### PR DESCRIPTION
The previous fix didn't take other current dirs and other path separators into consideration, and so it fixed the `./` problem on Linux/Unix but not e.g. `.\` on Windows.

In an attempt to be platform agnostic this patch uses `os.curdir` and `os.sep`.

Fixes #307.
