### PR TITLE
Environment Defaults

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -11,6 +11,9 @@ applicable.
     * - variable
       - default
       - description
+    * - ANSICON
+      - No default set
+      - This is used on Windows to set the title, if available.
     * - BASH_COMPLETIONS
       - Normally this is ``('/etc/bash_completion', 
                             '/usr/share/bash-completion/completions/git')``
@@ -70,6 +73,11 @@ applicable.
       - An error threshold. If the Levenshtein distance between the entered command and 
         a valid command is less than this value, the valid command will be offered as a 
         suggestion.
+    * - TERM
+      - No default
+      - TERM is sometimes set by the terminal emulator. This is used (when valid)
+        to determine whether or not to set the title. Users shouldn't need to 
+        set this themselves.
     * - TITLE
       - xonsh.environ.DEFAULT_TITLE
       - The title text for the window in which xonsh is running. Formatted in the same 

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -11,60 +11,37 @@ applicable.
     * - variable
       - default
       - description
-    * - PROMPT
-      - xonsh.environ.DEFAULT_PROMPT  
-      - The prompt text.  May contain keyword arguments which are auto-formatted,
-        see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
-    * - MULTILINE_PROMPT
-      - ``'.'``
-      - Prompt text for 2nd+ lines of input, may be str or function which returns a str.
-    * - TITLE
-      - xonsh.environ.DEFAULT_TITLE
-      - The title text for the window in which xonsh is running. Formatted in the same 
-        manner as PROMPT, 
-        see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - BASH_COMPLETIONS
+      - Normally this is ``('/etc/bash_completion', 
+                            '/usr/share/bash-completion/completions/git')``
+        but on Mac is ``'/usr/local/etc/bash_completion',
+                        '/opt/local/etc/profile.d/bash_completion.sh')``.
+      - This is a list (or tuple) of strings that specifies where the BASH completion 
+        files may be found. The default values are platform dependent, but sane. 
+        To specify an alternate list, do so in the run control file.
+    * - CASE_SENSITIVE_COMPLETIONS
+      - ``True`` on Linux, otherwise ``False``
+      - Sets whether completions should be case sensitive or case insensitive.
+    * - CDPATH
+      - ``[]``
+      - A list of paths to be used as roots for a ``cd``, breaking compatibility with 
+        bash, xonsh always prefer an existing relative path.
+    * - FORCE_POSIX_PATHS
+      - Not defined
+      - Forces forward slashes (``/``) on Windows systems when using auto completion if 
+        set to anything truthy.
     * - FORMATTER_DICT
       - xonsh.environ.FORMATTER_DICT  
       - Dictionary containing variables to be used when formatting PROMPT and TITLE 
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
-    * - XONSHRC
-      - ``'~/.xonshrc'``
-      - Location of run control file.
-    * - XONSH_HISTORY_SIZE
-      - ``(8128, 'commands')`` or ``'8128 commands'``           
-      - Value and units tuple that sets the size of history after garbage collection. 
-        Canonical units are ``'commands'`` for the number of past commands executed, 
-        ``'files'`` for the number of history files to keep, ``'s'`` for the number of
-        seconds in the past that are allowed, and ``'b'`` for the number of bytes that 
-        are allowed for history to consume. Common abbreviations, such as ``6 months``
-        or ``1 GB`` are also allowed.
-    * - XONSH_HISTORY_FILE
-      - ``'~/.xonsh_history'``
-      - Location of history file (deprecated).
-    * - XONSH_STORE_STDOUT 
-      - ``False``
-      - Whether or not to store the stdout and stderr streams in the history files.
-    * - XONSH_INTERACTIVE
-      - 
-      - ``True`` if xonsh is running interactively, and ``False`` otherwise.
-    * - BASH_COMPLETIONS
-      - ``[] or ['/etc/...']``
-      - This is a list of strings that specifies where the BASH completion files may 
-        be found. The default values are platform dependent, but sane.  To specify an 
-        alternate list, do so in the run control file.
-    * - SUGGEST_COMMANDS
-      - ``True``
-      - When a user types an invalid command, xonsh will try to offer suggestions of 
-        similar valid commands if this is ``True``.
-    * - SUGGEST_THRESHOLD
-      - ``3``
-      - An error threshold. If the Levenshtein distance between the entered command and 
-        a valid command is less than this value, the valid command will be offered as a 
-        suggestion.
-    * - SUGGEST_MAX_NUM
-      - ``5``
-      - xonsh will show at most this many suggestions in response to an invalid command.
-        If negative, there is no limit to how many suggestions are shown.
+    * - MULTILINE_PROMPT
+      - ``'.'``
+      - Prompt text for 2nd+ lines of input, may be str or function which returns 
+        a str.
+    * - PROMPT
+      - xonsh.environ.DEFAULT_PROMPT  
+      - The prompt text.  May contain keyword arguments which are auto-formatted,
+        see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
     * - SHELL_TYPE
       - ``'readline'``
       - Which shell is used. Currently two shell types are supported: ``'readline'`` that
