### PR TITLE
remove logo printing from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ def main():
     if sys.version_info[0] < 3:
         sys.exit('xonsh currently requires Python 3.4+')
     try:
-        print(logo)
+        if '--name' not in sys.argv:
+            print(logo)
     except UnicodeEncodeError:
         pass
     with open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'r') as f:
@@ -132,4 +133,3 @@ logo = """
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
it serves no higher purpose and breaks usage in pipsi

also it wouldn't happen for wheels

addresses #288