### PR TITLE
Fix error when checking for indentation

### DIFF
--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -79,6 +79,12 @@ def test_bad_indent():
             'x = 1\n')
     assert_raises(SyntaxError, check_parse, code)
 
+def test_indent_with_empty_line():
+    code = ('if True:\n'
+            '\n'
+            '    some_command for_sub_process_mode\n')
+    yield check_parse, code
+
 
 
 if __name__ == '__main__':

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -178,7 +178,8 @@ class Execer(object):
                     last_error_line = last_error_col = -1
                     input = '\n'.join(lines)
                     continue
-                if last_error_line > 1 and lines[idx-1].rstrip()[-1] == ':':
+
+                if last_error_line > 1 and lines[idx-1].rstrip()[-1:] == ':':
                     # catch non-indented blocks and raise error.
                     prev_indent = len(lines[idx-1]) - len(lines[idx-1].lstrip())
                     curr_indent = len(lines[idx]) - len(lines[idx].lstrip())


### PR DESCRIPTION
I have the following portion in my `.xonshrc` file:

    if not pid_exists($SSH_AGENT_PID):
        # Run SSH Agent + Add SSH Keys
        for l in re.split(r'[\n;]', $('ssh-agent')):
            if '=' not in l: continue
            
            parts = l.split('=', 1)
            os.system("SETX {0} {1}".format(*parts))
            builtins.__xonsh_env__[parts[0]] = parts[1]
    
        ssh-add ~/.ssh/id_rsa

And it was throwing an error at the last line saying index was out of range. Figure it was because `lines[idx-1].rstrip()` was an empty string so `lines[idx-1].rstrip()[-1]` was the culprit.

Not sure if this is the best way to fix it and how I can add tests for this.