### PR TITLE
Currently .gitignore ignores everything.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,6 @@ docs/_build/
 
 # temporary files from vim and emacs
 *~
-*#
-.#*
 *.swp
 *.swo
 


### PR DESCRIPTION
The first line removes is the major offender, the second just makes sense to also remove.