### PR TITLE
Capture process exit code for 'rtn' and 'last_cmd_rtn' and IGNOREEOF support.

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -74,6 +74,9 @@ applicable.
       - xonsh.environ.FORMATTER_DICT  
       - Dictionary containing variables to be used when formatting PROMPT and TITLE 
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - IGNOREEOF
+      - ``False``
+      - Prevents Ctrl-D from exiting the shell.
     * - INDENT
       - ``'    '``
       - Indentation string for multiline input

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -50,12 +50,13 @@ represent environment variable validation, conversion, detyping.
 """
 
 DEFAULT_ENSURERS = {
-    'AUTO_CD': (is_bool, to_bool, bool_to_str), 
+    'AUTO_CD': (is_bool, to_bool, bool_to_str),
     'AUTO_SUGGEST': (is_bool, to_bool, bool_to_str),
     'BASH_COMPLETIONS': (is_env_path, str_to_env_path, env_path_to_str),
     'CASE_SENSITIVE_COMPLETIONS': (is_bool, to_bool, bool_to_str),
     re.compile('\w*DIRS'): (is_env_path, str_to_env_path, env_path_to_str),
     'COMPLETIONS_DISPLAY': (is_completions_display_value, to_completions_display_value, str),
+    'IGNOREEOF': (is_bool, to_bool, bool_to_str),
     'LC_COLLATE': (always_false, locale_convert('LC_COLLATE'), ensure_string),
     'LC_CTYPE': (always_false, locale_convert('LC_CTYPE'), ensure_string),
     'LC_MESSAGES': (always_false, locale_convert('LC_MESSAGES'), ensure_string),
@@ -117,7 +118,7 @@ def xonshconfig(env):
 # to set them they have to do a copy and write them to the environment.
 # try to keep this sorted.
 DEFAULT_VALUES = {
-    'AUTO_CD': False,                 
+    'AUTO_CD': False,
     'AUTO_PUSHD': False,
     'AUTO_SUGGEST': True,
     'BASH_COMPLETIONS': (('/usr/local/etc/bash_completion',
@@ -133,6 +134,7 @@ DEFAULT_VALUES = {
     'COMPLETIONS_DISPLAY': 'multi',
     'DIRSTACK_SIZE': 20,
     'FORCE_POSIX_PATHS': False,
+    'IGNOREEOF': False,
     'INDENT': '    ',
     'LC_CTYPE': locale.setlocale(locale.LC_CTYPE),
     'LC_COLLATE': locale.setlocale(locale.LC_COLLATE),

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -114,6 +114,8 @@ else:
         if signal_to_send is not None:
             os.kill(obj.pid, signal_to_send)
         _, s = os.waitpid(obj.pid, os.WUNTRACED)
+        # s contains signal and exit code, get the real exit code
+        exit_code = s >> 8
         if os.WIFSTOPPED(s):
             obj.done = True
             job['bg'] = True
@@ -124,6 +126,7 @@ else:
             print()  # get a newline because ^C will have been printed
         if obj.poll() is not None:
             builtins.__xonsh_active_job__ = None
+        obj.returncode = exit_code
         _give_terminal_to(_shell_pgrp)  # give terminal back to the shell
 
 

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -88,7 +88,8 @@ class PromptToolkitShell(BaseShell):
             except KeyboardInterrupt:
                 self.reset_buffer()
             except EOFError:
-                break
+                if not builtins.__xonsh_env__.get("IGNOREEOF"):
+                    break
 
     def _get_prompt_tokens_and_style(self):
         """Returns function to pass as prompt to prompt_toolkit."""

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -195,7 +195,8 @@ class ReadlineShell(BaseShell, Cmd):
                     try:
                         line = input(self.prompt)
                     except EOFError:
-                        line = 'EOF'
+                        env = builtins.__xonsh_env__
+                        line = 'EOF' if not env.get("IGNOREEOF") else ''
                     if inserter is not None:
                         readline.set_pre_input_hook(None)
                 else:


### PR DESCRIPTION
While exploring xonsh I had a failed command and tested out what `echo $?` would do, I found 
that is what not what I expected, which is of course what bash does.  I dug deeper and found 
the rtn and last_cmd_rtm variable in history and found that my failed commands (e.g 'ls missingfille' and 'man missingmanpage') contain 0 for there exits codes, which is wrong as both exit non-zero for fails... this pull request fixes this. 

Also added IGNOREEOF, with bash-like behavior (true/false but not integer values currently).
I can split this into 2 pull-requests if desired.

Thanks for xonsh, the prospect of replacing bash is huge. 