### PR TITLE
First attempt to make a hack for prompt-toolkit coloring

### DIFF
--- a/tests/test_prompt_toolkit_tools.py
+++ b/tests/test_prompt_toolkit_tools.py
@@ -8,14 +8,16 @@ from xonsh.tools import format_prompt_for_prompt_toolkit
 from xonsh.tools import TERM_COLORS
 from xonsh.environ import format_prompt
 
+
+
 def test_format_prompt_for_prompt_toolkit():
-    
     templ = ('>>> {BOLD_BLUE}~/xonsh {WHITE} (main){NO_COLOR}')
     prompt = format_prompt(templ, TERM_COLORS)
     token_names, color_styles, strings = format_prompt_for_prompt_toolkit(prompt)
-    assert_equal(token_names, ['No_Color', 'BOLD_BLUE', 'WHITE', 'NO_COLOR'] )
-    assert_equal(color_styles, ['', 'bold #0000FF', '#FFFFFF', ''] )
+    assert_equal(token_names, ['NO_COLOR', 'BOLD_BLUE', 'WHITE', 'NO_COLOR'])
+    assert_equal(color_styles, ['', 'bold #0000FF', '#FFFFFF', ''])
     assert_equal(strings, ['>>> ', '~/xonsh ', ' (main)', ''])
+
 
 
 if __name__ == '__main__':

--- a/tests/test_prompt_toolkit_tools.py
+++ b/tests/test_prompt_toolkit_tools.py
@@ -4,39 +4,18 @@ from __future__ import unicode_literals, print_function
 import nose
 from nose.tools import assert_equal
 
-from xonsh.tools import FakeChar
 from xonsh.tools import format_prompt_for_prompt_toolkit
-
+from xonsh.tools import TERM_COLORS
+from xonsh.environ import format_prompt
 
 def test_format_prompt_for_prompt_toolkit():
-    cases = [
-        ('root $ ', ['r', 'o', 'o', 't', ' ', '$', ' ']),
-        ('\001\033[0;31m\002>>',
-            [FakeChar('>', prefix='\001\033[0;31m\002'), '>']
-        ),
-        ('\001\033[0;31m\002>>\001\033[0m\002',
-            [FakeChar('>', prefix='\001\033[0;31m\002'),
-             FakeChar('>', suffix='\001\033[0m\002')]
-        ),
-        ('\001\033[0;31m\002>\001\033[0m\002',
-            [FakeChar('>',
-                      prefix='\001\033[0;31m\002',
-                      suffix='\001\033[0m\002')
-            ]
-        ),
-        ('\001\033[0;31m\002> $\001\033[0m\002',
-            [FakeChar('>', prefix='\001\033[0;31m\002'),
-             ' ',
-             FakeChar('$', suffix='\001\033[0m\002')]
-        ),
-        ('\001\033[0;31m\002\001\033[0;32m\002$> \001\033[0m\002',
-            [FakeChar('$', prefix='\001\033[0;31m\002\001\033[0;32m\002'),
-             '>',
-             FakeChar(' ', suffix='\001\033[0m\002')]
-        ),
-        ]
-    for test, ans in cases:
-        yield assert_equal, ''.join(ans), format_prompt_for_prompt_toolkit(test)
+    
+    templ = ('>>> {BOLD_BLUE}~/xonsh {WHITE} (main){NO_COLOR}')
+    prompt = format_prompt(templ, TERM_COLORS)
+    token_names, color_styles, strings = format_prompt_for_prompt_toolkit(prompt)
+    assert_equal(token_names, ['No_Color', 'BOLD_BLUE', 'WHITE', 'NO_COLOR'] )
+    assert_equal(color_styles, ['', 'bold #0000FF', '#FFFFFF', ''] )
+    assert_equal(strings, ['>>> ', '~/xonsh ', ' (main)', ''])
 
 
 if __name__ == '__main__':

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -6,6 +6,8 @@ from warnings import warn
 from prompt_toolkit.shortcuts import get_input, create_eventloop
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from pygments.token import Token
+from pygments.style import Style
+from pygments.styles.default import DefaultStyle
 
 from xonsh.base_shell import BaseShell
 from xonsh.pyghooks import XonshLexer
@@ -40,23 +42,6 @@ def teardown_history(history):
         warn('do not have write permissions for ' + hfile, RuntimeWarning)
 
 