@@ -74,27 +51,53 @@ applicable.
         `prompt_toolkit <https://github.com/jonathanslenders/python-prompt-toolkit>`_
         library installed. To specify which shell should be used, do so in the run 
         control file.
-    * - CDPATH
-      - ``[]``
-      - A list of paths to be used as roots for a ``cd``, breaking compatibility with 
-        bash, xonsh always prefer an existing relative path.
+    * - SUGGEST_COMMANDS
+      - ``True``
+      - When a user types an invalid command, xonsh will try to offer suggestions of 
+        similar valid commands if this is ``True``.
+    * - SUGGEST_MAX_NUM
+      - ``5``
+      - xonsh will show at most this many suggestions in response to an invalid command.
+        If negative, there is no limit to how many suggestions are shown.
+    * - SUGGEST_THRESHOLD
+      - ``3``
+      - An error threshold. If the Levenshtein distance between the entered command and 
+        a valid command is less than this value, the valid command will be offered as a 
+        suggestion.
+    * - TITLE
+      - xonsh.environ.DEFAULT_TITLE
+      - The title text for the window in which xonsh is running. Formatted in the same 
+        manner as PROMPT, 
+        see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - XONSHRC
+      - ``'~/.xonshrc'``
+      - Location of run control file.
+    * - XONSH_CONFIG_DIR
+      - ``$XDG_CONFIG_HOME/xonsh``
+      - This is location where xonsh configuration information is stored.
+    * - XONSH_DATA_DIR
+      - ``$XDG_DATA_HOME/xonsh``
+      - This is the location where xonsh data files are stored, such as history.
+    * - XONSH_HISTORY_FILE
+      - ``'~/.xonsh_history'``
+      - Location of history file (deprecated).
+    * - XONSH_HISTORY_SIZE
+      - ``(8128, 'commands')`` or ``'8128 commands'``           
+      - Value and units tuple that sets the size of history after garbage collection. 
+        Canonical units are ``'commands'`` for the number of past commands executed, 
+        ``'files'`` for the number of history files to keep, ``'s'`` for the number of
+        seconds in the past that are allowed, and ``'b'`` for the number of bytes that 
+        are allowed for history to consume. Common abbreviations, such as ``6 months``
+        or ``1 GB`` are also allowed.
+    * - XONSH_INTERACTIVE
+      - 
+      - ``True`` if xonsh is running interactively, and ``False`` otherwise.
     * - XONSH_SHOW_TRACEBACK
       - Not defined
       - Controls if a traceback is shown exceptions occur in the shell. Set ``'True'`` 
         to always show or ``'False'`` to always hide. If undefined then traceback is 
         hidden but a notice is shown on how to enable the traceback.
-    * - CASE_SENSITIVE_COMPLETIONS
-      - ``True`` on Linux, otherwise ``False``
-      - Sets whether completions should be case sensitive or case insensitive.
-    * - FORCE_POSIX_PATHS
-      - Not defined
-      - Forces forward slashes (``/``) on Windows systems when using auto completion if 
-        set to anything truthy.
-    * - XONSH_DATA_DIR
-      - ``$XDG_DATA_HOME/xonsh``
-      - This is the location where xonsh data files are stored, such as history.
-    * - XONSH_CONFIG_DIR
-      - ``$XDG_CONFIG_HOME/xonsh``
-      - This is location where xonsh configuration information is stored.
-
+    * - XONSH_STORE_STDOUT 
+      - ``False``
+      - Whether or not to store the stdout and stderr streams in the history files.
 

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -27,17 +27,23 @@ applicable.
       - A list of paths to be used as roots for a ``cd``, breaking compatibility with 
         bash, xonsh always prefer an existing relative path.
     * - FORCE_POSIX_PATHS
-      - Not defined
+      - ``False``
       - Forces forward slashes (``/``) on Windows systems when using auto completion if 
         set to anything truthy.
     * - FORMATTER_DICT
       - xonsh.environ.FORMATTER_DICT  
       - Dictionary containing variables to be used when formatting PROMPT and TITLE 
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - INDENT
+      - ``'    '``
+      - Indentation string for multiline input
     * - MULTILINE_PROMPT
       - ``'.'``
       - Prompt text for 2nd+ lines of input, may be str or function which returns 
         a str.
