### PR TITLE
Make prompt_toolkit Python completions configurable

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -39,6 +39,18 @@ applicable.
       - ``[]``
       - A list of paths to be used as roots for a ``cd``, breaking compatibility with 
         bash, xonsh always prefer an existing relative path.
+    * - COMPLETIONS_DISPLAY
+      - ``'multi'``
+      - Configure if and how Python completions are displayed by the prompt_toolkit shell.
+        This option does not affect bash completions, auto-suggestions etc.
+        Changing it at runtime will take immediate effect, so you can quickly
+        disable and enable completions during shell sessions.
+        - If COMPLETIONS_DISPLAY is ``'none'`` or ``'false'``, do not display those completions.
+        - If COMPLETIONS_DISPLAY is ``'single'``, display completions in a single column while typing.
+        - If COMPLETIONS_DISPLAY is ``'multi'`` or ``'true'``, display completions in multiple columns while typing.
+        These option values are not case- or type-sensitive, so e.g.
+        writing ``$COMPLETIONS_DISPLAY = None`` and ``$COMPLETIONS_DISPLAY = 'none'`` is equivalent.
+        (Only usable with SHELL_TYPE=prompt_toolkit)
     * - DIRSTACK_SIZE
       - ``20``
       - Maximum size of the directory stack.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -15,7 +15,8 @@ from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, \
     is_int, always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
     env_path_to_str, is_bool, to_bool, bool_to_str, is_history_tuple, to_history_tuple, \
-    history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING
+    history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING, \
+    is_completions_display_value, to_completions_display_value
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
 
@@ -51,6 +52,7 @@ DEFAULT_ENSURERS = {
     'BASH_COMPLETIONS': (is_env_path, str_to_env_path, env_path_to_str),
     'CASE_SENSITIVE_COMPLETIONS': (is_bool, to_bool, bool_to_str),
     re.compile('\w*DIRS'): (is_env_path, str_to_env_path, env_path_to_str),
+    'COMPLETIONS_DISPLAY': (is_completions_display_value, to_completions_display_value, str),
     'LC_COLLATE': (always_false, locale_convert('LC_COLLATE'), ensure_string),
     'LC_CTYPE': (always_false, locale_convert('LC_CTYPE'), ensure_string),
     'LC_MESSAGES': (always_false, locale_convert('LC_MESSAGES'), ensure_string),
@@ -124,6 +126,7 @@ DEFAULT_VALUES = {
                              '/usr/share/bash-completion/completions/git')),
     'CASE_SENSITIVE_COMPLETIONS': ON_LINUX,
     'CDPATH': (),
+    'COMPLETIONS_DISPLAY': 'multi',
     'DIRSTACK_SIZE': 20,
     'FORCE_POSIX_PATHS': False,
     'INDENT': '    ',

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -68,15 +68,18 @@ class PromptToolkitShell(BaseShell):
                     auto_suggest = _auto_suggest
                 else:
                     auto_suggest = None
+                completions_display = builtins.__xonsh_env__.get('COMPLETIONS_DISPLAY')
+                multicolumn = True if completions_display == 'multi' else False
+                completer = None if completions_display == 'none' else self.pt_completer
                 line = get_input(
                     mouse_support=mouse_support,
                     auto_suggest=auto_suggest,
                     get_prompt_tokens=token_func,
                     style=style_cls,
-                    completer=self.pt_completer,
+                    completer=completer,
                     history=self.history,
                     key_bindings_registry=self.key_bindings_manager.registry,
-                    display_completions_in_columns=True)
+                    display_completions_in_columns=multicolumn)
                 if not line:
                     self.emptyline()
                 else:

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -69,7 +69,7 @@ class PromptToolkitShell(BaseShell):
                 else:
                     auto_suggest = None
                 completions_display = builtins.__xonsh_env__.get('COMPLETIONS_DISPLAY')
-                multicolumn = True if completions_display == 'multi' else False
+                multicolumn = (completions_display == 'multi')
                 completer = None if completions_display == 'none' else self.pt_completer
                 line = get_input(
                     mouse_support=mouse_support,

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -555,6 +555,21 @@ def ensure_int_or_slice(x):
         return int(x)
 
 
+def is_completions_display_value(x):
+    return x in {'none', 'single', 'multi'}
+
+
+def to_completions_display_value(x):
+    if str(x).lower() in {'none', 'false'}:
+        return 'none'
+    if str(x).lower() in {'multi', 'true'}:
+        return 'multi'
+    if str(x).lower() in {'single'}:
+        return 'single'
+    print('Warning: \'{}\' is not a valid value for $COMPLETIONS_DISPLAY. Using \'multi\'.'.format(str(x)))
+    return 'multi'
+
+
 # history validation
 
 _min_to_sec = lambda x: 60.0 * float(x)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -27,7 +27,7 @@ import subprocess
 from itertools import zip_longest
 from contextlib import contextmanager
 from collections import OrderedDict, Sequence
-
+from warnings import warn
 
 if sys.version_info[0] >= 3:
     string_types = (str, bytes)
@@ -560,14 +560,18 @@ def is_completions_display_value(x):
 
 
 def to_completions_display_value(x):
-    if str(x).lower() in {'none', 'false'}:
-        return 'none'
-    if str(x).lower() in {'multi', 'true'}:
-        return 'multi'
-    if str(x).lower() in {'single'}:
-        return 'single'
-    print('Warning: \'{}\' is not a valid value for $COMPLETIONS_DISPLAY. Using \'multi\'.'.format(str(x)))
-    return 'multi'
+    x = str(x).lower()
+    if x in {'none', 'false'}:
+        x = 'none'
+    elif x in {'multi', 'true'}:
+        x = 'multi'
+    elif x in {'single'}:
+        x = 'single'
+    else:
+        warn('"{}" is not a valid value for $COMPLETIONS_DISPLAY. '.format(x) +
+             'Using "multi".', RuntimeWarning)
+        x = 'multi'
+    return x
 
 
 # history validation


### PR DESCRIPTION
Completions provided by prompt_toolkit are now configurable
by setting $COMPLETIONS_DISPLAY.
Changing it at runtime will take immediate effect, so you can quickly
disable and enable completions during shell sessions.

Possible values for $COMPLETIONS_DISPLAY are:
- 'none' for no completions,
- 'single' for single-column completions,
- 'multi' for multi-column completions (default).