### PR TITLE
Make prompt_toolkit's auto_suggest optional

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -19,6 +19,11 @@ applicable.
     * - AUTO_PUSHD
       - ``False``
       - Flag for automatically pushing directorties onto the directory stack.
+    * - AUTO_SUGGEST
+      - ``True``
+      - Enable automatic command suggestions based on history (like in fish shell).
+        Pressing the right arrow key inserts the currently displayed suggestion.
+        (Only usable with SHELL_TYPE=prompt_toolkit)
     * - BASH_COMPLETIONS
       - Normally this is ``('/etc/bash_completion', '/usr/share/bash-completion/completions/git')``
         but on Mac is ``'/usr/local/etc/bash_completion', '/opt/local/etc/profile.d/bash_completion.sh')``.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -63,6 +63,7 @@ DEFAULT_ENSURERS = {
     'BASH_COMPLETIONS': (is_env_path, str_to_env_path, env_path_to_str),
     'TEEPTY_PIPE_DELAY': (is_float, float, str),
     'MOUSE_SUPPORT': (is_bool, to_bool, bool_to_str),
+    'AUTO_SUGGEST': (is_bool, to_bool, bool_to_str)
 }
 
 #
@@ -111,6 +112,7 @@ def xonshconfig(env):
 # try to keep this sorted.
 DEFAULT_VALUES = {
     'AUTO_PUSHD': False,
+    'AUTO_SUGGEST': True,
     'BASH_COMPLETIONS': ('/usr/local/etc/bash_completion',
                          '/opt/local/etc/profile.d/bash_completion.sh') if ON_MAC \
                         else ('/etc/bash_completion',

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -46,6 +46,11 @@ class PromptToolkitShell(BaseShell):
         super().__init__(**kwargs)
         self.history = setup_history()
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
+        self.mouse_support = builtins.__xonsh_env__.get('MOUSE_SUPPORT')
+        if builtins.__xonsh_env__.get('AUTO_SUGGEST') is True:
+            self.auto_suggest = AutoSuggestFromHistory()
+        else:
+            self.auto_suggest = None
         self.key_bindings_manager = KeyBindingManager(
             enable_auto_suggest_bindings=True,
             enable_search=True, enable_abort_and_exit_bindings=True)
@@ -59,13 +64,12 @@ class PromptToolkitShell(BaseShell):
         """Enters a loop that reads and execute input from user."""
         if intro:
             print(intro)
-        mouse_support = builtins.__xonsh_env__.get('MOUSE_SUPPORT')
         while not builtins.__xonsh_exit__:
             try:
                 token_func, style_cls = self._get_prompt_tokens_and_style()
                 line = get_input(
-                    mouse_support=mouse_support,
-                    auto_suggest=AutoSuggestFromHistory(),
+                    mouse_support=self.mouse_support,
+                    auto_suggest=self.auto_suggest,
                     get_prompt_tokens=token_func,
                     style=style_cls,
                     completer=self.pt_completer,


### PR DESCRIPTION
Introducing the new AUTO_SUGGEST environment variable for this,
which can either be True or False. Default is True.

In addition, make mouse_support a class variable of PromptToolkitShell
for consistency's sake.