+    * - PATH
+      - ``()``
+      - List of strings representing where to look for executables.
     * - PROMPT
       - xonsh.environ.DEFAULT_PROMPT  
       - The prompt text.  May contain keyword arguments which are auto-formatted,
@@ -69,6 +75,14 @@ applicable.
       - The title text for the window in which xonsh is running. Formatted in the same 
         manner as PROMPT, 
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - XDG_CONFIG_HOME
+      - ``~/.config``
+      - Open desktop standard configuration home dir. This is the same default as
+        used in the standard.
+    * - XDG_DATA_HOME
+      - ``~/.local/share``
+      - Open desktop standard data home dir. This is the same default as used
+        in the standard.
     * - XONSHRC
       - ``'~/.xonshrc'``
       - Location of run control file.
@@ -93,9 +107,9 @@ applicable.
       - 
       - ``True`` if xonsh is running interactively, and ``False`` otherwise.
     * - XONSH_SHOW_TRACEBACK
-      - Not defined
-      - Controls if a traceback is shown exceptions occur in the shell. Set ``'True'`` 
-        to always show or ``'False'`` to always hide. If undefined then traceback is 
+      - ``False`` but not set
+      - Controls if a traceback is shown exceptions occur in the shell. Set ``True`` 
+        to always show or ``False`` to always hide. If undefined then traceback is 
         hidden but a notice is shown on how to enable the traceback.
     * - XONSH_STORE_STDOUT 
       - ``False``

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -14,6 +14,9 @@ applicable.
     * - ANSICON
       - No default set
       - This is used on Windows to set the title, if available.
+    * - AUTO_PUSHD
+      - ``False``
+      - Flag for automatically pushing directorties onto the directory stack.
     * - BASH_COMPLETIONS
       - Normally this is ``('/etc/bash_completion', 
                             '/usr/share/bash-completion/completions/git')``
@@ -29,6 +32,9 @@ applicable.
       - ``[]``
       - A list of paths to be used as roots for a ``cd``, breaking compatibility with 
         bash, xonsh always prefer an existing relative path.
+    * - DIRSTACK_SIZE
+      - ``20``
+      - Maximum size of the directory stack.
     * - FORCE_POSIX_PATHS
       - ``False``
       - Forces forward slashes (``/``) on Windows systems when using auto completion if 
@@ -44,13 +50,29 @@ applicable.
       - ``'.'``
       - Prompt text for 2nd+ lines of input, may be str or function which returns 
         a str.
+    * - OLDPWD
+      - No default
+      - Used to represent a previous present working directory.
     * - PATH
       - ``()``
       - List of strings representing where to look for executables.
+    * - PATHEXT
+      - ``()``
+      - List of strings for filtering valid exeutables by.
     * - PROMPT
       - xonsh.environ.DEFAULT_PROMPT  
       - The prompt text.  May contain keyword arguments which are auto-formatted,
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - PROMPT_TOOLKIT_STYLES
+      - ``None``
+      - This is a mapping of user-specified styles for prompt-toolkit. See the 
+        prompt-toolkit documentation for more details. If None, this is skipped.
+    * - PUSHD_MINUS
+      - ``False``
+      - Flag for directory pushing functionality. False is the normal behaviour.
+    * - PUSHD_SILENT
+      - ``False``
+      - Whether or not to supress directory stack manipulation output.
     * - SHELL_TYPE
       - ``'readline'``
       - Which shell is used. Currently two shell types are supported: ``'readline'`` that

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -119,7 +119,7 @@ class BaseShell(object):
             return
         hist = builtins.__xonsh_history__
         ts1 = None
-        tee = Tee() if builtins.__xonsh_env__.get('XONSH_STORE_STDOUT', False) \
+        tee = Tee() if builtins.__xonsh_env__.get('XONSH_STORE_STDOUT') \
                     else io.StringIO()
         try:
             ts0 = time.time()

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -181,9 +181,8 @@ class BaseShell(object):
         term = env.get('TERM', None)
         if term is None or term == 'linux':
             return
-        if 'TITLE' in env:
-            t = env['TITLE']
-        else:
+        t = env.get('TITLE')
+        if t is None:
             return
         t = format_prompt(t)
         if ON_WINDOWS and 'ANSICON' not in env:
@@ -204,14 +203,11 @@ class BaseShell(object):
                     self.mlprompt = '<multiline prompt error> '
             return self.mlprompt
         env = builtins.__xonsh_env__
-        if 'PROMPT' in env:
-            p = env['PROMPT']
-            try:
-                p = format_prompt(p)
-            except Exception:
-                print_exception()
-        else:
-            p = "set '$PROMPT = ...' $ "
+        p = env.get('PROMPT')
+        try:
+            p = format_prompt(p)
+        except Exception:
+            print_exception()
         self.settitle()
         return p
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -268,20 +268,17 @@ RE_SHEBANG = re.compile(r'#![ \t]*(.+?)$')
 def _get_runnable_name(fname):
     if os.path.isfile(fname) and fname != os.path.basename(fname):
         return fname
