### PR TITLE
Allow environment variables in PROMPT

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -950,9 +950,16 @@ For example:
     2 ~ $
     8 ~ $
 
-If a function in ``$FORMATTER_DICT`` returns ``None``, the ``None`` will be 
+If a function in ``$FORMATTER_DICT`` returns ``None``, the ``None`` will be
 interpreted as an empty string.
 
+Environment variables and functions are also available with the ``$``
+prefix.  For example:
+
+.. code-block:: xonshcon
+
+    snail@home ~ $ $PROMPT = "{$LANG} >"
+    en_US.utf8 >
 
 Executing Commands and Scripts
 ==============================

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -421,13 +421,16 @@ def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
         fmtter = formatter_dict
     included_names = set(i[1] for i in _FORMATTER.parse(template))
     fmt = {}
-    for d in (builtins.__xonsh_env__, fmtter):
-        for k, v in d.items():
-            if k not in included_names:
-                continue
-            val = v() if callable(v) else v
-            val = '' if val is None else val
-            fmt[k] = val
+    for name in included_names:
+        if name is None:
+            continue
+        if name.startswith('$'):
+            v = builtins.__xonsh_env__[name[1:]]
+        else:
+            v = fmtter[name]
+        val = v() if callable(v) else v
+        val = '' if val is None else val
+        fmt[name] = val
     return template.format(**fmt)
 
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -421,12 +421,13 @@ def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
         fmtter = formatter_dict
     included_names = set(i[1] for i in _FORMATTER.parse(template))
     fmt = {}
-    for k, v in fmtter.items():
-        if k not in included_names:
-            continue
-        val = v() if callable(v) else v
-        val = '' if val is None else val
-        fmt[k] = val
+    for d in (builtins.__xonsh_env__, fmtter):
+        for k, v in d.items():
+            if k not in included_names:
+                continue
+            val = v() if callable(v) else v
+            val = '' if val is None else val
+            fmt[k] = val
     return template.format(**fmt)
 
 


### PR DESCRIPTION
xonsh rocks.

Coming over from zsh, I found it handy to display environment variables in a PROMPT.  For example, to print out the current pyenv by displaying `$PYENV_VERSION`.

This is a simple hack to allow that.  Alternatively, we could treat only `${FOO}` as environment variables, but that would require writing a simple parser for the `PROMPT` language.

Obviously this needs a test, but I thought I'd get some feedback on the concept first. 