### PR TITLE
fix pretty printing bug on windows

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -57,7 +57,7 @@ parser.add_argument('args',
 
 def _pprint_displayhook(value):
     if value is not None:
-        __builtins__['_'] = value
+        builtins._ = value
         pprint(value)
 
 


### PR DESCRIPTION
This bug was mentioned by @BYK in a [post on the mailing list](https://groups.google.com/d/msg/xonsh/fRoEQR0QGeA/6mNa83TABAAJ).  It seems not to be something specific to that example, though, but rather something completely general: on Windows only, any time we attempt to pretty-print a Python value, this error occurs.

This patch should fix (tested quickly on Windows 8 and Debian Jessie).