### PR TITLE
Updated source-bash to handle multiline values

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1,5 +1,6 @@
 """Aliases for the xonsh shell."""
 import os
+import re
 import shlex
 import builtins
 import subprocess
@@ -40,7 +41,7 @@ def source_bash(args, stdin=None):
             return None, 'could not source {0}\n'.format(args)
         f.seek(0)
         exported = f.read()
-    items = [l.split('=', 1) for l in exported.splitlines() if '=' in l]
+    items = re.findall(r'([A-Za-z_]+)=(.+?)\n[A-Za-z_]+=', exported, re.DOTALL)
     newenv = dict(items)
     for k, v in newenv.items():
         if k in env and v == denv[k]:


### PR DESCRIPTION
When trying to execute source-bash on a file that contains a value which
has newlines as part of it only the first line is captured. This is due
to using splitlines() naively. In order to overcome this limitation I
added a regex to parse the values.