### PR TITLE
call expand_path() in more places

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -659,6 +659,7 @@ def load_builtins(execer=None):
     builtins.__xonsh_superhelp__ = superhelper
     builtins.__xonsh_regexpath__ = regexpath
     builtins.__xonsh_glob__ = globpath
+    builtins.__xonsh_expand_path__ = expand_path
     builtins.__xonsh_exit__ = False
     if hasattr(builtins, 'exit'):
         builtins.__xonsh_pyexit__ = builtins.exit
@@ -709,6 +710,7 @@ def unload_builtins():
              '__xonsh_superhelp__',
              '__xonsh_regexpath__',
              '__xonsh_glob__',
+             '__xonsh_expand_path__',
              '__xonsh_exit__',
              '__xonsh_pyexit__',
              '__xonsh_pyquit__',

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -2407,8 +2407,13 @@ class Parser(object):
                                     col=self.col)
                     p0._cliarg_action = 'extend'
                 else:
-                    p0.s = os.path.expanduser(p0.s)
+                    p0 = xonsh_call('__xonsh_expand_path__', args=[p0],
+                                    lineno=self.lineno, col=self.col)
                     p0._cliarg_action = 'append'
+            elif isinstance(p1, ast.Str):
+                p0 = xonsh_call('__xonsh_expand_path__', args=[p1],
+                                lineno=self.lineno, col=self.col)
+                p0._cliarg_action = 'append'
             elif isinstance(p1, ast.AST):
                 p0 = p1
                 p0._cliarg_action = 'append'


### PR DESCRIPTION
This should address #469 by calling `expand_path()` in the relevant places.  @Carreau, would you mind testing this out.  If people really want raw tildes in subproc mode they can always do `@('~')`