### PR TITLE
Add default indent if not env variable not set

### DIFF
--- a/xonsh/prompt_toolkit_key_bindings.py
+++ b/xonsh/prompt_toolkit_key_bindings.py
@@ -31,12 +31,12 @@ def load_xonsh_bindings(key_bindings_manager):
         If there are only whitespaces before current cursor position insert
         indent instead of autocompleting.
         """
-        event.cli.current_buffer.insert_text(env.get('INDENT'))
+        event.cli.current_buffer.insert_text(env.get('INDENT', '    '))
 
     @handle(Keys.BackTab)
     def insert_literal_tab(event):
         """
         Insert literal tab on Shift+Tab instead of autocompleting
         """
-        event.cli.current_buffer.insert_text(env.get('INDENT'))
+        event.cli.current_buffer.insert_text(env.get('INDENT', '    '))
 


### PR DESCRIPTION
This tiny PR adds a default indent if indent is not set. Was trying to fix the error in 0.2.2, but found it was already fixed; this does help though if the user does not have `INDENT` set in `.xonshrc`.