### PR TITLE
Add support for system-wide xonshrc

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -133,9 +133,8 @@ applicable.
       - The location of the static xonsh configuration file, if it exists. This is
         in JSON format.
     * - XONSHRC
-      - ``~/.xonshrc``
-	``/etc/xonshrc`` (Linux and OSX) 
-	``%ALLUSERSPROFILE%\Application Data\xonsh\xonshrc`` (Windows)
+      - ``('/etc/xonshrc', '~/.xonshrc')`` (Linux and OSX) 
+    	``('%ALLUSERSPROFILE%\xonsh\xonshrc', '~/.xonshrc')`` (Windows)
       - A tuple of the locations of run control files, if they exist.  User defined
 	run control file will supercede values set in system-wide control file if there
 	is a naming collision.

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -134,7 +134,11 @@ applicable.
         in JSON format.
     * - XONSHRC
       - ``~/.xonshrc``
-      - Location of run control file.
+	``/etc/xonshrc`` (Linux and OSX) 
+	``%ALLUSERSPROFILE%\Application Data\xonsh\xonshrc`` (Windows)
+      - A tuple of the locations of run control files, if they exist.  User defined
+	run control file will supercede values set in system-wide control file if there
+	is a naming collision.
     * - XONSH_CONFIG_DIR
       - ``$XDG_CONFIG_HOME/xonsh``
       - This is location where xonsh configuration information is stored.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -621,23 +621,22 @@ def xonshrc_context(rcfiles=None, execer=None):
        or sum([os.path.isfile(rcfile) for rcfile in rcfiles]) == 0):
         return {}
     for rcfile in rcfiles:
+        if not os.path.isfile(rcfile):
+            continue
+        with open(rcfile, 'r') as f:
+            rc = f.read()
+        if not rc.endswith('\n'):
+            rc += '\n'
+        fname = execer.filename
+        env = {}
         try:
-            with open(rcfile, 'r') as f:
-                rc = f.read()
-            if not rc.endswith('\n'):
-                rc += '\n'
-            fname = execer.filename
-            env = {}
-            try:
-                execer.filename = rcfile
-                execer.exec(rc, glbs=env)
-            except SyntaxError as err:
-                msg = 'syntax error in xonsh run control file {0!r}: {1!s}'
-                warn(msg.format(rcfile, err), RuntimeWarning)
-            finally:
-                execer.filename = fname
-        except:
-            pass
+            execer.filename = rcfile
+            execer.exec(rc, glbs=env)
+        except SyntaxError as err:
+            msg = 'syntax error in xonsh run control file {0!r}: {1!s}'
+            warn(msg.format(rcfile, err), RuntimeWarning)
+        finally:
+            execer.filename = fname
     return env
 
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -142,7 +142,9 @@ DEFAULT_VALUES = {
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
     'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
     'XONSHCONFIG': xonshconfig,
-    'XONSHRC': (os.path.expanduser('~/.xonshrc'),'/etc/xonshrc') if ON_LINUX \
+    'XONSHRC': (os.path.expanduser('~/.xonshrc'),\
+                os.path.join(os.environ['ALLUSERSPROFILE'], 'Application Data', 'xonsh', 'xonshrc'))\
+               if ON_WINDOWS\
                else (os.path.expanduser('~/.xonshrc'),'/etc/xonshrc'), 
     'XONSH_CONFIG_DIR': xonsh_config_dir,
     'XONSH_DATA_DIR': xonsh_data_dir,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -142,10 +142,10 @@ DEFAULT_VALUES = {
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
     'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
     'XONSHCONFIG': xonshconfig,
-    'XONSHRC': (os.path.expanduser('~/.xonshrc'),\
-                os.path.join(os.environ['ALLUSERSPROFILE'], 'Application Data', 'xonsh', 'xonshrc'))\
-               if ON_WINDOWS\
-               else (os.path.expanduser('~/.xonshrc'),'/etc/xonshrc'), 
+    'XONSHRC': ((os.path.join(os.environ['ALLUSERSPROFILE'],
+                              'Application Data', 'xonsh', 'xonshrc'),
+                os.path.expanduser('~/.xonshrc')) if ON_WINDOWS
+               else ('/etc/xonshrc', os.path.expanduser('~/.xonshrc'))), 
     'XONSH_CONFIG_DIR': xonsh_config_dir,
     'XONSH_DATA_DIR': xonsh_data_dir,
     'XONSH_HISTORY_FILE': os.path.expanduser('~/.xonsh_history.json'),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -144,7 +144,7 @@ DEFAULT_VALUES = {
     'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
     'XONSHCONFIG': xonshconfig,
     'XONSHRC': ((os.path.join(os.environ['ALLUSERSPROFILE'],
-                              'Application Data', 'xonsh', 'xonshrc'),
+                              'xonsh', 'xonshrc'),
                 os.path.expanduser('~/.xonshrc')) if ON_WINDOWS
                else ('/etc/xonshrc', os.path.expanduser('~/.xonshrc'))), 
     'XONSH_CONFIG_DIR': xonsh_config_dir,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -59,6 +59,7 @@ DEFAULT_ENSURERS = {
     'LC_TIME': (always_false, locale_convert('LC_TIME'), ensure_string),
     'XONSH_HISTORY_SIZE': (is_history_tuple, to_history_tuple, history_tuple_to_str),
     'XONSH_STORE_STDOUT': (is_bool, to_bool, bool_to_str),
+    'XONSHRC': (is_env_path, str_to_env_path, env_path_to_str),
     'CASE_SENSITIVE_COMPLETIONS': (is_bool, to_bool, bool_to_str),
     'BASH_COMPLETIONS': (is_env_path, str_to_env_path, env_path_to_str),
     'TEEPTY_PIPE_DELAY': (is_float, float, str),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -620,6 +620,7 @@ def xonshrc_context(rcfiles=None, execer=None):
     if (rcfiles is None or execer is None
        or sum([os.path.isfile(rcfile) for rcfile in rcfiles]) == 0):
         return {}
+    env = {}
     for rcfile in rcfiles:
         if not os.path.isfile(rcfile):
             continue
@@ -628,7 +629,6 @@ def xonshrc_context(rcfiles=None, execer=None):
         if not rc.endswith('\n'):
             rc += '\n'
         fname = execer.filename
-        env = {}
         try:
             execer.filename = rcfile
             execer.exec(rc, glbs=env)

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -60,6 +60,6 @@ class Shell(object):
             self.ctx = ctx
         else:
             rc = env.get('XONSHRC')
-            self.ctx = xonshrc_context(rcfile=rc, execer=self.execer)
+            self.ctx = xonshrc_context(rcfiles=rc, execer=self.execer)
         builtins.__xonsh_ctx__ = self.ctx
         self.ctx['__name__'] = '__main__'


### PR DESCRIPTION
As discussed in #277 

Linux and OSX will look for a system-wide config file in  `/etc/xonshrc` in addition to the user's config file.  

Windows system config file is stored in `%ALLUSERSPROFILE%\Application Data\xonsh\xonshrc`

I don't have a windows machine to try this out on, but this is the same way that pip handles global configuration files, so it should work(?).  If a windows user ( @melund ?) can try this out to make sure it's grabbing both configuration files, that would be great.  

The way it's set up now, user `.xonshrc` will override system `xonshrc` if there are conflicting `$env` names.

Also, apologies.  Would've rebased but I wasn't sure if it would re-notify the linked issues and commits in one of the commit messages and opted for less noise.