### PR TITLE
Display completions in columns.

### DIFF
--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -69,6 +69,7 @@ class PromptToolkitShell(BaseShell):
                     completer=self.pt_completer,
                     history=self.history,
                     key_bindings_registry=self.key_bindings_manager.registry,
+                    display_completions_in_columns=True,
                     lexer=self.lexer)
                 if not line:
                     self.emptyline()


### PR DESCRIPTION
Feel free to merge this or not.

This will show the completions in multiple columns instead of one dropdown menu.
I think it makes sense for a shell, but maybe you want to have this configurable.