### PR TITLE
Make history module mostly lint clean.

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,23 +1,28 @@
 """Tests the xonsh history."""
+# pylint: disable=protected-access
+# TODO: Remove the following pylint directive when it correctly handles calls
+# to nose assert_xxx functions.
+# pylint: disable=no-value-for-parameter
 from __future__ import unicode_literals, print_function
 import io
 import os
 import sys
 
 import nose
-from nose.tools import assert_equal, assert_true
+from nose.tools import assert_equal, assert_is_none, assert_is_not_none
 
 from xonsh.lazyjson import LazyJSON
-from xonsh.history import History, CommandField
+from xonsh.history import History
 from xonsh import history
 
 HIST_TEST_KWARGS = dict(sessionid='SESSIONID', gc=False)
 
 
 def test_hist_init():
+    """Test initialization of the shell history."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.init'
-    hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
+    History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     with LazyJSON(FNAME) as lj:
         obs = lj['here']
     assert_equal('yup', obs)
@@ -25,24 +30,26 @@ def test_hist_init():
 
 
 def test_hist_append():
+    """Verify appending to the history works."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.append'
     hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     hf = hist.append({'joco': 'still alive'})
-    yield assert_true, hf is None
+    yield assert_is_none, hf
     yield assert_equal, 'still alive', hist.buffer[0]['joco']
     os.remove(FNAME)
 
 
 def test_hist_flush():
+    """Verify explicit flushing of the history works."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.flush'
     hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     hf = hist.flush()
-    yield assert_true, hf is None
+    yield assert_is_none, hf
     hist.append({'joco': 'still alive'})
     hf = hist.flush()
-    yield assert_true, hf is not None
+    yield assert_is_not_none, hf
     while hf.is_alive():
         pass
     with LazyJSON(FNAME) as lj:
@@ -52,12 +59,13 @@ def test_hist_flush():
 
 
 def test_cmd_field():
+    """Test basic history behavior."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.cmdfield'
     hist = History(filename=FNAME, here='yup', **HIST_TEST_KWARGS)
     # in-memory
     hf = hist.append({'rtn': 1})
-    yield assert_true, hf is None
+    yield assert_is_none, hf
     yield assert_equal, 1, hist.rtns[0]
     yield assert_equal, 1, hist.rtns[-1]
     yield assert_equal, None, hist.outs[-1]
@@ -65,24 +73,28 @@ def test_cmd_field():
     yield assert_equal, [1], hist.rtns[:]
     # on disk
     hf = hist.flush()
-    yield assert_true, hf is not None
+    yield assert_is_not_none, hf
     yield assert_equal, 1, hist.rtns[0]
     yield assert_equal, 1, hist.rtns[-1]
     yield assert_equal, None, hist.outs[-1]
     os.remove(FNAME)
 
+
 def test_show_cmd():
+    """Verify that CLI history commands work."""
     FNAME = 'xonsh-SESSIONID.json'
     FNAME += '.show_cmd'
     cmds = ['ls', 'cat hello kitty', 'abc', 'def', 'touch me', 'grep from me']
 
     def format_hist_line(idx, cmd):
+        """Construct a history output line."""
         return ' {:d}  {:s}\n'.format(idx, cmd)
 
     def run_show_cmd(hist_args, commands, base_idx=0, step=1):
+        """Run and evaluate the output of the given show command."""
         stdout.seek(0, io.SEEK_SET)
         stdout.truncate()
-        history._main(hist, hist_args)  # pylint: disable=protected-access
+        history._main(hist, hist_args)
         stdout.seek(0, io.SEEK_SET)
         hist_lines = stdout.readlines()
         yield assert_equal, len(commands), len(hist_lines)
@@ -95,7 +107,7 @@ def test_show_cmd():
     saved_stdout = sys.stdout
     sys.stdout = stdout
 
-    for cmd in cmds: # populate the shell history
+    for cmd in cmds:  # populate the shell history
         hist.append({'inp': cmd, 'rtn': 0})
 
     # Verify an implicit "show" emits the entire history.
@@ -109,7 +121,7 @@ def test_show_cmd():
     # Verify an explicit "show" with a reversed qualifier emits the entire
     # history in reverse order.
     for x in run_show_cmd(['show', '-r'], list(reversed(cmds)),
-                         len(cmds) - 1, -1):
+                          len(cmds) - 1, -1):
         yield x
 
     # Verify that showing a specific history entry relative to the start of the

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -1,5 +1,6 @@
 """Implements the xonsh history object"""
 import argparse
+import functools
 import os
 import uuid
 import time
@@ -321,6 +322,7 @@ class History(object):
 #
 # Interface to History
 #
+@functools.lru_cache()
 def _create_parser():
     """Create a parser for the "history" command."""
     p = argparse.ArgumentParser(prog='history',
@@ -431,9 +433,9 @@ def _main(hist, args):
     if (args[0] == 'show' and len(args) > 1 and args[-1].startswith('-') and
             args[-1][1].isdigit()):
         args.insert(-1, '--')  # ensure parsing stops before a negative int
-    ns = _HIST_PARSER.parse_args(args)
+    ns = _create_parser().parse_args(args)
     if ns.action is None:  # apply default action
-        ns = _HIST_PARSER.parse_args(['show'] + args)
+        ns = _create_parser().parse_args(['show'] + args)
     _MAIN_ACTIONS[ns.action](ns, hist)
 
 
@@ -441,5 +443,3 @@ def main(args=None, stdin=None):
     """This is the history command entry point."""
     _ = stdin
     _main(builtins.__xonsh_history__, args)  # pylint: disable=no-member
-
-_HIST_PARSER = _create_parser()


### PR DESCRIPTION
This fixes most of the lint errors in the history code. It also fixes
two bugs that were found by pylint due to misnamed variables. This patch
does not make any functional changes. I'll fix the remaining lint errors
in a subsequent patch when I tackle cross-module issues.