### PR TITLE
Use console_scripts to generate entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ def main():
         platforms='Cross Platform',
         classifiers=['Programming Language :: Python :: 3'],
         packages=['xonsh'],
-        scripts=['scripts/xonsh', 'scripts/xonsh.bat'],
         cmdclass={'install': xinstall, 'sdist': xsdist},
         )
     if HAVE_SETUPTOOLS:
@@ -87,8 +86,11 @@ def main():
             'pygments.lexers': ['xonsh = xonsh.pyghooks:XonshLexer',
                                 'xonshcon = xonsh.pyghooks:XonshConsoleLexer',
                                 ],
+            'console_scripts': ['xonsh = xonsh.main:main'],
             }
         skw['cmdclass']['develop'] = xdevelop
+    else:
+        skw['scripts'] = ['scripts/xonsh', 'scripts/xonsh.bat']
     setup(**skw)
 
 logo = """


### PR DESCRIPTION
This is better than writing platform-dependant scripts to provide an entry point. The old way is kept as a fallback when setuptools is not available.

Should address #466 (at least when `setuptools` is available).

Reference:

http://python-packaging.readthedocs.org/en/latest/command-line-scripts.html#the-console-scripts-entry-point