### PR TITLE
Add support for -i and -l options

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -205,6 +205,8 @@ applicable.
     * - XONSH_INTERACTIVE
       - 
       - ``True`` if xonsh is running interactively, and ``False`` otherwise.
+    * - XONSH_LOGIN
+      - ``True`` if xonsh is running as a login shell, and ``False`` otherwise.
     * - XONSH_SHOW_TRACEBACK
       - ``False`` but not set
       - Controls if a traceback is shown exceptions occur in the shell. Set ``True`` 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Tests the xonsh main function."""
+from __future__ import unicode_literals, print_function
+
+import builtins
+from unittest.mock import patch
+
+import nose
+from nose.tools import assert_true, assert_false
+
+import xonsh.main
+
+from tools import mock_xonsh_env
+
+
+def test_login_shell():
+    def Shell(*args, **kwargs):
+        pass
+
+    with patch('xonsh.main.Shell', Shell), mock_xonsh_env({}):
+        xonsh.main.premain([])
+        assert_false(builtins.__xonsh_env__.get('XONSH_LOGIN'))
+
+    with patch('xonsh.main.Shell', Shell), mock_xonsh_env({}):
+        xonsh.main.premain(['-l'])
+        assert_true(builtins.__xonsh_env__.get('XONSH_LOGIN'))
+
+if __name__ == '__main__':
+    nose.runmodule()

--- a/tests/test_man.py
+++ b/tests/test_man.py
@@ -8,7 +8,7 @@ from nose.plugins.skip import SkipTest
 from xonsh.tools import ON_WINDOWS
 from xonsh.completer import ManCompleter
 
-from tools import mock_xonsh_env
+from tests.tools import mock_xonsh_env
 
 _OLD_MANPATH = None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -71,6 +71,7 @@ DEFAULT_ENSURERS = {
     'XONSH_ENCODING': (is_string, ensure_string, ensure_string),
     'XONSH_ENCODING_ERRORS': (is_string, ensure_string, ensure_string),
     'XONSH_HISTORY_SIZE': (is_history_tuple, to_history_tuple, history_tuple_to_str),
+    'XONSH_LOGIN': (is_bool, to_bool, bool_to_str),
     'XONSH_STORE_STDOUT': (is_bool, to_bool, bool_to_str),
     'VI_MODE': (is_bool, to_bool, bool_to_str),
 }
@@ -171,6 +172,7 @@ DEFAULT_VALUES = {
     'XONSH_ENCODING_ERRORS': 'surrogateescape',
     'XONSH_HISTORY_FILE': os.path.expanduser('~/.xonsh_history.json'),
     'XONSH_HISTORY_SIZE': (8128, 'commands'),
+    'XONSH_LOGIN': False,
     'XONSH_SHOW_TRACEBACK': False,
     'XONSH_STORE_STDOUT': False,
 }

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -24,6 +24,16 @@ parser.add_argument('-c',
                     dest='command',
                     required=False,
                     default=None)
+parser.add_argument('-i',
+                    help='force running in interactive mode',
+                    dest='force_interactive',
+                    action='store_true',
+                    default=False)
+parser.add_argument('-l',
+                    help='run as a login shell',
+                    dest='login',
+                    action='store_true',
+                    default=False)
 parser.add_argument('--no-rc',
                     help="Do not load the .xonshrc file",
                     dest='norc',
@@ -75,6 +85,8 @@ def premain(argv=None):
     env = builtins.__xonsh_env__
     if args.defines is not None:
         env.update([x.split('=', 1) for x in args.defines])
+    if args.login:
+        env['XONSH_LOGIN'] = True
     env['XONSH_INTERACTIVE'] = False
     return args
 
@@ -98,7 +110,7 @@ def main(argv=None):
             shell.execer.exec(code, mode='exec', glbs=shell.ctx)
         else:
             print('xonsh: {0}: No such file or directory.'.format(args.file))
-    elif not sys.stdin.isatty():
+    elif not sys.stdin.isatty() and not args.force_interactive:
         # run a script given on stdin
         code = sys.stdin.read()
         code = code if code.endswith('\n') else code + '\n'


### PR DESCRIPTION
Support for the login option is very minimal, but the `XONSH_LOGIN` variable is set in this case so that scripts may take an appropriate action.

I know that the guidelines call for all new code to have tests, but I'm unclear what the right way to test this is; we currently have no tests that actually check the `main` function at all, and at any rate, I'd usually prefer using a tool like [cram](https://pypi.python.org/pypi/cram) to test this certain class of feature anyway. I'm happy to amend the PR with guidance.

Fixes #517 
