### PR TITLE
bugfix for install missing scripts/xonsh.bat (windows)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def main():
         platforms='Cross Platform',
         classifiers=['Programming Language :: Python :: 3'],
         packages=['xonsh'],
-        scripts=['scripts/xonsh'],
+        scripts=['scripts/xonsh', 'scripts/xonsh.bat'],
         cmdclass={'install': xinstall, 'sdist': xsdist},
         )
     if HAVE_SETUPTOOLS:


### PR DESCRIPTION
Windows install is faulty, "xonsh.bat" is not created when installed as reported in issue #457.
Pull request to resolve issue.
