### PR TITLE
add a uniform character encoding to all files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding=utf-8
+# -*- coding: utf-8 -*-
 """The xonsh installer."""
 from __future__ import print_function, unicode_literals
 import os
@@ -33,6 +33,7 @@ CONDA = ("--conda" in sys.argv)
 if CONDA:
     sys.argv.remove("--conda")
 
+
 def clean_tables():
     for f in TABLES:
         if os.path.isfile(f):
@@ -51,13 +52,14 @@ def build_tables():
 
 def install_jupyter_hook(root=None):
     if not HAVE_JUPYTER:
-        print('Could not install Jupyter kernel spec, please install Jupyter/IPython.')
+        print('Could not install Jupyter kernel spec, please install '
+              'Jupyter/IPython.')
         return
     spec = {"argv": [sys.executable, "-m", "xonsh.jupyter_kernel",
                                      "-f", "{connection_file}"],
-            "display_name":"Xonsh",
-            "language":"xonsh",
-            "codemirror_mode":"shell",
+            "display_name": "Xonsh",
+            "language": "xonsh",
+            "codemirror_mode": "shell",
             }
     if CONDA:
         d = os.path.join(sys.prefix + '/share/jupyter/kernels/xonsh/')
@@ -73,7 +75,10 @@ def install_jupyter_hook(root=None):
             with open(os.path.join(d, 'kernel.json'), 'w') as f:
                 json.dump(spec, f, sort_keys=True)
             print('Installing Jupyter kernel spec...')
-            KernelSpecManager().install_kernel_spec(d, 'xonsh', user=('--user' in sys.argv), replace=True, prefix=root)
+            KernelSpecManager().install_kernel_spec(
+                d, 'xonsh', user=('--user' in sys.argv), replace=True,
+                prefix=root)
+
 
 class xinstall(install):
     def run(self):

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Testing built_ins.Aliases"""
 from __future__ import unicode_literals, print_function
 

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh builtins."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Testing dirstack"""
 from __future__ import unicode_literals, print_function
 

--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh environment."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh lexer."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/test_foreign_shells.py
+++ b/tests/test_foreign_shells.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests foreign shells."""
 from __future__ import unicode_literals, print_function
 import os
@@ -43,7 +44,7 @@ def test_foreign_bash_data():
     rcfile = os.path.join(os.path.dirname(__file__), 'bashrc.sh')
     try:
         obsenv, obsaliases = foreign_shell_data('bash', currenv=(),
-                                                extra_args=('--rcfile', rcfile), 
+                                                extra_args=('--rcfile', rcfile),
                                                 safe=False)
     except (subprocess.CalledProcessError, FileNotFoundError):
         raise SkipTest

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh history."""
 # pylint: disable=protected-access
 # TODO: Remove the following pylint directive when it correctly handles calls

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Testing xonsh import hooks"""
 from __future__ import unicode_literals, print_function
 

--- a/tests/test_lazyjson.py
+++ b/tests/test_lazyjson.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests lazy json functionality."""
 from __future__ import unicode_literals, print_function
 from io import StringIO

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh lexer."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/test_man.py
+++ b/tests/test_man.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 
 import nose

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
 """Tests the xonsh parser."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/test_prompt_toolkit_history.py
+++ b/tests/test_prompt_toolkit_history.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests for the LimitedFileHistory class."""
 import os
 from tempfile import NamedTemporaryFile

--- a/tests/test_prompt_toolkit_tools.py
+++ b/tests/test_prompt_toolkit_tools.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests some tools function for prompt_toolkit integration."""
 from __future__ import unicode_literals, print_function
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh replay functionality."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh lexer."""
 from __future__ import unicode_literals, print_function
 import os

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tests the xonsh lexer."""
 from __future__ import unicode_literals, print_function
 import sys

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Aliases for the xonsh shell."""
 import os
 import shlex
@@ -33,7 +34,7 @@ def _ensure_source_foreign_parser():
     desc = "Sources a file written in a foreign shell language."
     parser = ArgumentParser('source-foreign', description=desc)
     parser.add_argument('shell', help='Name or path to the foreign shell')
