### PR TITLE
Add literal tab insert to prompt tk keybinding

### DIFF
--- a/xonsh/prompt_toolkit_key_bindings.py
+++ b/xonsh/prompt_toolkit_key_bindings.py
@@ -34,9 +34,9 @@ def load_xonsh_bindings(key_bindings_manager):
         event.cli.current_buffer.insert_text(env.get('INDENT'))
 
     @handle(Keys.BackTab)
-    def _(insert_literal_tab):
+    def insert_literal_tab(event):
         """
         Insert literal tab on Shift+Tab instead of autocompleting
         """
-        insert_literal_tab.cli.current_buffer.insert_text(env.get('INDENT'))
+        event.cli.current_buffer.insert_text(env.get('INDENT'))
 

--- a/xonsh/prompt_toolkit_key_bindings.py
+++ b/xonsh/prompt_toolkit_key_bindings.py
@@ -32,3 +32,11 @@ def load_xonsh_bindings(key_bindings_manager):
         indent instead of autocompleting.
         """
         event.cli.current_buffer.insert_text(env.get('INDENT'))
+
+    @handle(Keys.BackTab)
+    def _(event):
+        """
+        Insert literal tab on Shift+Tab instead of autocompleting
+        """
+        event.cli.current_buffer.insert_text(env.get('INDENT'))
+

--- a/xonsh/prompt_toolkit_key_bindings.py
+++ b/xonsh/prompt_toolkit_key_bindings.py
@@ -34,9 +34,9 @@ def load_xonsh_bindings(key_bindings_manager):
         event.cli.current_buffer.insert_text(env.get('INDENT'))
 
     @handle(Keys.BackTab)
-    def _(event):
+    def _(insert_literal_tab):
         """
         Insert literal tab on Shift+Tab instead of autocompleting
         """
-        event.cli.current_buffer.insert_text(env.get('INDENT'))
+        insert_literal_tab.cli.current_buffer.insert_text(env.get('INDENT'))
 


### PR DESCRIPTION
This adds a key handle to insert a literal tab character when the user hits `Shift+Tab`. 

I just copied the readline keybinding, but it can be changed if folks want a different choice.

Resolves #408 