### PR TITLE
set prompt_toolkit completion to trigger on tab

### DIFF
--- a/xonsh/prompt_toolkit_completer.py
+++ b/xonsh/prompt_toolkit_completer.py
@@ -16,8 +16,8 @@ class PromptToolkitCompleter(Completer):
     def get_completions(self, document, complete_event):
         """Returns a generator for list of completions."""
 
-        #  Only generate completions when the user typed not a tab.
-        if not (document.char_before_cursor or '').isspace():
+        #  Only generate completions when the user hits tab.
+        if complete_event.completion_requested:
             line = document.current_line
             endidx = document.cursor_position_col
             space_pos = document.find_backwards(' ')


### PR DESCRIPTION
prompt_toolkit completion wasn't triggering for command arguments unless
the first letter was entered.  now it shows all the options when the
user hits tab, which matches the readline functionality and also the
default behavior in bash, zsh, fish, etc...

previously

```
git <TAB>
```
would return nothing, while

```
git s<TAB>
```

would offer `send-email`, `stage`, `stash`, `status`, etc...

Now 
```
git <TAB>
```

will show all available git arguments so long as `$BASH_COMPLETIONS` is set.