### PR TITLE
aliases: make bash_aliases() more robust

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1,10 +1,8 @@
 """Aliases for the xonsh shell."""
 import os
-import sys
 import shlex
 import builtins
 import subprocess
-import datetime
 from warnings import warn
 from argparse import ArgumentParser
 
@@ -75,6 +73,7 @@ def xexec(args, stdin=None):
 
 _BANG_N_PARSER = None
 
+
 def bang_n(args, stdin=None):
     """Re-runs the nth command as specified in the argument."""
     global _BANG_N_PARSER
@@ -109,7 +108,8 @@ def bash_aliases():
                                     universal_newlines=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
         s = ''
-    items = [line.split('=', 1) for line in s.splitlines() if line.startswith('alias ') and '=' in line]
+    items = [line.split('=', 1) for line in s.splitlines()
+             if line.startswith('alias ') and '=' in line]
     aliases = {}
     for key, value in items:
         try:
@@ -185,5 +185,3 @@ elif ON_MAC:
 else:
     DEFAULT_ALIASES['grep'] = ['grep', '--color=auto']
     DEFAULT_ALIASES['ls'] = ['ls', '--color=auto', '-v']
-
-

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -104,7 +104,7 @@ def bang_bang(args, stdin=None):
 def bash_aliases():
     """Computes a dictionary of aliases based on Bash's aliases."""
     try:
-        s = subprocess.check_output(['bash', '-i', '-l', '-c', 'alias'],
+        s = subprocess.check_output(['bash', '-i', '-c', 'alias'],
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True)
     except (subprocess.CalledProcessError, FileNotFoundError):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -104,13 +104,12 @@ def bang_bang(args, stdin=None):
 def bash_aliases():
     """Computes a dictionary of aliases based on Bash's aliases."""
     try:
-        s = subprocess.check_output(['bash', '-i', '-l'],
-                                    input='alias',
+        s = subprocess.check_output(['bash', '-i', '-l', '-c', 'alias'],
                                     stderr=subprocess.PIPE,
                                     universal_newlines=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
         s = ''
-    items = [line.split('=', 1) for line in s.splitlines() if '=' in line]
+    items = [line.split('=', 1) for line in s.splitlines() if line.startswith('alias ') and '=' in line]
     aliases = {}
     for key, value in items:
         try:


### PR DESCRIPTION
* Call bash with `-c alias` rather than passing `alias` through stdin, to avoid `$PROMPT_COMMAND` giving us garbage.
* Check each alias read in is really an alias, to make doubly-sure we don't get garbage in our aliases.

We should have a way of disabling the bash alias extraction altogether though. After all, not everyone uses bash as their main shell, and the idea of a shell calling another shell to automatically pull in aliases scares me.

Fixes: #204