### PR TITLE
Prompt Indentation After Colon

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -891,7 +891,6 @@ for the commands themselves.
 
 Customizing the Prompt
 ======================
-
 Customizing the prompt is probably the most common reason for altering an
 environment variable.  The ``PROMPT`` variable can be a string, or it can be a
 function (of no arguments) that returns a string.  The result can contain
@@ -901,7 +900,7 @@ keyword arguments, which will be replaced automatically:
 
     >>> $PROMPT = '{user}@{hostname}:{cwd} > '
     snail@home:~ > # it works!
-    snail@home:~ > $PROMPT = lambda : '{user}@{hostname}:{cwd} >> '
+    snail@home:~ > $PROMPT = lambda: '{user}@{hostname}:{cwd} >> '
     snail@home:~ >> # so does that!
 
 By default, the following variables are available for use:
@@ -925,7 +924,7 @@ or ``{BOLD_BLUE}``.  Colors have the form shown below:
   * ``NO_COLOR``: Resets any previously used color codes
 
 You can make use of additional variables beyond these by adding them to the
-``FORMATTER_PROMPT`` environment variable.  The values in this dictionary
+``FORMATTER_DICT`` environment variable.  The values in this dictionary
 should be strings (which will be inserted into the prompt verbatim), or
 functions of no arguments (which will be called each time the prompt is
 generated, and the results of those calls will be inserted into the prompt).
@@ -942,6 +941,10 @@ For example:
     5 ~ $
     2 ~ $
     8 ~ $
+
+If a function in ``$FORMATTER_DICT`` returns ``None``, the ``None`` will be 
+interpreted as an empty string.
+
 
 Executing Commands and Scripts
 ==============================

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -5,7 +5,7 @@ import os
 import nose
 from nose.tools import assert_equal, assert_true, assert_not_in
 
-from xonsh.environ import Env
+from xonsh.environ import Env, format_prompt
 
 def test_env_normal():
     env = Env(VAR='wakka')
@@ -35,6 +35,20 @@ def test_env_detype_no_dict():
     det = env.detype()
     assert_not_in('YO', det)
 
+def test_format_prompt():
+    formatter_dict = {
+        'a_string': 'cat',
+        'none': (lambda: None),
+        'f': (lambda: 'wakka'),
+        }
+    cases = {
+        'my {a_string}': 'my cat',
+        'my {none}{a_string}': 'my cat',
+        '{f} jawaka': 'wakka jawaka',
+        }
+    for p, exp in cases.items():
+        obs = format_prompt(template=p, formatter_dict=formatter_dict)
+        yield assert_equal, exp, obs
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -400,19 +400,24 @@ FORMATTER_DICT = dict(user=os.environ.get(USER, '<user>'),
                       branch_color=branch_color,
                       **TERM_COLORS)
 
-_formatter = string.Formatter()
+_FORMATTER = string.Formatter()
 
 
-def format_prompt(template=DEFAULT_PROMPT):
-    """Formats a xonsh prompt template string.
-    """
-    env = builtins.__xonsh_env__
+def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
+    """Formats a xonsh prompt template string."""
     template = template() if callable(template) else template
-    fmt = env.get('FORMATTER_DICT', FORMATTER_DICT)
-    included_names = set(i[1] for i in _formatter.parse(template))
-    fmt = {k: (v() if callable(v) else v)
-           for (k, v) in fmt.items()
-           if k in included_names}
+    if formatter_dict is None:
+        fmtter = builtins.__xonsh_env__.get('FORMATTER_DICT', FORMATTER_DICT)
+    else:
+        fmtter = formatter_dict
+    included_names = set(i[1] for i in _FORMATTER.parse(template))
+    fmt = {}
+    for k, v in fmtter.items():
+        if k not in included_names:
+            continue
+        val = v() if callable(v) else v
+        val = '' if val is None else val
+        fmt[k] = val
     return template.format(**fmt)
 
 

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -88,6 +88,9 @@ def _insert_text_func(s, readline):
     return inserter
 
 
+DEDENT_TOKENS = frozenset(['raise', 'return', 'pass', 'break', 'continue'])
+
+
 class ReadlineShell(BaseShell, Cmd):
     """The readline based xonsh shell."""
 
@@ -131,6 +134,11 @@ class ReadlineShell(BaseShell, Cmd):
             elif line.rstrip()[-1] == ':':
                 ind = line[:len(line) - len(line.lstrip())]
                 ind += builtins.__xonsh_env__.get('INDENT', '')
+                readline.set_pre_input_hook(_insert_text_func(ind, readline))
+                self._current_indent = ind
+            elif line.split(maxsplit=1)[0] in DEDENT_TOKENS:
+                env = builtins.__xonsh_env__
+                ind = self._current_indent[:-len(env.get('INDENT', ''))]
                 readline.set_pre_input_hook(_insert_text_func(ind, readline))
                 self._current_indent = ind
             else:


### PR DESCRIPTION
This implements automatic indentation after lines that start with a colon. This implementation is readline specific. Should close #296, as requested by @asmeurer.