### PR TITLE
Remove from __future__ import

### DIFF
--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -1,5 +1,4 @@
 """The xonsh abstract syntax tree node."""
-from __future__ import unicode_literals, print_function
 from ast import Module, Num, Expr, Str, Bytes, UnaryOp, UAdd, USub, Invert, \
     BinOp, Add, Sub, Mult, Div, FloorDiv, Mod, Pow, Compare, Lt, Gt, \
     LtE, GtE, Eq, NotEq, In, NotIn, Is, IsNot, Not, BoolOp, Or, And, Subscript, \

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -1,5 +1,4 @@
 """A (tab-)completer for xonsh."""
-from __future__ import print_function, unicode_literals
 import os
 import re
 import builtins

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -1,5 +1,4 @@
 """Implements the xonsh executer"""
-from __future__ import print_function, unicode_literals
 import re
 import os
 import types

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -1,7 +1,6 @@
 """Import hooks for importing xonsh source files. This module registers
 the hooks it defines when it is imported.
 """
-from __future__ import print_function, unicode_literals
 import os
 import sys
 import builtins

--- a/xonsh/inspectors.py
+++ b/xonsh/inspectors.py
@@ -7,8 +7,6 @@ This file was forked from the IPython project:
 * Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
 * Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
 """
-from __future__ import print_function, unicode_literals
-
 import os
 import sys
 import types

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -1,5 +1,4 @@
 """Implements a lazy JSON file class that wraps around json data."""
-from __future__ import print_function, unicode_literals
 import io
 import weakref
 from contextlib import contextmanager

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -1,7 +1,6 @@
 """
 Lexer for xonsh code, written using a hybrid of ``tokenize`` and PLY
 """
-from __future__ import print_function, unicode_literals
 import re
 import sys
 import tokenize

--- a/xonsh/openpy.py
+++ b/xonsh/openpy.py
@@ -11,8 +11,6 @@ This file was forked from the IPython project:
 * Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
 * Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
 """
-from __future__ import absolute_import
-
 import io
 import re
 import os.path

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1,5 +1,4 @@
 """Implements the xonsh parser"""
-from __future__ import print_function, unicode_literals
 import os
 import sys
 from collections import Iterable, Sequence, Mapping

--- a/xonsh/pretty.py
+++ b/xonsh/pretty.py
@@ -83,7 +83,6 @@ Inheritance diagram:
             Portions (c) 2009 by Robert Kern.
 :license: BSD License.
 """
-from __future__ import print_function
 from contextlib import contextmanager
 import sys
 import types

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,6 +1,4 @@
 """Hooks for pygments syntax highlighting."""
-from __future__ import print_function, unicode_literals
-
 from pygments.lexer import inherit, bygroups, using, this
 from pygments.token import Name, Generic, Keyword, Text, String
 from pygments.lexers.shell import BashLexer

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -6,7 +6,6 @@ The following time_it alias and Timer was forked from the IPython project:
 * Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
 * Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
 """
-from __future__ import unicode_literals, print_function
 import gc
 import sys
 import math


### PR DESCRIPTION
Since Python > 3.4 is required no need for __future__.