### PR TITLE
Mention where the Arch linux package can be found

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,7 +102,8 @@ the following from the source directory,
 
     $ python setup.py install
 
-ArchLinux users can install xonsh with e.g. yaourt or aura:
+Arch Linux users can install xonsh from the Arch User Repository with e.g.
+yaourt or aura:
 
 **yaourt:**
 


### PR DESCRIPTION
There are many tools to download packages from the Arch User Repository apart from the ones included in the installation instructions.