### PR TITLE
Fix use-before-define error in "make test"

### DIFF
--- a/scripts/run_tests.xsh
+++ b/scripts/run_tests.xsh
@@ -36,7 +36,7 @@ elif len($ARGS) == 2 and $ARG1 == 'edited':
             if os.path.exists(test_fname):
                 tests.add(test_fname)
         elif edited_fname.startswith('tests/'):
-            tests.add(test_fname)
+            tests.add(edited_fname)
         else:
             print('Ignoring file because I cannot find a test for: {!r}.'.
                   format(edited_fname), file=sys.stderr)


### PR DESCRIPTION
In the case that a test was edited, "make test" would erroneously
attempt to add `test_fname` to the list of files to test...which doesn't
exist in that branch. Instead, it should be adding `edited_fname` in
that case.