### PR TITLE
enable sudo completion in pt and readline shells

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -28,6 +28,8 @@ XONSH_TOKENS = {
     '...'
 }
 
+COMPLETION_SKIP_TOKENS = {'sudo', 'time'}
+
 BASH_COMPLETE_SCRIPT = """source {filename}
 COMP_WORDS=({line})
 COMP_LINE={comp_line}
@@ -123,11 +125,11 @@ class Completer(object):
         ctx = ctx or {}
         prefixlow = prefix.lower()
         cmd = line.split(' ', 1)[0]
-        if cmd == 'sudo':
+        if cmd in COMPLETION_SKIP_TOKENS:
+            begidx -= len(cmd)+1
+            endidx -= len(cmd)+1
             cmd = line.split(' ', 2)[1]
             line = line.split(' ', 1)[1]
-            begidx -= 5
-            endidx -= 5
         csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         startswither = startswithnorm if csc else startswithlow
         if begidx == 0:

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -123,6 +123,11 @@ class Completer(object):
         ctx = ctx or {}
         prefixlow = prefix.lower()
         cmd = line.split(' ', 1)[0]
+        if cmd == 'sudo':
+            cmd = line.split(' ', 2)[1]
+            line = line.split(' ', 1)[1]
+            begidx -= 5
+            endidx -= 5
         csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         startswither = startswithnorm if csc else startswithlow
         if begidx == 0:
@@ -138,6 +143,8 @@ class Completer(object):
             if len(rtn) == 0:
                 rtn = self.path_complete(prefix)
             return sorted(rtn)
+#        elif prefix.startswith('sudo '):
+#            rtn = self.cmd_complete(prefixe[5:], begidx,endidx)
         elif prefix.startswith('${') or prefix.startswith('@('):
             # python mode explicitly
             rtn = set()

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -143,8 +143,6 @@ class Completer(object):
             if len(rtn) == 0:
                 rtn = self.path_complete(prefix)
             return sorted(rtn)
-#        elif prefix.startswith('sudo '):
-#            rtn = self.cmd_complete(prefixe[5:], begidx,endidx)
         elif prefix.startswith('${') or prefix.startswith('@('):
             # python mode explicitly
             rtn = set()


### PR DESCRIPTION
If the command is 'sudo', this short-circuits the completion and just
cuts sudo out of the logic entirely, allowing the completer to act as if
it weren't there.

This might be a little too hacky, but it works on my machines without issue and enables completion lines beginning with `sudo` for both `prompt_toolkit` and `readline`.  

I'm also submitting this because `sudo` completion doesn't work for me even though it's in my `$BASH_COMPLETIONS`.  If others have `sudo` completion working already, then I'll dig around more to try and determine the root cause of the issue.  