### PR TITLE
add alias expansion to completer

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -108,6 +108,22 @@ class Aliases(MutableMapping):
                                        seen_tokens | {token},
                                        rest + acc_args)
 
+    def expand_alias(self, line):
+        """
+        Expands any aliases present in line if alias does not point to a
+        builtin function and if alias is only a single command.
+        """
+        word = line.split(' ', 1)[0]
+        if (word in builtins.aliases and
+            type(self.get(word)) is list and
+            len(self.get(word)) == 1):
+            word_idx = line.find(word)
+            line = line[:word_idx] +\
+                self.get(word)[0] +\
+                line[word_idx+len(word):]
+
+        return line
+
     #
     # Mutable mapping interface
     #

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -78,22 +78,6 @@ def _normpath(p):
 
     return p
 
-def alias_expand(line):
-    """ Expands any aliases present in line if alias does not point to a builtin function and if alias is only a single command.
-    """
-    
-    for word in line.split(' '):
-        if (word in builtins.aliases
-            and type(builtins.aliases.get(word)) is list
-            and len(builtins.aliases.get(word)) == 1):
-            word_idx = line.find(word)
-            line = line[:word_idx] +\
-                    builtins.aliases.get(word)[0] +\
-                    line[word_idx+len(word):]
-
-    return line
-
-
 class Completer(object):
     """This provides a list of optional completions for the xonsh shell."""
 
@@ -139,7 +123,7 @@ class Completer(object):
         dot = '.'
         ctx = ctx or {}
         prefixlow = prefix.lower()
-        line = alias_expand(line)
+        line = builtins.aliases.expand_alias(line)
         cmd = line.split(' ', 1)[0]
         if cmd in COMPLETION_SKIP_TOKENS:
             begidx -= len(cmd)+1

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -78,6 +78,21 @@ def _normpath(p):
 
     return p
 
+def alias_expand(line):
+    """ Expands any aliases present in line if alias does not point to a builtin function and if alias is only a single command.
+    """
+    
+    for word in line.split(' '):
+        if (word in builtins.aliases
+            and type(builtins.aliases.get(word)) is list
+            and len(builtins.aliases.get(word)) == 1):
+            word_idx = line.find(word)
+            line = line[:word_idx] +\
+                    builtins.aliases.get(word)[0] +\
+                    line[word_idx+len(word):]
+
+    return line
+
 
 class Completer(object):
     """This provides a list of optional completions for the xonsh shell."""
@@ -124,6 +139,7 @@ class Completer(object):
         dot = '.'
         ctx = ctx or {}
         prefixlow = prefix.lower()
+        line = alias_expand(line)
         cmd = line.split(' ', 1)[0]
         if cmd in COMPLETION_SKIP_TOKENS:
             begidx -= len(cmd)+1
@@ -174,6 +190,7 @@ class Completer(object):
                 if startswither(s, prefix, prefixlow)}
         rtn |= self.path_complete(prefix)
         return sorted(rtn)
+
 
     def find_and_complete(self, line, idx, ctx=None):
         """Finds the completions given only the full code line and a current cursor


### PR DESCRIPTION
Adds a function to expand aliases in the completer to allow completion
for user-defined aliases.

e.g.
```Bash
aliases['g'] = 'git'
aliases['ck'] = 'checkout'
```
then `'g ck' TAB` will show available branches for checkout.

This is currently restricted to single item aliases.

I think this helps satisfy #391 but it may not work exactly as expected -- I'm not sure if the `aliases` dict pulls in aliases from `~/.gitconfig`

Other questions:

Is there a use case for expanding multiple word aliases?  That would be relatively easy to add in.

Should this be optional?  It does have to run the expansion every time the completer is called though it is quite fast.  A failed search through a 500 key-pair dictionary takes on the order of 1e-8 seconds.