### PR TITLE
add `AUTO_CD` functionality

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -16,9 +16,12 @@ applicable.
     * - ANSICON
       - No default set
       - This is used on Windows to set the title, if available.
+    * - AUTO_CD
+      - ``False``
+      - Flag to enable changing to a directory by entering the dirname or full path only (without the `cd` command)
     * - AUTO_PUSHD
       - ``False``
-      - Flag for automatically pushing directorties onto the directory stack.
+      - Flag for automatically pushing directories onto the directory stack.
     * - AUTO_SUGGEST
       - ``True``
       - Enable automatic command suggestions based on history (like in fish shell).

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -21,7 +21,7 @@ from collections import Sequence, MutableMapping, Iterable, namedtuple, \
 from xonsh.tools import suggest_commands, XonshError, ON_POSIX, ON_WINDOWS, \
     string_types
 from xonsh.inspectors import Inspector
-from xonsh.environ import Env, default_env
+from xonsh.environ import Env, default_env, locate_binary
 from xonsh.aliases import DEFAULT_ALIASES
 from xonsh.jobs import add_job, wait_for_active_job
 from xonsh.proc import ProcProxy, SimpleProcProxy, TeePTYProc
@@ -523,6 +523,13 @@ def run_subproc(cmds, captured=True):
             stderr = streams['stderr']
         uninew = (ix == last_cmd) and (not captured)
         alias = builtins.aliases.get(cmd[0], None)
+        if (alias is None
+            and builtins.__xonsh_env__.get('AUTO_CD')
+            and os.path.isdir(cmd[0])
+            and locate_binary(cmd[0], cwd=None) is None
+            and len(cmds)==1):
+            cmd.insert(0, 'cd')
+            return run_subproc(cmds, captured=False)
         if callable(alias):
             aliased_cmd = alias
         else:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -529,7 +529,8 @@ def run_subproc(cmds, captured=True):
             and locate_binary(cmd[0], cwd=None) is None
             and len(cmds)==1):
             cmd.insert(0, 'cd')
-            return run_subproc(cmds, captured=False)
+            alias = builtins.aliases.get('cd', None)
+
         if callable(alias):
             aliased_cmd = alias
         else:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -47,6 +47,7 @@ represent environment variable validation, conversion, detyping.
 """
 
 DEFAULT_ENSURERS = {
+    'AUTO_CD': (is_bool, to_bool, bool_to_str), 
     'AUTO_SUGGEST': (is_bool, to_bool, bool_to_str),
     'BASH_COMPLETIONS': (is_env_path, str_to_env_path, env_path_to_str),
     'CASE_SENSITIVE_COMPLETIONS': (is_bool, to_bool, bool_to_str),
@@ -112,6 +113,7 @@ def xonshconfig(env):
 # to set them they have to do a copy and write them to the environment.
 # try to keep this sorted.
 DEFAULT_VALUES = {
+    'AUTO_CD': False,                 
     'AUTO_PUSHD': False,
     'AUTO_SUGGEST': True,
     'BASH_COMPLETIONS': (('/usr/local/etc/bash_completion',


### PR DESCRIPTION
As suggested in #439 

I couldn't find a better place to insert this other than `base_shell.py` -- it might be a bit too hacky, but I'm open to suggestions.

If user enters the name of a directory, e.g.

```
gil@theo ~ $ /usr/bin
```

then Xonsh will first try to run that command.  When it fails and raises
a XonshError, if the env variable `$AUTO_CD=True` then Xonsh will check
to see if the input is a valid directory and that there is no binary in
`$PATH` that matches the input (this last bit is likely redundant).

If all conditions are met, it reruns the "command" but prepends `cd` to it.