### PR TITLE
add ON_ARCH env to adjust $BASH_COMPLETIONS per os

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -21,7 +21,9 @@ applicable.
       - Flag for automatically pushing directorties onto the directory stack.
     * - BASH_COMPLETIONS
       - Normally this is ``('/etc/bash_completion', '/usr/share/bash-completion/completions/git')``
-        but on Mac is ``'/usr/local/etc/bash_completion', '/opt/local/etc/profile.d/bash_completion.sh')``.
+        but on Mac is ``('/usr/local/etc/bash_completion', '/opt/local/etc/profile.d/bash_completion.sh')``
+        and on Arch Linux is ``('/usr/share/bash-completion/bash_completion',
+        '/usr/share/bash-completion/completions/git')``.
       - This is a list (or tuple) of strings that specifies where the BASH completion 
         files may be found. The default values are platform dependent, but sane. 
         To specify an alternate list, do so in the run control file.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -12,10 +12,10 @@ from functools import wraps
 from collections import MutableMapping, MutableSequence, MutableSet, namedtuple
 
 from xonsh import __version__ as XONSH_VERSION
-from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, string_types, \
+from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, \
     is_int, always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
     env_path_to_str, is_bool, to_bool, bool_to_str, is_history_tuple, to_history_tuple, \
-    history_tuple_to_str, is_float
+    history_tuple_to_str, is_float, string_types
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
 
@@ -112,10 +112,14 @@ def xonshconfig(env):
 # try to keep this sorted.
 DEFAULT_VALUES = {
     'AUTO_PUSHD': False,
-    'BASH_COMPLETIONS': ('/usr/local/etc/bash_completion',
-                         '/opt/local/etc/profile.d/bash_completion.sh') if ON_MAC \
-                        else ('/etc/bash_completion',
-                              '/usr/share/bash-completion/completions/git'),
+    'BASH_COMPLETIONS': (('/usr/local/etc/bash_completion',
+                             '/opt/local/etc/profile.d/bash_completion.sh')
+                        if ON_MAC else
+                        ('/usr/share/bash-completion/bash_completion',
+                             '/usr/share/bash-completion/completions/git') 
+                        if ON_ARCH else
+                        ('/etc/bash_completion',
+                             '/usr/share/bash-completion/completions/git')),
     'CASE_SENSITIVE_COMPLETIONS': ON_LINUX,
     'CDPATH': (),
     'DIRSTACK_SIZE': 20,

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -41,6 +41,7 @@ DEFAULT_ENCODING = sys.getdefaultencoding()
 ON_WINDOWS = (platform.system() == 'Windows')
 ON_MAC = (platform.system() == 'Darwin')
 ON_LINUX = (platform.system() == 'Linux')
+ON_ARCH = (platform.linux_distribution()[0] == 'arch')
 ON_POSIX = (os.name == 'posix')
 
 VER_3_4 = (3, 4)


### PR DESCRIPTION
Arch places the default bash_completion scriptlet in
`/usr/share/bash-completion`, not in `/etc/bash_completion` as in most *nix
systems.

This adds an extra flag to tools.py to check if the current OS is
Arch, `ON_ARCH`, (according to `platform.linux_distribution`) and if it is, adjusts
the default location for bash_completion accordingly.

This fixes one of the issues in #421 -- the sudo aliasing isn't handled here, though