-def get_user_input(get_prompt_tokens,
-                   history=None,
-                   lexer=None,
-                   key_bindings_registry=None,
-                   completer=None):
-    """Customized function that mostly mimics promp_toolkit's get_input.
-
-    Main difference between this and prompt_toolkit's get_input() is that it
-    allows to pass get_tokens() function instead of text prompt.
-    """
-    return get_input(
-        lexer=lexer,
-        completer=completer,
-        history=history,
-        get_prompt_tokens=get_prompt_tokens,
-        key_bindings_registry=key_bindings_registry)
-
 
 class PromptToolkitShell(BaseShell):
     """The xonsh shell."""
@@ -78,8 +63,10 @@ class PromptToolkitShell(BaseShell):
             print(intro)
         while not builtins.__xonsh_exit__:
             try:
-                line = get_user_input(
-                    get_prompt_tokens=self._get_prompt_tokens(),
+                token_func, Style_cls = self._get_prompt_tokens_and_style()
+                line = get_input(
+                    get_prompt_tokens=token_func,
+                    style = Style_cls,
                     completer=self.pt_completer,
                     history=self.history,
                     key_bindings_registry=self.key_bindings_manager.registry,
@@ -94,12 +81,24 @@ class PromptToolkitShell(BaseShell):
             except EOFError:
                 break
 
-    def _get_prompt_tokens(self):
+    def _get_prompt_tokens_and_style(self):
         """Returns function to pass as prompt to prompt_toolkit."""
+        colors, strings = format_prompt_for_prompt_toolkit(self.prompt)
+        tokens = [getattr(Token,'X'+str(i)) for i,_ in enumerate(colors)]
         def get_tokens(cli):
-            return [(Token.Prompt,
-                     format_prompt_for_prompt_toolkit(self.prompt))]
-        return get_tokens
+            return list(zip(tokens, strings))
+        class CustomStyle(Style):
+            styles = {
+                Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
+                Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
+                Token.Menu.Completions.ProgressButton: 'bg:#003333',
+                Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
+            }
+            styles.update(DefaultStyle.styles)
+            #Lastly we add the prompt custom styles
+            styles.update({t: s for (t,s) in zip(tokens, colors)} )
+        return get_tokens, CustomStyle
+
 
     @property
     def lexer(self):

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -81,10 +81,13 @@ class PromptToolkitShell(BaseShell):
             except EOFError:
                 break
 
+
+
     def _get_prompt_tokens_and_style(self):
         """Returns function to pass as prompt to prompt_toolkit."""
-        colors, strings = format_prompt_for_prompt_toolkit(self.prompt)
-        tokens = [getattr(Token,'X'+str(i)) for i,_ in enumerate(colors)]
+        token_names, cstyles, strings = format_prompt_for_prompt_toolkit(self.prompt)
+        
+        tokens = [getattr(Token, n) for n in token_names]
         def get_tokens(cli):
             return list(zip(tokens, strings))
         class CustomStyle(Style):
@@ -94,10 +97,13 @@ class PromptToolkitShell(BaseShell):
                 Token.Menu.Completions.ProgressButton: 'bg:#003333',
                 Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
             }
-            styles.update(DefaultStyle.styles)
-            #Lastly we add the prompt custom styles
-            styles.update({t: s for (t,s) in zip(tokens, colors)} )
+            # update with the prompt styles
+            styles.update({t: s for (t,s) in zip(tokens, cstyles)} )
+            # Update with with any user styles
+            userstyle = builtins.__xonsh_env__.get('PROMPT_TOOLKIT_STYLES', {})
+            styles.update(userstyle)
         return get_tokens, CustomStyle
+
 
 
     @property

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -42,7 +42,6 @@ def teardown_history(history):
         warn('do not have write permissions for ' + hfile, RuntimeWarning)
 
 
-
 class PromptToolkitShell(BaseShell):
     """The xonsh shell."""
 
@@ -63,10 +62,10 @@ class PromptToolkitShell(BaseShell):
             print(intro)
         while not builtins.__xonsh_exit__:
             try:
-                token_func, Style_cls = self._get_prompt_tokens_and_style()
+                token_func, style_cls = self._get_prompt_tokens_and_style()
                 line = get_input(
                     get_prompt_tokens=token_func,
-                    style = Style_cls,
+                    style=style_cls,
                     completer=self.pt_completer,
                     history=self.history,
                     key_bindings_registry=self.key_bindings_manager.registry,
@@ -81,15 +80,14 @@ class PromptToolkitShell(BaseShell):
             except EOFError:
                 break
 
-
-
     def _get_prompt_tokens_and_style(self):
         """Returns function to pass as prompt to prompt_toolkit."""
         token_names, cstyles, strings = format_prompt_for_prompt_toolkit(self.prompt)
-        
         tokens = [getattr(Token, n) for n in token_names]
+
         def get_tokens(cli):
             return list(zip(tokens, strings))
+
         class CustomStyle(Style):
             styles = {
                 Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
@@ -98,13 +96,12 @@ class PromptToolkitShell(BaseShell):
                 Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
             }
             # update with the prompt styles
-            styles.update({t: s for (t,s) in zip(tokens, cstyles)} )
+            styles.update({t: s for (t, s) in zip(tokens, cstyles)})
             # Update with with any user styles
             userstyle = builtins.__xonsh_env__.get('PROMPT_TOOLKIT_STYLES', {})
             styles.update(userstyle)
+
         return get_tokens, CustomStyle
-
-
 
     @property
     def lexer(self):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -550,7 +550,7 @@ def get_xonsh_color_names(color_code):
     try:
         return next(k for k, v in TERM_COLORS.items() if v == color_code)
     except StopIteration:
-        return 'No_Color'
+        return 'NO_COLOR'
 
 
 def format_prompt_for_prompt_toolkit(prompt):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -519,31 +519,32 @@ class FakeChar(str):
 RE_HIDDEN_MAX = re.compile('(\001.*?\002)+')
 
 
-_PT_COLORS={'BLACK': '#000000', 
-            'RED': '#FF0000',
-            'GREEN': '#008000',
-            'YELLOW':'#FFFF00', 
-            'BLUE'  :'#0000FF', 
-            'PURPLE':'#0000FF',
-            'CYAN':'#00FFFF',
-            'WHITE':'#FFFFFF'}
+_PT_COLORS = {'BLACK': '#000000',
+              'RED': '#FF0000',
+              'GREEN': '#008000',
+              'YELLOW': '#FFFF00',
+              'BLUE': '#0000FF',
+              'PURPLE': '#0000FF',
+              'CYAN': '#00FFFF',
+              'WHITE': '#FFFFFF'}
 
 _PT_STYLE = {'BOLD': 'bold',
-             'UNDERLINE':'underline',
-             'INTENSE':'italic'}
+             'UNDERLINE': 'underline',
+             'INTENSE': 'italic'}
 
 
 def _make_style(color_name):
     """ Convert color names to pygments styles codes """
     style = []
-    for k,v in _PT_STYLE.items():
-        if k in color_name: 
+    for k, v in _PT_STYLE.items():
+        if k in color_name:
             style.append(v)
-    for k,v in _PT_COLORS.items():
+    for k, v in _PT_COLORS.items():
         if k in color_name:
             style.append(v)
     return ' '.join(style)
-    
+
+
 def get_xonsh_color_names(color_code):
     """ Makes a reverse lookup in TERM_COLORS  """
     try:
@@ -552,21 +553,18 @@ def get_xonsh_color_names(color_code):
         return 'No_Color'
 
 
-     
 def format_prompt_for_prompt_toolkit(prompt):
     """Converts a prompt with color codes to a pygments style and tokens
     """
     parts = RE_HIDDEN_MAX.split(prompt)
-    #ensure that parts is [colorcode, string, colorcode, string,...]
-    if parts and parts[0] is '': 
+    # ensure that parts is [colorcode, string, colorcode, string,...]
+    if parts and len(parts[0]) == 0:
         parts = parts[1:]
     else:
-        parts.insert(0,'')
-    if len(parts)%2 != 0:
+        parts.insert(0, '')
+    if len(parts) % 2 != 0:
         parts.append()
     strings = parts[1::2]
-    token_names = [get_xonsh_color_names(c) for c in parts[::2] ]
+    token_names = [get_xonsh_color_names(c) for c in parts[::2]]
     cstyles = [_make_style(c) for c in token_names]
     return token_names, cstyles, strings
-    
-


### PR DESCRIPTION
This may not be ready for merging yet.

I made an attempt to implement the suggestions from @jonathanslenders to get coloring working with prompt toolkit. Some part of it is quite a hack, but it works without changing the current way prompt colors are set in xonsh. So it basically strips the color codes from the prompt string and converts them to pygments tokens. It makes a reversed lookup in the TERM_COLORS dictionary (that is the hack-ish part) 

The good thing about this setup is that it only recomputes the prompt once for every input. That seems to speed things up quite a lot. 

I still haven't found out how to reserve the lower lines the terminal. So the prompt still jumps up/down when the completer list pops up (https://github.com/scopatz/xonsh/issues/362). 