-    parser.add_argument('files_or_code', nargs='+', 
+    parser.add_argument('files_or_code', nargs='+',
                         help='file paths to source or code in the target '
                              'language.')
     parser.add_argument('-i', '--interactive', type=to_bool, default=True,
@@ -42,23 +43,23 @@ def _ensure_source_foreign_parser():
     parser.add_argument('-l', '--login', type=to_bool, default=False,
                         help='whether the sourced shell should be login',
                         dest='login')
-    parser.add_argument('--envcmd', default='env', dest='envcmd', 
+    parser.add_argument('--envcmd', default='env', dest='envcmd',
                         help='command to print environment')
-    parser.add_argument('--aliascmd', default='alias', dest='aliascmd', 
+    parser.add_argument('--aliascmd', default='alias', dest='aliascmd',
                         help='command to print aliases')
     parser.add_argument('--extra-args', default=(), dest='extra_args',
-                        type=(lambda s: tuple(s.split())), 
+                        type=(lambda s: tuple(s.split())),
                         help='extra arguments needed to run the shell')
-    parser.add_argument('-s', '--safe', type=to_bool, default=True, 
+    parser.add_argument('-s', '--safe', type=to_bool, default=True,
                         help='whether the source shell should be run safely, '
                              'and not raise any errors, even if they occur.',
                         dest='safe')
-    parser.add_argument('-p', '--prevcmd', default=None, dest='prevcmd', 
+    parser.add_argument('-p', '--prevcmd', default=None, dest='prevcmd',
                         help='command(s) to run before any other commands, '
                              'replaces traditional source.')
-    parser.add_argument('--postcmd', default='', dest='postcmd', 
+    parser.add_argument('--postcmd', default='', dest='postcmd',
                         help='command(s) to run after all other commands')
-    parser.add_argument('--funcscmd', default=None, dest='funcscmd', 
+    parser.add_argument('--funcscmd', default=None, dest='funcscmd',
                         help='code to find locations of all native functions '
                              'in the shell language.')
     parser.add_argument('--sourcer', default=None, dest='sourcer',
@@ -66,7 +67,7 @@ def _ensure_source_foreign_parser():
                              'default: source.')
     _SOURCE_FOREIGN_PARSER = parser
     return parser
-    
+
 
 def source_foreign(args, stdin=None):
     """Sources a file written in a foreign shell language."""
@@ -78,10 +79,10 @@ def source_foreign(args, stdin=None):
         ns.prevcmd = '{0} {1}'.format(ns.sourcer, ' '.join(ns.files_or_code))
     foreign_shell_data.cache_clear()  # make sure that we don't get prev src
     fsenv, fsaliases = foreign_shell_data(shell=ns.shell, login=ns.login,
-                            interactive=ns.interactive, envcmd=ns.envcmd, 
-                            aliascmd=ns.aliascmd, extra_args=ns.extra_args,  
-                            safe=ns.safe, prevcmd=ns.prevcmd, 
-                            postcmd=ns.postcmd, funcscmd=ns.funcscmd, 
+                            interactive=ns.interactive, envcmd=ns.envcmd,
+                            aliascmd=ns.aliascmd, extra_args=ns.extra_args,
+                            safe=ns.safe, prevcmd=ns.prevcmd,
+                            postcmd=ns.postcmd, funcscmd=ns.funcscmd,
                             sourcer=ns.sourcer)
     # apply results
     env = builtins.__xonsh_env__

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The xonsh abstract syntax tree node."""
 # These are imported into our module namespace for the benefit of parser.py.
 # pylint: disable=unused-import

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The base class for xonsh shell"""
 import io
 import os

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -1,5 +1,8 @@
-"""The xonsh built-ins. Note that this module is named 'built_ins' so as
-not to be confused with the special Python builtins module.
+# -*- coding: utf-8 -*-
+"""The xonsh built-ins.
+
+Note that this module is named 'built_ins' so as not to be confused with the
+special Python builtins module.
 """
 import os
 import re
@@ -31,14 +34,14 @@ from xonsh.foreign_shells import load_foreign_aliases
 ENV = None
 BUILTINS_LOADED = False
 INSPECTOR = Inspector()
-AT_EXIT_SIGNALS = (signal.SIGABRT, signal.SIGFPE, signal.SIGILL, signal.SIGSEGV, 
+AT_EXIT_SIGNALS = (signal.SIGABRT, signal.SIGFPE, signal.SIGILL, signal.SIGSEGV,
                    signal.SIGTERM)
 if ON_POSIX:
     AT_EXIT_SIGNALS += (signal.SIGTSTP, signal.SIGQUIT, signal.SIGHUP)
 
 
 def resetting_signal_handle(sig, f):
-    """Sets a new signal handle that will automaticallly restore the old value 
+    """Sets a new signal handle that will automaticallly restore the old value
     once the new handle is finished.
     """
     oldh = signal.getsignal(sig)
@@ -319,9 +322,9 @@ def get_script_subproc_command(fname, args):
         raise PermissionError
 
     if ON_POSIX and not os.access(fname, os.R_OK):
-        # on some systems, some importnat programs (e.g. sudo) will have execute 
-        # permissions but not read/write permisions. This enables things with the SUID 
-        # set to be run. Needs to come before _is_binary() is called, because that 
+        # on some systems, some importnat programs (e.g. sudo) will have execute
+        # permissions but not read/write permisions. This enables things with the SUID
+        # set to be run. Needs to come before _is_binary() is called, because that
         # function tries to read the file.
         return [fname] + args
     elif _is_binary(fname):
@@ -612,7 +615,7 @@ def run_subproc(cmds, captured=True):
         if prev_proc.stdout not in (None, sys.stdout):
             output = prev_proc.stdout.read()
         if captured:
-            # to get proper encoding from Popen, we have to 
+            # to get proper encoding from Popen, we have to
             # use a byte stream and then implement universal_newlines here
             output = output.decode(encoding=ENV.get('XONSH_ENCODING'),
                                    errors=ENV.get('XONSH_ENCODING_ERRORS'))
@@ -681,7 +684,7 @@ def load_builtins(execer=None):
     builtins.aliases.update(load_foreign_aliases(issue_warning=False))
     # history needs to be started after env and aliases
     # would be nice to actually include non-detyped versions.
-    builtins.__xonsh_history__ = History(env=ENV.detype(), #aliases=builtins.aliases, 
+    builtins.__xonsh_history__ = History(env=ENV.detype(), #aliases=builtins.aliases,
                                          ts=[time.time(), None], locked=True)
     lastflush = lambda s=None, f=None: builtins.__xonsh_history__.flush(at_exit=True)
     atexit.register(lastflush)

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """A (tab-)completer for xonsh."""
 import os
 import re
@@ -56,13 +57,13 @@ def startswithnorm(x, start, startlow=None):
 
 
 def _normpath(p):
-    """ Wraps os.normpath() to avoid removing './' at the beginning 
+    """ Wraps os.normpath() to avoid removing './' at the beginning
         and '/' at the end. On windows it does the same with backslases
-    """   
+    """
     initial_dotslash = p.startswith(os.curdir + os.sep)
     initial_dotslash |= (ON_WINDOWS and p.startswith(os.curdir + os.altsep))
     p = p.rstrip()
-    trailing_slash = p.endswith(os.sep) 
+    trailing_slash = p.endswith(os.sep)
     trailing_slash |= (ON_WINDOWS and p.endswith(os.altsep))
     p = os.path.normpath(p)
     if initial_dotslash and p != '.':
@@ -315,7 +316,7 @@ class Completer(object):
         for f in builtins.__xonsh_env__.get('BASH_COMPLETIONS'):
             if os.path.isfile(f):
                 # We need to "Unixify" Windows paths for Bash to understand
-                if ON_WINDOWS:  
+                if ON_WINDOWS:
                     f = RE_WIN_DRIVE.sub(lambda m: '/{0}/'.format(m.group(1).lower()), f).replace('\\', '/')
                 srcs.append('source ' + f)
         return srcs

--- a/xonsh/diff_history.py
+++ b/xonsh/diff_history.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tools for diff'ing two xonsh history files in a meaningful fashion."""
 from datetime import datetime
 from itertools import zip_longest
@@ -117,7 +118,7 @@ class HistoryDiffer(object):
         s += ' started: ' + ts0.isoformat(' ')
         if ts[1] is not None:
             ts1 = datetime.fromtimestamp(ts[1])
-            s += ' stopped: ' + ts1.isoformat(' ') + ' runtime: ' + str(ts1 - ts0) 
+            s += ' stopped: ' + ts1.isoformat(' ') + ' runtime: ' + str(ts1 - ts0)
         return s
 
     def header(self):
@@ -195,7 +196,7 @@ class HistoryDiffer(object):
             pass
         elif bout is None:
             aid = self.a['sessionid']
-            s += 'Note: only {red}{aid}{no_color} output stored\n'.format(red=RED, 
+            s += 'Note: only {red}{aid}{no_color} output stored\n'.format(red=RED,
                                                             aid=aid, no_color=NO_COLOR)
         elif aout is None:
             bid = self.b['sessionid']
@@ -234,7 +235,7 @@ class HistoryDiffer(object):
         s = ''
         for tag, i1, i2, j1, j2 in sm.get_opcodes():
             if tag == REPLACE:
-                for i, ainp, j, binp in zip_longest(range(i1, i2), ainps[i1:i2], 
+                for i, ainp, j, binp in zip_longest(range(i1, i2), ainps[i1:i2],
                                                     range(j1, j2), binps[j1:j2]):
                     if j is None:
                         s += self._cmd_in_one_diff(ainp, i, self.a, aid, RED)
@@ -254,7 +255,7 @@ class HistoryDiffer(object):
                     if len(odiff) > 0:
                         h = ('cmd #{i} in {red}{aid}{no_color} input is the same as \n'
                              'cmd #{j} in {green}{bid}{no_color}, but output differs:\n')
-                        s += h.format(i=i, aid=aid, j=j, bid=bid, red=RED, green=GREEN, 
+                        s += h.format(i=i, aid=aid, j=j, bid=bid, red=RED, green=GREEN,
                                       no_color=NO_COLOR)
                         s += odiff + '\n'
             else:
@@ -299,7 +300,7 @@ def _create_parser(p=None):
 def _main_action(ns, hist=None):
     hd = HistoryDiffer(ns.a, ns.b, reopen=ns.reopen, verbose=ns.verbose)
     print(hd.format())
-    
+
 
 def main(args=None, stdin=None):
     """Main entry point for history diff'ing"""

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -1,5 +1,5 @@
-"""Directory stack and associated utilities for the xonsh shell.
-"""
+# -*- coding: utf-8 -*-
+"""Directory stack and associated utilities for the xonsh shell."""
 import os
 import builtins
 from glob import iglob

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Environment for the xonsh shell."""
 import os
 import re
@@ -126,7 +127,7 @@ DEFAULT_VALUES = {
                              '/opt/local/etc/profile.d/bash_completion.sh')
                         if ON_MAC else
                         ('/usr/share/bash-completion/bash_completion',
-                             '/usr/share/bash-completion/completions/git') 
+                             '/usr/share/bash-completion/completions/git')
                         if ON_ARCH else
                         ('/etc/bash_completion',
                              '/usr/share/bash-completion/completions/git')),
@@ -163,7 +164,7 @@ DEFAULT_VALUES = {
     'XONSHRC': ((os.path.join(os.environ['ALLUSERSPROFILE'],
                               'xonsh', 'xonshrc'),
                 os.path.expanduser('~/.xonshrc')) if ON_WINDOWS
-               else ('/etc/xonshrc', os.path.expanduser('~/.xonshrc'))), 
+               else ('/etc/xonshrc', os.path.expanduser('~/.xonshrc'))),
     'XONSH_CONFIG_DIR': xonsh_config_dir,
     'XONSH_DATA_DIR': xonsh_data_dir,
     'XONSH_ENCODING': DEFAULT_ENCODING,

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -1,4 +1,5 @@
-"""Implements the xonsh executer"""
+# -*- coding: utf-8 -*-
+"""Implements the xonsh executer."""
 import re
 import os
 import types

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tools to help interface with foreign shells, such as Bash."""
 import os
 import re
@@ -67,11 +68,11 @@ DEFAULT_SOURCERS = {
 }
 
 @lru_cache()
-def foreign_shell_data(shell, interactive=True, login=False, envcmd='env', 
-                       aliascmd='alias', extra_args=(), currenv=None, 
+def foreign_shell_data(shell, interactive=True, login=False, envcmd='env',
+                       aliascmd='alias', extra_args=(), currenv=None,
                        safe=True, prevcmd='', postcmd='', funcscmd=None,
                        sourcer=None):
-    """Extracts data from a foreign (non-xonsh) shells. Currently this gets 
+    """Extracts data from a foreign (non-xonsh) shells. Currently this gets
     the environment, aliases, and functions but may be extended in the future.
 
     Parameters
@@ -93,7 +94,7 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd='env',
     safe : bool, optional
         Flag for whether or not to safely handle exceptions and other errors.
     prevcmd : str, optional
-        A command to run in the shell before anything else, useful for 
+        A command to run in the shell before anything else, useful for
         sourcing and other commands that may require environment recovery.
     postcmd : str, optional
         A command to run after everything else, useful for cleaning up any
@@ -103,12 +104,12 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd='env',
         and locations of any functions that are native to the foreign shell.
         This command should print *only* a whitespace separated sequence
         of pairs function name & filenames where the functions are defined.
-        If this is None, then a default script will attempted to be looked 
+        If this is None, then a default script will attempted to be looked
         up based on the shell name. Callable wrappers for these functions
         will be returned in the aliases dictionary.
     sourcer : str or None, optional
         How to source a foreign shell file for purposes of calling functions
-        in that shell. If this is None, a default value will attempt to be 
+        in that shell. If this is None, a default value will attempt to be
         looked up based on the shell name.
 
     Returns
@@ -116,7 +117,7 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd='env',
     env : dict
         Dictionary of shell's environment
     aliases : dict
-        Dictionary of shell's alaiases, this includes foreign function 
+        Dictionary of shell's alaiases, this includes foreign function
         wrappers.
     """
     cmd = [shell]
@@ -161,7 +162,7 @@ def parse_env(s):
     return env
 
 
-ALIAS_RE = re.compile('__XONSH_ALIAS_BEG__\n(.*)__XONSH_ALIAS_END__', 
+ALIAS_RE = re.compile('__XONSH_ALIAS_BEG__\n(.*)__XONSH_ALIAS_END__',
                       flags=re.DOTALL)
 
 def parse_aliases(s):
@@ -211,7 +212,7 @@ def parse_funcs(s, shell, sourcer=None):
     for funcname, filename in zip(flatpairs[::2], flatpairs[1::2]):
         if funcname.startswith('_'):
             continue  # skip private functions
-        wrapper = ForeignShellFunctionAlias(name=funcname, shell=shell, 
+        wrapper = ForeignShellFunctionAlias(name=funcname, shell=shell,
                                             sourcer=sourcer, filename=filename)
         funcs[funcname] = wrapper
     return funcs
@@ -223,7 +224,7 @@ class ForeignShellFunctionAlias(object):
     """
 
     INPUT = ('{sourcer} {filename}\n'
-             '{funcname} {args}\n') 
+             '{funcname} {args}\n')
 
     def __init__(self, name, shell, filename, sourcer=None):
         """
@@ -278,8 +279,8 @@ class ForeignShellFunctionAlias(object):
         return args, True
 
 
-VALID_SHELL_PARAMS = frozenset(['shell', 'interactive', 'login', 'envcmd', 
-                                'aliascmd', 'extra_args', 'currenv', 'safe', 
+VALID_SHELL_PARAMS = frozenset(['shell', 'interactive', 'login', 'envcmd',
+                                'aliascmd', 'extra_args', 'currenv', 'safe',
                                 'prevcmd', 'postcmd', 'funcscmd', 'sourcer'])
 
 def ensure_shell(shell):
@@ -357,7 +358,7 @@ def load_foreign_envs(shells=None, config=None, issue_warning=True):
         keyword arguments. Not compatible with config not being None.
     config : str of None, optional
         Path to the static config file. Not compatible with shell not being None.
-        If both shell and config is None, then it will be read from the 
+        If both shell and config is None, then it will be read from the
         $XONSHCONFIG environment variable.
     issue_warning : bool, optional
         Issues warnings if config file cannot be found.
@@ -386,7 +387,7 @@ def load_foreign_aliases(shells=None, config=None, issue_warning=True):
         keyword arguments. Not compatible with config not being None.
     config : str of None, optional
         Path to the static config file. Not compatible with shell not being None.
-        If both shell and config is None, then it will be read from the 
+        If both shell and config is None, then it will be read from the
         $XONSHCONFIG environment variable.
     issue_warning : bool, optional
         Issues warnings if config file cannot be found.

--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -1,4 +1,5 @@
-"""Implements the xonsh history object"""
+# -*- coding: utf-8 -*-
+"""Implements the xonsh history object."""
 import argparse
 import functools
 import os

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -1,5 +1,7 @@
-"""Import hooks for importing xonsh source files. This module registers
-the hooks it defines when it is imported.
+# -*- coding: utf-8 -*-
+"""Import hooks for importing xonsh source files.
+
+This module registers the hooks it defines when it is imported.
 """
 import os
 import sys

--- a/xonsh/inspectors.py
+++ b/xonsh/inspectors.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tools for inspecting Python objects.
 
 This file was forked from the IPython project:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -1,6 +1,5 @@
-"""
-Job control for the xonsh shell.
-"""
+# -*- coding: utf-8 -*-
+"""Job control for the xonsh shell."""
 import os
 import sys
 import time

--- a/xonsh/jupyter_kernel.py
+++ b/xonsh/jupyter_kernel.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Hooks for Jupyter Xonsh Kernel."""
 import io
 import builtins

--- a/xonsh/lazyjson.py
+++ b/xonsh/lazyjson.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Implements a lazy JSON file class that wraps around json data."""
 import io
 import weakref

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -1,5 +1,7 @@
-"""
-Lexer for xonsh code, written using a hybrid of ``tokenize`` and PLY
+# -*- coding: utf-8 -*-
+"""Lexer for xonsh code.
+
+Written using a hybrid of ``tokenize`` and PLY.
 """
 import re
 import sys

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The main xonsh script."""
 import os
 import sys

--- a/xonsh/openpy.py
+++ b/xonsh/openpy.py
@@ -1,6 +1,7 @@
-"""
-Tools to open ``*.py`` files as Unicode, using the encoding specified within the
-file, as per PEP 263.
+# -*- coding: utf-8 -*-
+"""Tools to open ``*.py`` files as Unicode.
+
+Uses the encoding specified within the file, as per PEP 263.
 
 Much of the code is taken from the tokenize module in Python 3.2.
 

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -1,4 +1,5 @@
-"""Implements the xonsh parser"""
+# -*- coding: utf-8 -*-
+"""Implements the xonsh parser."""
 import os
 import sys
 from collections import Iterable, Sequence, Mapping
@@ -213,8 +214,8 @@ class Parser(object):
             'or_and_test', 'and_not_test', 'comp_op_expr', 'pipe_xor_expr',
             'xor_and_expr', 'ampersand_shift_expr', 'shift_arith_expr',
             'pm_term', 'op_factor', 'trailer', 'comma_subscript',
-            'comma_expr_or_star_expr', 'comma_test', 'comma_argument', 'comma_item', 
-            'attr_period_name', 'test_comma', 'equals_yield_expr_or_testlist', 
+            'comma_expr_or_star_expr', 'comma_test', 'comma_argument', 'comma_item',
+            'attr_period_name', 'test_comma', 'equals_yield_expr_or_testlist',
             'test_or_star_expr']
         if VER_MAJOR_MINOR <= VER_3_4:
             list_rules += ['argument_comma',]
@@ -807,7 +808,7 @@ class Parser(object):
         elif lenp == 4:
             op = self._augassign_op[p2]
             if op is None:
-                self._parse_error('operation {0!r} not supported'.format(p2), 
+                self._parse_error('operation {0!r} not supported'.format(p2),
                                   self.currloc(lineno=p.lineno, column=p.lexpos))
             p0 = ast.AugAssign(target=p1[0], op=op(), value=p[3],
                                lineno=self.lineno, col_offset=self.col)
@@ -1282,7 +1283,7 @@ class Parser(object):
 
     def p_async_stmt(self, p):
         """async_stmt : async_funcdef
-                      | async_with_stmt 
+                      | async_with_stmt
                       | async_for_stmt
         """
         p[0] = p[1]
@@ -1585,7 +1586,7 @@ class Parser(object):
         """
         op = self._term_binops[p[1]]
         if op is None:
-            self._parse_error('operation {0!r} not supported'.format(p[1]), 
+            self._parse_error('operation {0!r} not supported'.format(p[1]),
                               self.currloc(lineno=p.lineno, column=p.lexpos))
         p[0] = [op(), p[2]]
 
@@ -1686,7 +1687,7 @@ class Parser(object):
                 assert False
             leader = p0
         if lenp == 4:
-            p0 = ast.Await(value=p0, ctx=ast.Load(), lineno=self.lineno, 
+            p0 = ast.Await(value=p0, ctx=ast.Load(), lineno=self.lineno,
                            col_offset=self.col)
         p[0] = p0
 
@@ -1961,7 +1962,7 @@ class Parser(object):
         )
     def p_item(self, p):
         lenp = len(p)
-        if lenp == 4: 
+        if lenp == 4:
             p0 = [p[1], p[3]]
         elif lenp == 3:
             p0 = [None, p[2]]
@@ -2144,7 +2145,7 @@ class Parser(object):
         """argument : test
                     | test comp_for
                     | test EQUALS test
-        """, 
+        """,
         v35 = \
         """argument : test_or_star_expr
                     | test comp_for

--- a/xonsh/pretty.py
+++ b/xonsh/pretty.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-"""
-Python advanced pretty printer.  This pretty printer is intended to
-replace the old `pprint` python module which does not allow developers
-to provide their own pretty print callbacks.
+"""Python advanced pretty printer.
+
+This pretty printer is intended to replace the old `pprint` python module which
+does not allow developers to provide their own pretty print callbacks.
 
 This module is based on ruby's `prettyprint.rb` library by `Tanaka Akira`.
 

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Interface for running Python functions as subprocess-mode commands.
 
 Code for several helper methods in the `ProcProxy` class have been reproduced
@@ -358,8 +359,8 @@ class TeePTYProc(object):
 
     def __init__(self, args, stdin=None, stdout=None, stderr=None, preexec_fn=None,
                  env=None, universal_newlines=False):
-        """Popen replacement for running commands in teed psuedo-terminal. This 
-        allows the capturing AND streaming of stdout and stderr.  Availability 
+        """Popen replacement for running commands in teed psuedo-terminal. This
+        allows the capturing AND streaming of stdout and stderr.  Availability
         is Linux-only.
         """
         self.stdin = stdin
@@ -368,7 +369,7 @@ class TeePTYProc(object):
         self.args = args
         self.universal_newlines = universal_newlines
         xenv = builtins.__xonsh_env__ if hasattr(builtins, '__xonsh_env__') \
-                                      else {'XONSH_ENCODING': 'utf-8', 
+                                      else {'XONSH_ENCODING': 'utf-8',
                                             'XONSH_ENCODING_ERRORS': 'strict'}
 
         if not os.access(args[0], os.F_OK):

--- a/xonsh/prompt_toolkit_completer.py
+++ b/xonsh/prompt_toolkit_completer.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Completer implementation to use with prompt_toolkit."""
 from prompt_toolkit.completion import Completer, Completion
 

--- a/xonsh/prompt_toolkit_history.py
+++ b/xonsh/prompt_toolkit_history.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """History object for use with prompt_toolkit."""
 import os
 

--- a/xonsh/prompt_toolkit_key_bindings.py
+++ b/xonsh/prompt_toolkit_key_bindings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Key bindings for prompt_toolkit xonsh shell."""
 import builtins
 

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -1,4 +1,5 @@
-"""The prompt_toolkit based xonsh shell"""
+# -*- coding: utf-8 -*-
+"""The prompt_toolkit based xonsh shell."""
 import os
 import builtins
 from warnings import warn
@@ -50,7 +51,7 @@ class PromptToolkitShell(BaseShell):
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
         self.key_bindings_manager = KeyBindingManager(
             enable_auto_suggest_bindings=True,
-            enable_search=True, 
+            enable_search=True,
             enable_abort_and_exit_bindings=True,
             enable_vi_mode=Condition(lambda cli: builtins.__xonsh_env__.get('VI_MODE')),
             enable_open_in_editor=True)

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Hooks for pygments syntax highlighting."""
 from pygments.lexer import inherit, bygroups, using, this
 from pygments.token import Name, Generic, Keyword, Text, String

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -1,4 +1,5 @@
-"""The readline based xonsh shell"""
+# -*- coding: utf-8 -*-
+"""The readline based xonsh shell."""
 import os
 import sys
 import time
@@ -255,7 +256,7 @@ class ReadlineShell(BaseShell, Cmd):
 class ReadlineHistoryAdder(Thread):
 
     def __init__(self, wait_for_gc=True, *args, **kwargs):
-        """Thread responsible for adding inputs from history to the current readline 
+        """Thread responsible for adding inputs from history to the current readline
         instance. May wait for the history garbage collector to finish.
         """
         super(ReadlineHistoryAdder, self).__init__(*args, **kwargs)

--- a/xonsh/replay.py
+++ b/xonsh/replay.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Tools to replay xonsh history files."""
 import time
 import builtins
@@ -31,7 +32,7 @@ class Replayer(object):
         self._lj.close()
 
     def replay(self, merge_envs=DEFAULT_MERGE_ENVS, target=None):
-        """Replays the history specified, returns the history object where the code 
+        """Replays the history specified, returns the history object where the code
         was executed.
 
         Parameters
@@ -40,7 +41,7 @@ class Replayer(object):
             Describes how to merge the environments, in order of increasing precednce.
             Available strings are 'replay' and 'native'. The 'replay' env comes from the
             history file that we are replaying. The 'native' env comes from what this
-            instance of xonsh was started up with. Instead of a string, a dict or other 
+            instance of xonsh was started up with. Instead of a string, a dict or other
             mapping may be passed in as well. Defaults to ('replay', 'native').
         target : str, optional
             Path to new history file.
@@ -85,8 +86,8 @@ def _create_parser(p=None):
     if p_was_none:
         from argparse import ArgumentParser
         p = ArgumentParser('replay', description='replays a xonsh history file')
-    p.add_argument('--merge-envs', dest='merge_envs', default=DEFAULT_MERGE_ENVS, 
-                   nargs='+', 
+    p.add_argument('--merge-envs', dest='merge_envs', default=DEFAULT_MERGE_ENVS,
+                   nargs='+',
                    help="Describes how to merge the environments, in order of "
                         "increasing precedence. Available strings are 'replay' and "
                         "'native'. The 'replay' env comes from the history file that we "
@@ -95,7 +96,7 @@ def _create_parser(p=None):
                         "be passed in. Defaults to '--merge-envs replay native'.")
     p.add_argument('--json', dest='json', default=False, action='store_true',
                    help='print history info in JSON format')
-    p.add_argument('-o', '--target', dest='target', default=None, 
+    p.add_argument('-o', '--target', dest='target', default=None,
                    help='path to new history file')
     p.add_argument('path', help='path to replay history file')
     if p_was_none:

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """The xonsh shell"""
 import builtins
 from warnings import warn

--- a/xonsh/teepty.py
+++ b/xonsh/teepty.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 """This implements a psuedo-TTY that tees its output into a Python buffer.
 
 This file was forked from a version distibuted under an MIT license and
-Copyright (c) 2011 Joshua D. Bartlett. 
-See http://sqizit.bartletts.id.au/2011/02/14/pseudo-terminals-in-python/ for 
+Copyright (c) 2011 Joshua D. Bartlett.
+See http://sqizit.bartletts.id.au/2011/02/14/pseudo-terminals-in-python/ for
 more information.
 """
 import io
@@ -45,7 +46,7 @@ def _findfirst(s, substrs):
 
 
 def _on_main_thread():
-    """Checks if we are on the main thread or not. Duplicated from xonsh.tools 
+    """Checks if we are on the main thread or not. Duplicated from xonsh.tools
     here so that this module only relies on the Python standrd library.
     """
     return threading.current_thread() is threading.main_thread()
@@ -67,7 +68,7 @@ def _find_error_code(e):
 class TeePTY(object):
     """This class is a pseudo terminal that tees the stdout and stderr into a buffer."""
 
-    def __init__(self, bufsize=1024, remove_color=True, encoding='utf-8', 
+    def __init__(self, bufsize=1024, remove_color=True, encoding='utf-8',
                  errors='strict'):
         """
         Parameters
@@ -92,7 +93,7 @@ class TeePTY(object):
         self._temp_stdin = None
 
     def __str__(self):
-        return self.buffer.getvalue().decode(encoding=self.encoding, 
+        return self.buffer.getvalue().decode(encoding=self.encoding,
                                              errors=self.errors)
 
     def __del__(self):
@@ -179,7 +180,7 @@ class TeePTY(object):
         self._set_pty_size()
 
     def _set_pty_size(self):
-        """Sets the window size of the child pty based on the window size of 
+        """Sets the window size of the child pty based on the window size of
         our own controlling terminal.
         """
         assert self.master_fd is not None
@@ -199,7 +200,7 @@ class TeePTY(object):
             try:
                 rfds, wfds, xfds = select.select([master_fd, pty.STDIN_FILENO], [], [])
             except OSError as e:
-                if e.errno == 4:  # Interrupted system call. 
+                if e.errno == 4:  # Interrupted system call.
                     continue      # This happens at terminal resize.
             if master_fd in rfds:
                 data = os.read(master_fd, bufsize)
@@ -215,15 +216,15 @@ class TeePTY(object):
         elif flag is not None:
             if flag in START_ALTERNATE_MODE:
                 # This code is executed when the child process switches the terminal into
-                # alternate mode. The line below assumes that the user has opened vim, 
+                # alternate mode. The line below assumes that the user has opened vim,
                 # less, or similar, and writes writes to stdin.
-                d0 = data[:i] 
+                d0 = data[:i]
                 self._in_alt_mode = True
                 d1 = self._sanatize_data(data[i+len(flag):])
                 data = d0 + d1
             elif flag in END_ALTERNATE_MODE:
                 # This code is executed when the child process switches the terminal back
-                # out of alternate mode. The line below assumes that the user has 
+                # out of alternate mode. The line below assumes that the user has
                 # returned to the command prompt.
                 self._in_alt_mode = False
                 data = self._sanatize_data(data[i+len(flag):])
@@ -249,7 +250,7 @@ class TeePTY(object):
             data = data[n:]
 
     def _stdin_filename(self, stdin):
-        if stdin is None: 
+        if stdin is None:
             rtn = None
         elif isinstance(stdin, io.FileIO) and os.path.isfile(stdin.name):
             rtn = stdin.name
@@ -292,15 +293,15 @@ class TeePTY(object):
             raise ValueError('stdin not understood {0!r}'.format(stdin))
 
     def _delay_for_pipe(self, env=None, delay=None):
-        # This delay is sometimes needed because the temporary stdin file that 
+        # This delay is sometimes needed because the temporary stdin file that
         # is being written (the pipe) may not have even hits its first flush()
-        # call by the time the spawned process starts up and determines there 
+        # call by the time the spawned process starts up and determines there
         # is nothing in the file. The spawn can thus exit, without doing any
         # real work.  Consider the case of piping something into grep:
         #
         #   $ ps aux | grep root
         #
-        # grep will exit on EOF and so there is a race between the buffersize 
+        # grep will exit on EOF and so there is a race between the buffersize
         # and flushing the temporary file and grep.  However, this race is not
         # always meaningful. Pagers, for example, update when the file is written
         # to. So what is important is that we start the spawned process ASAP:
@@ -311,14 +312,14 @@ class TeePTY(object):
         # not blocking and letting the spawned process have enough to work with
         # such that it doesn't exit prematurely.  Unfortunately, there is no
         # way to know a priori how big the file is, how long the spawned process
-        # will run for, etc. Thus as user-definable delay let's the user 
+        # will run for, etc. Thus as user-definable delay let's the user
         # find something that works for them.
         if delay is None:
             delay = (env or os.environ).get('TEEPTY_PIPE_DELAY', -1.0)
         delay = float(delay)
         if 0.0 < delay:
             time.sleep(delay)
-        
+
 
 if __name__ == '__main__':
     tpty = TeePTY()

--- a/xonsh/timings.py
+++ b/xonsh/timings.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Timing related functionality for the xonsh shell.
 
 The following time_it alias and Timer was forked from the IPython project:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Misc. xonsh tools.
 
 The following implementations were forked from the IPython project:
@@ -450,7 +451,7 @@ def on_main_thread():
 
 @contextmanager
 def swap(namespace, name, value, default=NotImplemented):
-    """Swaps a current variable name in a namespace for another value, and then 
+    """Swaps a current variable name in a namespace for another value, and then
     replaces it when the context is exited.
     """
     old = getattr(namespace, name, default)
@@ -591,11 +592,11 @@ CANON_HISTORY_UNITS = frozenset(['commands', 'files', 's', 'b'])
 
 HISTORY_UNITS = {
     '': ('commands', int),
-    'c': ('commands', int), 
-    'cmd': ('commands', int), 
-    'cmds': ('commands', int), 
-    'command': ('commands', int), 
-    'commands': ('commands', int), 
+    'c': ('commands', int),
+    'cmd': ('commands', int),
+    'cmds': ('commands', int),
+    'command': ('commands', int),
+    'commands': ('commands', int),
     'f': ('files', int),
     'files': ('files', int),
     's': ('s', float),


### PR DESCRIPTION
I wouldn't normally do something like this but issue #487 brought to
my attention the fact that too many of the python modules don't have
an encoding comment and of those that do there is a lot of pointless
inconsistency in the style of the comment.