### PR TITLE
Make history module mostly lint clean.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,96 +1,103 @@
 """Tests the xonsh history."""
+# pylint: disable=protected-access
 from __future__ import unicode_literals, print_function
 import io
 import os
 import sys
 
 import nose
-from nose.tools import assert_equal, assert_true
+from nose import tools as nose_tools
 
-from xonsh.lazyjson import LazyJSON
-from xonsh.history import History, CommandField
+from xonsh import lazyjson
 from xonsh import history
 
 HIST_TEST_KWARGS = dict(sessionid='SESSIONID', gc=False)
 
-
 def test_hist_init():
+    """Test initialization of the shell history."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.init'
-    hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
-    with LazyJSON(FNAME) as lj:
+    history.History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
+    with lazyjson.LazyJSON(FNAME) as lj:
         obs = lj['here']
-    assert_equal('yup', obs)
+    yield nose_tools.assert_equal, 'yup', obs
     os.remove(FNAME)
 
 
 def test_hist_append():
+    """Verify appending to the history works."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.append'
-    hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
+    hist = history.History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     hf = hist.append({'joco': 'still alive'})
-    yield assert_true, hf is None
-    yield assert_equal, 'still alive', hist.buffer[0]['joco']
+    yield nose_tools.assert_is_none, hf
+    yield nose_tools.assert_equal, 'still alive', hist.buffer[0]['joco']
     os.remove(FNAME)
 
 
 def test_hist_flush():
+    """Verify explicit flushing of the history works."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.flush'
-    hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
+    hist = history.History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     hf = hist.flush()
-    yield assert_true, hf is None
+    yield nose_tools.assert_is_none, hf
     hist.append({'joco': 'still alive'})
     hf = hist.flush()
-    yield assert_true, hf is not None
+    yield nose_tools.assert_is_not_none, hf
     while hf.is_alive():
         pass
-    with LazyJSON(FNAME) as lj:
+    with lazyjson.LazyJSON(FNAME) as lj:
         obs = lj['cmds'][0]['joco']
-    yield assert_equal, 'still alive', obs
+    yield nose_tools.assert_equal, 'still alive', obs
     os.remove(FNAME)
 
 
 def test_cmd_field():
+    """Test basic history behavior."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.cmdfield'
-    hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
+    hist = history.History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     # in-memory
     hf = hist.append({'rtn': 1})
-    yield assert_true, hf is None
-    yield assert_equal, 1, hist.rtns[0]
-    yield assert_equal, 1, hist.rtns[-1]
-    yield assert_equal, None, hist.outs[-1]
+    yield nose_tools.assert_is_none, hf
+    yield nose_tools.assert_equal, 1, hist.rtns[0]
+    yield nose_tools.assert_equal, 1, hist.rtns[-1]
+    yield nose_tools.assert_equal, None, hist.outs[-1]
     # slice
-    yield assert_equal, [1], hist.rtns[:]
+    yield nose_tools.assert_equal, [1], hist.rtns[:]
     # on disk
     hf = hist.flush()
-    yield assert_true, hf is not None
-    yield assert_equal, 1, hist.rtns[0]
-    yield assert_equal, 1, hist.rtns[-1]
-    yield assert_equal, None, hist.outs[-1]
+    yield nose_tools.assert_is_not_none, hf
+    yield nose_tools.assert_equal, 1, hist.rtns[0]
+    yield nose_tools.assert_equal, 1, hist.rtns[-1]
+    yield nose_tools.assert_equal, None, hist.outs[-1]
     os.remove(FNAME)
 
+
 def test_show_cmd():
+    """Verify that CLI history commands work."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.show_cmd'
     cmds = ['ls', 'cat hello kitty', 'abc', 'def', 'touch me', 'grep from me']
 
     def format_hist_line(idx, cmd):
+        """Construct a history output line."""
         return ' {:d}  {:s}\n'.format(idx, cmd)
 
     def run_show_cmd(hist_args, commands, base_idx=0, step=1):
+        """Run and evaluate the output of the given show command."""
         stdout.seek(0, io.SEEK_SET)
         stdout.truncate()
-        history._main(hist, hist_args)  # pylint: disable=protected-access
+        history._main(hist, hist_args)
         stdout.seek(0, io.SEEK_SET)
         hist_lines = stdout.readlines()
-        yield assert_equal, len(commands), len(hist_lines)
+        yield nose_tools.assert_equal, len(commands), len(hist_lines)
         for idx, (cmd, actual) in enumerate(zip(commands, hist_lines)):
             expected = format_hist_line(base_idx + idx * step, cmd)
-            yield assert_equal, expected, actual
+            yield nose_tools.assert_equal, expected, actual
 
-    hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
+    hist = history.History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     stdout = io.StringIO()
     saved_stdout = sys.stdout
     sys.stdout = stdout
@@ -109,7 +116,7 @@ def test_show_cmd():
     # Verify an explicit "show" with a reversed qualifier emits the entire
     # history in reverse order.
     for x in run_show_cmd(['show', '-r'], list(reversed(cmds)),
-                         len(cmds) - 1, -1):
+                          len(cmds) - 1, -1):
         yield x
 
     # Verify that showing a specific history entry relative to the start of the


### PR DESCRIPTION
This fixes most of the lint errors in the history code. It also fixes two bugs
that were found by pylint due to misnamed variables. This patch does not make
any functional changes. I'll fix the remaining lint errors in a subsequent
patch when I tackle cross-module issues.