### PR TITLE
add open in editor to prompt_toolkit_shell

### DIFF
--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -48,6 +48,7 @@ class PromptToolkitShell(BaseShell):
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
         self.key_bindings_manager = KeyBindingManager(
             enable_auto_suggest_bindings=True,
+            enable_open_in_editor=True,
             enable_search=True, enable_abort_and_exit_bindings=True)
         load_xonsh_bindings(self.key_bindings_manager)
 


### PR DESCRIPTION
h/t @jonathanslenders

When using the prompt_toolkit shell, user can press Ctrl-X Ctrl-E to
open the current line in $EDITOR.

Limitations -- it can only open the _current_ line, so if you are
already in a multiline prompt, you can't edit what is already entered in
lines above.

However, you can enter multiline commands in the editor and these are
correctly interpreted by xonsh (assuming correct syntax, etc)

Resolves #445 