### PR TITLE
fix to actually quit on certain signals

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -44,6 +44,8 @@ def resetting_signal_handle(sig, f):
     def newh(s=None, frame=None):
         f(s, frame)
         signal.signal(sig, oldh)
+        if sig != 0:
+            sys.exit(sig)
     signal.signal(sig, newh)
 
 


### PR DESCRIPTION
This is a critical bug fix that makes sure that the if xonsh receives non-SIGINT signals, that it will actually exit.  This is blocking v0.2.  It is only two lines of code so hopefully it can be reviewed quickly :)