-    for d in builtins.__xonsh_env__['PATH']:
+    for d in builtins.__xonsh_env__.get('PATH'):
         if os.path.isdir(d):
             files = os.listdir(d)
-
             if ON_WINDOWS:
-                PATHEXT = builtins.__xonsh_env__.get('PATHEXT', [])
+                PATHEXT = builtins.__xonsh_env__.get('PATHEXT')
                 for dirfile in files:
                     froot, ext = os.path.splitext(dirfile)
                     if fname == froot and ext.upper() in PATHEXT:
                         return os.path.join(d, dirfile)
-
             if fname in files:
                 return os.path.join(d, fname)
-
     return None
 
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -38,10 +38,6 @@ COMP_CWORD={n}
 for ((i=0;i<${{#COMPREPLY[*]}};i++)) do echo ${{COMPREPLY[i]}}; done
 """
 
-
-get_env = lambda name, default=None: builtins.__xonsh_env__.get(name, default)
-
-
 def startswithlow(x, start, startlow=None):
     """True if x starts with a string or its lowercase version. The lowercase
     version may be optionally be provided.
@@ -73,7 +69,7 @@ def _normpath(p):
     if trailing_slash:
         p = os.path.join(p, '')
 
-    if ON_WINDOWS and get_env('FORCE_POSIX_PATHS', False):
+    if ON_WINDOWS and builtins.__xonsh_env__.get('FORCE_POSIX_PATHS'):
         p = p.replace(os.sep, os.altsep)
 
     return p
@@ -125,7 +121,7 @@ class Completer(object):
         ctx = ctx or {}
         prefixlow = prefix.lower()
         cmd = line.split(' ', 1)[0]
-        csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+        csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         startswither = startswithnorm if csc else startswithlow
         if begidx == 0:
             # the first thing we're typing; could be python or subprocess, so
@@ -172,7 +168,7 @@ class Completer(object):
 
     def _add_env(self, paths, prefix):
         if prefix.startswith('$'):
-            csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+            csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
             startswither = startswithnorm if csc else startswithlow
             key = prefix[1:]
             keylow = key.lower()
@@ -186,8 +182,9 @@ class Completer(object):
 
     def _add_cdpaths(self, paths, prefix):
         """Completes current prefix using CDPATH"""
-        csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
-        for cdp in get_env("CDPATH", []):
+        env = builtins.__xonsh_env__
+        csc = env.get('CASE_SENSITIVE_COMPLETIONS')
+        for cdp in env.get('CDPATH'):
             test_glob = os.path.join(cdp, prefix) + '*'
             for s in iglobpath(test_glob, ignore_case=(not csc)):
                 if os.path.isdir(s):
@@ -197,7 +194,7 @@ class Completer(object):
         """Completes a command name based on what is on the $PATH"""
         space = ' '
         cmdlow = cmd.lower()
-        csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+        csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         startswither = startswithnorm if csc else startswithlow
         return {s + space
                 for s in self._all_commands()
@@ -207,7 +204,7 @@ class Completer(object):
         """Completes a name of a module to import."""
         prefixlow = prefix.lower()
         modules = set(sys.modules.keys())
-        csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+        csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         startswither = startswithnorm if csc else startswithlow
         return {s for s in modules if startswither(s, prefix, prefixlow)}
 
@@ -217,7 +214,7 @@ class Completer(object):
         slash = '/'
         tilde = '~'
         paths = set()
-        csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+        csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         if prefix.startswith("'") or prefix.startswith('"'):
             prefix = prefix[1:]
         for s in iglobpath(prefix + '*', ignore_case=(not csc)):
@@ -279,9 +276,10 @@ class Completer(object):
 
     def _source_completions(self):
         srcs = []
-        for f in builtins.__xonsh_env__.get('BASH_COMPLETIONS', ()):
+        for f in builtins.__xonsh_env__.get('BASH_COMPLETIONS'):
             if os.path.isfile(f):
-                if ON_WINDOWS:  # We need to "Unixify" Windows paths for Bash to understand
+                # We need to "Unixify" Windows paths for Bash to understand
+                if ON_WINDOWS:  
                     f = RE_WIN_DRIVE.sub(lambda m: '/{0}/'.format(m.group(1).lower()), f).replace('\\', '/')
                 srcs.append('source ' + f)
         return srcs
@@ -346,7 +344,7 @@ class Completer(object):
         if len(attr) == 0:
             opts = [o for o in opts if not o.startswith('_')]
         else:
-            csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+            csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
             startswither = startswithnorm if csc else startswithlow
             attrlow = attr.lower()
             opts = [o for o in opts if startswither(o, attrlow)]
@@ -407,7 +405,7 @@ class ManCompleter(object):
 
     def option_complete(self, prefix, cmd):
         """Completes an option name, basing on content of man page."""
-        csc = get_env('CASE_SENSITIVE_COMPLETIONS', True)
+        csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         startswither = startswithnorm if csc else startswithlow
         if cmd not in self._options.keys():
             try:

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -6,10 +6,7 @@ from glob import iglob
 from argparse import ArgumentParser
 
 DIRSTACK = []
-"""
-A list containing the currently remembered directories.
-"""
-
+"""A list containing the currently remembered directories."""
 
 def _get_cwd():
     try:
@@ -42,7 +39,7 @@ def _try_cdpath(apath):
     # in bash a full $ cd ./xonsh is needed.
     # In xonsh a relative folder is allways preferred.
     env = builtins.__xonsh_env__
-    cdpaths = env.get('CDPATH', [])
+    cdpaths = env.get('CDPATH')
     for cdp in cdpaths:
         for cdpath_prefixed_path in iglob(os.path.join(cdp, apath)):
             return cdpath_prefixed_path
@@ -92,15 +89,14 @@ def cd(args, stdin=None):
     if not os.path.isdir(d):
         return '', 'cd: {0} is not a directory\n'.format(d)
     # now, push the directory onto the dirstack if AUTO_PUSHD is set
-    if cwd is not None and env.get('AUTO_PUSHD', False):
+    if cwd is not None and env.get('AUTO_PUSHD'):
         pushd(['-n', '-q', cwd])
     _change_working_directory(os.path.abspath(d))
     return None, None
 
 
 def pushd(args, stdin=None):
-    """
-    xonsh command: pushd
+    """xonsh command: pushd
 
     Adds a directory to the top of the directory stack, or rotates the stack,
     making the new top of the stack the current working directory.
@@ -165,11 +161,11 @@ def pushd(args, stdin=None):
         else:
             DIRSTACK.insert(0, os.path.expanduser(os.path.abspath(new_pwd)))
 
-    maxsize = env.get('DIRSTACK_SIZE', 20)
+    maxsize = env.get('DIRSTACK_SIZE')
     if len(DIRSTACK) > maxsize:
         DIRSTACK = DIRSTACK[:maxsize]
 
-    if not args.quiet and not env.get('PUSHD_SILENT', False):
+    if not args.quiet and not env.get('PUSHD_SILENT'):
         return dirs([], None)
 
     return None, None
@@ -190,7 +186,7 @@ def popd(args, stdin=None):
 
     env = builtins.__xonsh_env__
 
-    if env.get('PUSHD_MINUS', False):
+    if env.get('PUSHD_MINUS'):
         BACKWARD = '-'
         FORWARD = '+'
     else:
@@ -238,15 +234,14 @@ def popd(args, stdin=None):
         if args.cd:
             _change_working_directory(os.path.abspath(new_pwd))
 
-    if not args.quiet and not env.get('PUSHD_SILENT', False):
+    if not args.quiet and not env.get('PUSHD_SILENT'):
         return dirs([], None)
 
     return None, None
 
 
 def dirs(args, stdin=None):
-    """
-    xonsh command: dirs
+    """xonsh command: dirs
 
     Displays the list of currently remembered directories.  Can also be used
     to clear the directory stack.
@@ -261,7 +256,7 @@ def dirs(args, stdin=None):
 
     env = builtins.__xonsh_env__
 
-    if env.get('PUSHD_MINUS', False):
+    if env.get('PUSHD_MINUS'):
         BACKWARD = '-'
         FORWARD = '+'
     else:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -98,11 +98,14 @@ def xonsh_config_dir(env):
 # to set them they have to do a copy and write them to the environment.
 # try to keep this sorted.
 DEFAULT_VALUES = {
+    'AUTO_PUSHD': False,
     'BASH_COMPLETIONS': ('/usr/local/etc/bash_completion',
                          '/opt/local/etc/profile.d/bash_completion.sh') if ON_MAC \
                         else ('/etc/bash_completion', 
                               '/usr/share/bash-completion/completions/git'),
     'CASE_SENSITIVE_COMPLETIONS': ON_LINUX,
+    'CDPATH': (),
+    'DIRSTACK_SIZE': 20,
     'FORCE_POSIX_PATHS': False,
     'INDENT': '    ',
     'LC_CTYPE': locale.setlocale(locale.LC_CTYPE),
@@ -112,7 +115,11 @@ DEFAULT_VALUES = {
     'LC_NUMERIC': locale.setlocale(locale.LC_NUMERIC),
     'MULTILINE_PROMPT': '.',
     'PATH': (),
+    'PATHEXT': (),
     'PROMPT': DEFAULT_PROMPT,
+    'PROMPT_TOOLKIT_STYLES': None,
+    'PUSHD_MINUS': False,
+    'PUSHD_SILENT': False,
     'SHELL_TYPE': 'readline',
     'SUGGEST_COMMANDS': True,
     'SUGGEST_MAX_NUM': 5,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -529,7 +529,7 @@ RE_HIDDEN = re.compile('\001.*?\002')
 
 def multiline_prompt():
     """Returns the filler text for the prompt in multiline scenarios."""
-    curr = builtins.__xonsh_env__.get('PROMPT', "set '$PROMPT = ...' $ ")
+    curr = builtins.__xonsh_env__.get('PROMPT')
     curr = format_prompt(curr)
     line = curr.rsplit('\n', 1)[1] if '\n' in curr else curr
     line = RE_HIDDEN.sub('', line)  # gets rid of colors
@@ -539,7 +539,7 @@ def multiline_prompt():
     # tail is the trailing whitespace
     tail = line if headlen == 0 else line.rsplit(head[-1], 1)[1]
     # now to constuct the actual string
-    dots = builtins.__xonsh_env__.get('MULTILINE_PROMPT', '.')
+    dots = builtins.__xonsh_env__.get('MULTILINE_PROMPT')
     dots = dots() if callable(dots) else dots
     if dots is None or len(dots) == 0:
         return ''

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -96,31 +96,37 @@ def xonsh_config_dir(env):
 
 # Default values should generally be immutable, that way if a user wants
 # to set them they have to do a copy and write them to the environment.
+# try to keep this sorted.
 DEFAULT_VALUES = {
-    'INDENT': '    ',
-    'PROMPT': DEFAULT_PROMPT,
-    'TITLE': DEFAULT_TITLE,
-    'MULTILINE_PROMPT': '.',
-    'XONSHRC': os.path.expanduser('~/.xonshrc'),
-    'XONSH_HISTORY_SIZE': (8128, 'commands'),
-    'XONSH_HISTORY_FILE': os.path.expanduser('~/.xonsh_history.json'),
-    'XONSH_STORE_STDOUT': False,
-    'SHELL_TYPE': 'readline',
+    'BASH_COMPLETIONS': ('/usr/local/etc/bash_completion',
+                         '/opt/local/etc/profile.d/bash_completion.sh') if ON_MAC \
+                        else ('/etc/bash_completion', 
+                              '/usr/share/bash-completion/completions/git'),
     'CASE_SENSITIVE_COMPLETIONS': ON_LINUX,
+    'FORCE_POSIX_PATHS': False,
+    'INDENT': '    ',
     'LC_CTYPE': locale.setlocale(locale.LC_CTYPE),
     'LC_COLLATE': locale.setlocale(locale.LC_COLLATE),
     'LC_TIME': locale.setlocale(locale.LC_TIME),
     'LC_MONETARY': locale.setlocale(locale.LC_MONETARY),
     'LC_NUMERIC': locale.setlocale(locale.LC_NUMERIC),
-    'BASH_COMPLETIONS': ('/usr/local/etc/bash_completion',
-                         '/opt/local/etc/profile.d/bash_completion.sh') if ON_MAC \
-                        else ('/etc/bash_completion', 
-                              '/usr/share/bash-completion/completions/git'),
-    'FORCE_POSIX_PATHS': False,
-    'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
-    'XONSH_DATA_DIR': xonsh_data_dir,
+    'MULTILINE_PROMPT': '.',
+    'PATH': (),
+    'PROMPT': DEFAULT_PROMPT,
+    'SHELL_TYPE': 'readline',
+    'SUGGEST_COMMANDS': True,
+    'SUGGEST_MAX_NUM': 5,
+    'SUGGEST_THRESHOLD': 3,
+    'TITLE': DEFAULT_TITLE,
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
+    'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
+    'XONSHRC': os.path.expanduser('~/.xonshrc'),
     'XONSH_CONFIG_DIR': xonsh_config_dir,
+    'XONSH_DATA_DIR': xonsh_data_dir,
+    'XONSH_HISTORY_FILE': os.path.expanduser('~/.xonsh_history.json'),
+    'XONSH_HISTORY_SIZE': (8128, 'commands'),
+    'XONSH_SHOW_TRACEBACK': False,
+    'XONSH_STORE_STDOUT': False,
 }
 
 class DefaultNotGivenType(object):

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -29,7 +29,7 @@ class HistoryGC(Thread):
             time.sleep(0.01)
         env = builtins.__xonsh_env__
         if self.size is None:
-            hsize, units = env.get('XONSH_HISTORY_SIZE', (8128, 'commands'))
+            hsize, units = env.get('XONSH_HISTORY_SIZE')
         else:
             hsize, units = to_history_tuple(self.size)
         files = self.unlocked_files()

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -79,7 +79,7 @@ class HistoryGC(Thread):
         """Finds the history files and returns the ones that are unlocked, this is 
         sorted by the last closed time. Returns a list of (timestamp, file) tuples.
         """
-        xdd = os.path.abspath(builtins.__xonsh_env__['XONSH_DATA_DIR'])
+        xdd = os.path.abspath(builtins.__xonsh_env__.get('XONSH_DATA_DIR'))
         fs = [f for f in iglob(os.path.join(xdd, 'xonsh-*.json'))]
         files = []
         for f in fs:
@@ -209,7 +209,7 @@ class History(object):
         """
         self.sessionid = sid = uuid.uuid4() if sessionid is None else sessionid
         if filename is None: 
-            self.filename = os.path.join(builtins.__xonsh_env__['XONSH_DATA_DIR'], 
+            self.filename = os.path.join(builtins.__xonsh_env__.get('XONSH_DATA_DIR'), 
                                          'xonsh-{0}.json'.format(sid))
         else: 
             self.filename = filename

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -18,8 +18,7 @@ from xonsh.prompt_toolkit_key_bindings import load_xonsh_bindings
 def setup_history():
     """Creates history object."""
     env = builtins.__xonsh_env__
-    hfile = env.get('XONSH_HISTORY_FILE',
-                    os.path.expanduser('~/.xonsh_history'))
+    hfile = env.get('XONSH_HISTORY_FILE')
     history = LimitedFileHistory()
     try:
         history.read_history_file(hfile)
@@ -31,9 +30,8 @@ def setup_history():
 def teardown_history(history):
     """Tears down the history object."""
     env = builtins.__xonsh_env__
-    hsize = env.get('XONSH_HISTORY_SIZE', (8128, 'commands'))[0]
-    hfile = env.get('XONSH_HISTORY_FILE',
-                    os.path.expanduser('~/.xonsh_history'))
+    hsize = env.get('XONSH_HISTORY_SIZE')[0]
+    hfile = env.get('XONSH_HISTORY_FILE')
     try:
         history.save_history_to_file(hfile, hsize)
     except PermissionError:
@@ -97,7 +95,8 @@ class PromptToolkitShell(BaseShell):
             # update with the prompt styles
             styles.update({t: s for (t, s) in zip(tokens, cstyles)})
             # Update with with any user styles
-            userstyle = builtins.__xonsh_env__.get('PROMPT_TOOLKIT_STYLES', {})
-            styles.update(userstyle)
+            userstyle = builtins.__xonsh_env__.get('PROMPT_TOOLKIT_STYLES')
+            if userstyle is not None:
+                styles.update(userstyle)
 
         return get_tokens, CustomStyle

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -47,7 +47,7 @@ def setup_readline():
     readline.parse_and_bind('"\e[B": history-search-forward')
     readline.parse_and_bind('"\e[A": history-search-backward')
     # Setup Shift-Tab to indent
-    readline.parse_and_bind('"\e[Z": "{0}"'.format(env.get('INDENT', '')))
+    readline.parse_and_bind('"\e[Z": "{0}"'.format(env.get('INDENT')))
 
     # handle tab completion differences found in libedit readline compatibility
     # as discussed at http://stackoverflow.com/a/7116997
@@ -139,12 +139,12 @@ class ReadlineShell(BaseShell, Cmd):
                 self._current_indent = ''
             elif line.rstrip()[-1] == ':':
                 ind = line[:len(line) - len(line.lstrip())]
-                ind += builtins.__xonsh_env__.get('INDENT', '')
+                ind += builtins.__xonsh_env__.get('INDENT')
                 readline.set_pre_input_hook(_insert_text_func(ind, readline))
                 self._current_indent = ind
             elif line.split(maxsplit=1)[0] in DEDENT_TOKENS:
                 env = builtins.__xonsh_env__
-                ind = self._current_indent[:-len(env.get('INDENT', ''))]
+                ind = self._current_indent[:-len(env.get('INDENT'))]
                 readline.set_pre_input_hook(_insert_text_func(ind, readline))
                 self._current_indent = ind
             else:

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -26,25 +26,26 @@ class Shell(object):
     def __init__(self, ctx=None, shell_type=None, **kwargs):
         self._init_environ(ctx)
         env = builtins.__xonsh_env__
-
+        # piclk a valid shell
         if shell_type is not None:
             env['SHELL_TYPE'] = shell_type
-        if env['SHELL_TYPE'] == 'prompt_toolkit':
+        shell_type = env.get('SHELL_TYPE')
+        if shell_type == 'prompt_toolkit':
             if not is_prompt_toolkit_available():
                 warn('prompt_toolkit is not available, using readline instead.')
-                env['SHELL_TYPE'] = 'readline'
-
-        if env['SHELL_TYPE'] == 'prompt_toolkit':
+                shell_type = env['SHELL_TYPE'] = 'readline'
+        # actually make the shell
+        if shell_type == 'prompt_toolkit':
             from xonsh.prompt_toolkit_shell import PromptToolkitShell
             self.shell = PromptToolkitShell(execer=self.execer,
                                             ctx=self.ctx, **kwargs)
-        elif env['SHELL_TYPE'] == 'readline':
+        elif shell_type == 'readline':
             from xonsh.readline_shell import ReadlineShell
             self.shell = ReadlineShell(execer=self.execer,
                                        ctx=self.ctx, **kwargs)
         else:
             raise XonshError('{} is not recognized as a shell type'.format(
-                env['SHELL_TYPE']))
+                             shell_type))
         # allows history garbace colector to start running
         builtins.__xonsh_history__.gc.wait_for_shell = False
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -342,11 +342,11 @@ def command_not_found(cmd):
 
 def suggest_commands(cmd, env, aliases):
     """Suggests alternative commands given an environment and aliases."""
-    suggest_cmds = env.get('SUGGEST_COMMANDS', True)
+    suggest_cmds = env.get('SUGGEST_COMMANDS')
     if not suggest_cmds:
         return
-    thresh = env.get('SUGGEST_THRESHOLD', 3)
-    max_sugg = env.get('SUGGEST_MAX_NUM', 5)
+    thresh = env.get('SUGGEST_THRESHOLD')
+    max_sugg = env.get('SUGGEST_MAX_NUM')
     if max_sugg < 0:
         max_sugg = float('inf')
 
@@ -357,7 +357,7 @@ def suggest_commands(cmd, env, aliases):
             if levenshtein(a.lower(), cmd, thresh) < thresh:
                 suggested[a] = 'Alias'
 
-    for d in filter(os.path.isdir, env.get('PATH', [])):
+    for d in filter(os.path.isdir, env.get('PATH')):
         for f in os.listdir(d):
             if f not in suggested:
                 if levenshtein(f.lower(), cmd, thresh) < thresh:
@@ -387,8 +387,8 @@ def print_exception():
     """Print exceptions with/without traceback."""
     if 'XONSH_SHOW_TRACEBACK' not in builtins.__xonsh_env__:
         sys.stderr.write('xonsh: For full traceback set: '
-                         '$XONSH_SHOW_TRACEBACK=True\n')
-    if builtins.__xonsh_env__.get('XONSH_SHOW_TRACEBACK', False):
+                         '$XONSH_SHOW_TRACEBACK = True\n')
+    if builtins.__xonsh_env__.get('XONSH_SHOW_TRACEBACK'):
         traceback.print_exc()
     else:
         exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -401,15 +401,12 @@ def print_exception():
 def levenshtein(a, b, max_dist=float('inf')):
     """Calculates the Levenshtein distance between a and b."""
     n, m = len(a), len(b)
-
     if abs(n - m) > max_dist:
         return float('inf')
-
     if n > m:
         # Make sure n <= m, to use O(min(n,m)) space
         a, b = b, a
         n, m = m, n
-
     current = range(n + 1)
     for i in range(1, m + 1):
         previous, current = current, [i] + [0] * n
@@ -419,7 +416,6 @@ def levenshtein(a, b, max_dist=float('inf')):
             if a[j - 1] != b[i - 1]:
                 change = change + 1
             current[j] = min(add, delete, change)
-
     return current[n]
 
 
@@ -441,7 +437,6 @@ def escape_windows_title_string(s):
     """
     for c in '^&<>|':
         s = s.replace(c, '^' + c)
-
     s = s.replace('/?', '/.')
     return s
 


### PR DESCRIPTION
This PR adds a single place for environment variable defaults to be stored and used.  It also updates the `Env.get()` method to look at these defaults first if a default value is not explicitly given. It will return None if a value cannot be found. 

This solves the problem of having to recall and reimplement the default in several points across the code base. For example, `$XONSH_HISTORY_SIZE` comes up quite a lot and has a less than trivial specification.

This also trims down the `BASE_ENV` to explicitly what is needed.  This saves on a bit of space in the history files.