### PR TITLE
allow user to enable vi_mode in prompt_toolkit

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -152,6 +152,9 @@ applicable.
       - The title text for the window in which xonsh is running. Formatted in the same 
         manner as PROMPT, 
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
+    * - VI_MODE
+      - ``False``
+      - Flag to enable ``vi_mode`` in the ``prompt_toolkit`` shell.  
     * - XDG_CONFIG_HOME
       - ``~/.config``
       - Open desktop standard configuration home dir. This is the same default as

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -70,6 +70,7 @@ DEFAULT_ENSURERS = {
     'XONSH_ENCODING_ERRORS': (is_string, ensure_string, ensure_string),
     'XONSH_HISTORY_SIZE': (is_history_tuple, to_history_tuple, history_tuple_to_str),
     'XONSH_STORE_STDOUT': (is_bool, to_bool, bool_to_str),
+    'VI_MODE': (is_bool, to_bool, bool_to_str),
 }
 
 #
@@ -153,6 +154,7 @@ DEFAULT_VALUES = {
     'SUGGEST_THRESHOLD': 3,
     'TEEPTY_PIPE_DELAY': 0.01,
     'TITLE': DEFAULT_TITLE,
+    'VI_MODE': False,
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
     'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
     'XONSHCONFIG': xonshconfig,

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -31,6 +31,7 @@ def setup_history():
 
 def teardown_history(history):
     """Tears down the history object."""
+    import builtins
     env = builtins.__xonsh_env__
     hsize = env.get('XONSH_HISTORY_SIZE')[0]
     hfile = env.get('XONSH_HISTORY_FILE')
@@ -47,12 +48,11 @@ class PromptToolkitShell(BaseShell):
         super().__init__(**kwargs)
         self.history = setup_history()
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
-        self.vi_mode_enabled = builtins.__xonsh_env__.get('VI_MODE')
         self.key_bindings_manager = KeyBindingManager(
             enable_auto_suggest_bindings=True,
             enable_search=True, 
             enable_abort_and_exit_bindings=True,
-            enable_vi_mode=Condition(lambda cli: self.vi_mode_enabled),
+            enable_vi_mode=Condition(lambda cli: builtins.__xonsh_env__.get('VI_MODE')),
             enable_open_in_editor=True)
         load_xonsh_bindings(self.key_bindings_manager)
 
@@ -76,7 +76,6 @@ class PromptToolkitShell(BaseShell):
                 completions_display = builtins.__xonsh_env__.get('COMPLETIONS_DISPLAY')
                 multicolumn = (completions_display == 'multi')
                 completer = None if completions_display == 'none' else self.pt_completer
-                self.vi_mode_enabled = builtins.__xonsh_env__.get('VI_MODE')
                 line = prompt(
                     mouse_support=mouse_support,
                     auto_suggest=auto_suggest,

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -6,6 +6,7 @@ from warnings import warn
 from prompt_toolkit.shortcuts import get_input
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.filters import Condition
 from pygments.token import Token
 from pygments.style import Style
 
@@ -46,9 +47,11 @@ class PromptToolkitShell(BaseShell):
         super().__init__(**kwargs)
         self.history = setup_history()
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
+        self.vi_mode_enabled = builtins.__xonsh_env__.get('VI_MODE')
         self.key_bindings_manager = KeyBindingManager(
             enable_auto_suggest_bindings=True,
-            enable_search=True, enable_abort_and_exit_bindings=True)
+            enable_search=True, enable_abort_and_exit_bindings=True,
+            enable_vi_mode=Condition(lambda cli: self.vi_mode_enabled))
         load_xonsh_bindings(self.key_bindings_manager)
 
     def __del__(self):
@@ -71,6 +74,7 @@ class PromptToolkitShell(BaseShell):
                 completions_display = builtins.__xonsh_env__.get('COMPLETIONS_DISPLAY')
                 multicolumn = (completions_display == 'multi')
                 completer = None if completions_display == 'none' else self.pt_completer
+                self.vi_mode_enabled = builtins.__xonsh_env__.get('VI_MODE')
                 line = get_input(
                     mouse_support=mouse_support,
                     auto_suggest=auto_suggest,


### PR DESCRIPTION
This adds the envvar `VI_MODE`, (default `False`).  If it is set to `True`,
either in a `.xonshrc` or dynamically, then the prompt is switched to
`vi_mode`.

`vi_mode` defaults to an `--insert--` environment, then user can hit ESC
to enter command mode, etc...'

Resolves #491 