### PR TITLE
Update _normpath wrapper to prevent removing a trailing slash

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -9,6 +9,9 @@ import sys
 
 from xonsh.built_ins import iglobpath
 from xonsh.tools import subexpr_from_unbalanced
+from xonsh.tools import ON_WINDOWS
+
+
 
 RE_DASHF = re.compile(r'-F\s+(\w+)')
 RE_ATTR = re.compile(r'(\S+(\..+)*)\.(\w*)$')
@@ -52,11 +55,22 @@ def startswithnorm(x, start, startlow=None):
 
 
 def _normpath(p):
-    # Prevent normpath() from removing initial ‘./’
-    here = os.curdir + os.sep
-    if p.startswith(here):
-        return os.path.join(os.curdir, os.path.normpath(p[len(here):]))
-    return os.path.normpath(p)
+    """ Wraps os.normpath() to avoid removing './' at the beginning 
+        and '/' at the end. On windows it returns a path with forward slashes
+    """   
+    initial_dotslash = p.startswith(os.curdir + os.sep)
+    initial_dotslash |= (os.altsep and p.startswith(os.curdir + os.altsep))
+    p = p.rstrip()
+    trailing_slash = p.endswith(os.sep) 
+    trailing_slash |= (os.altsep and p.endswith(os.altsep))
+    p = os.path.normpath(p)
+    if initial_dotslash:
+        p = os.path.join(os.curdir, p)
+    if trailing_slash:
+        p = os.path.join(p,'')
+#    if ON_WINDOWS:
+#        p = p.replace(os.sep, os.altsep)        
+    return p
 
 
 class Completer(object):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -68,8 +68,6 @@ def _normpath(p):
         p = os.path.join(os.curdir, p)
     if trailing_slash:
         p = os.path.join(p,'')
-#    if ON_WINDOWS:
-#        p = p.replace(os.sep, os.altsep)        
     return p
 
 


### PR DESCRIPTION
This is a small update to _normpath() wrapper function. Right now it removes any trailing slashes (at least on Windows), which is annoying when completing directory names. 

I have been thinking a bit about the path completion in general. On windows, it doesn't work well when there are white spaces in the files names. I tried different things to fix the path_complete(). But the real problem is that the completions are only done from the last white space. I haven't any real fixes for this yet. 