### PR TITLE
Added DIRS rule to environ

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -142,8 +142,10 @@ Like other variables in Python, environment variables have a type. Sometimes
 this type is imposed based on the variable name. The current rules are pretty
 simple:
 
-* ``PATH``: any variable whose name contains PATH is a list of strings.
+* ``\w*PATH``: any variable whose name ends in PATH is a list of strings.
+* ``\w*DIRS``: any variable whose name ends in DIRS is a list of strings.
 * ``XONSH_HISTORY_SIZE``: this variable is an int.
+* ``CASE_SENSITIVE_COMPLETIONS``: this variable is a boolean.
 
 xonsh will automatically convert back and forth to untyped (string-only)
 representations of the environment as needed (mostly by subprocess commands).

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -44,6 +44,7 @@ represent environment variable validation, conversion, detyping.
 
 DEFAULT_ENSURERS = {
     re.compile('\w*PATH'): (is_env_path, str_to_env_path, env_path_to_str),
+    re.compile('\w*DIRS'): (is_env_path, str_to_env_path, env_path_to_str),
     'LC_CTYPE': (always_false, locale_convert('LC_CTYPE'), ensure_string),
     'LC_MESSAGES': (always_false, locale_convert('LC_MESSAGES'), ensure_string),
     'LC_COLLATE': (always_false, locale_convert('LC_COLLATE'), ensure_string),


### PR DESCRIPTION
Appearently, some people - like the [freedesktop standards](http://standards.freedesktop.org/basedir-spec/latest/ar01s02.html) - use `DIRS` instead of `PATH`.  A bit odd, but easy to support.