### PR TITLE
Add equivalent of `\$` in bash as `prompt_end`

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -841,6 +841,7 @@ By default, the following variables are available for use:
     if any.
   * ``branch_color``: ``{BOLD_GREEN}`` if the current git branch is clean,
     otherwise ``{BOLD_RED}``
+  * ``prompt_end``: `#` if the user has root/admin permissions `$` otherwise
 
 You can also color your prompt easily by inserting keywords such as ``{GREEN}``
 or ``{BOLD_BLUE}``.  Colors have the form shown below:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -12,11 +12,13 @@ from functools import wraps
 from collections import MutableMapping, MutableSequence, MutableSet, namedtuple
 
 from xonsh import __version__ as XONSH_VERSION
-from xonsh.tools import TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, \
-    is_int, always_true, always_false, ensure_string, is_env_path, str_to_env_path, \
-    env_path_to_str, is_bool, to_bool, bool_to_str, is_history_tuple, to_history_tuple, \
-    history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING, \
+from xonsh.tools import (
+    TERM_COLORS, ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, IS_ROOT,
+    always_true, always_false, ensure_string, is_env_path, str_to_env_path,
+    env_path_to_str, is_bool, to_bool, bool_to_str, is_history_tuple, to_history_tuple,
+    history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING,
     is_completions_display_value, to_completions_display_value
+)
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
 
@@ -84,7 +86,7 @@ def is_callable_default(x):
 
 DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
                   '{cwd}{branch_color}{curr_branch} '
-                  '{BOLD_BLUE}${NO_COLOR} ')
+                  '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
 DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
 
 @default_value
@@ -539,6 +541,7 @@ else:
 
 FORMATTER_DICT = dict(
     user=os.environ.get(USER, '<user>'),
+    prompt_end='#' if IS_ROOT else '$',
     hostname=socket.gethostname().split('.', 1)[0],
     cwd=_replace_home_cwd,
     cwd_dir=lambda: os.path.dirname(_replace_home_cwd()),

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -16,6 +16,7 @@ Implementations:
 * indent()
 
 """
+import ctypes
 import os
 import re
 import sys
@@ -24,7 +25,6 @@ import platform
 import traceback
 import threading
 import subprocess
-from itertools import zip_longest
 from contextlib import contextmanager
 from collections import OrderedDict, Sequence
 from warnings import warn
@@ -43,6 +43,7 @@ ON_MAC = (platform.system() == 'Darwin')
 ON_LINUX = (platform.system() == 'Linux')
 ON_ARCH = (platform.linux_distribution()[0] == 'arch')
 ON_POSIX = (os.name == 'posix')
+IS_ROOT = ctypes.windll.shell32.IsUserAnAdmin() != 0 if ON_WINDOWS else os.getuid() == 0
 
 VER_3_4 = (3, 4)
 VER_3_5 = (3, 5)


### PR DESCRIPTION
Adds a new `prompt_end` formatter variable for prompt. The value is `$`
for normal users and `#` for root users.