### PR TITLE
Highlight (python) code when using prompt_toolkit

### DIFF
--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -3,15 +3,12 @@
 
 Written using a hybrid of ``tokenize`` and PLY.
 """
-import re
-import sys
 import tokenize
 
 from io import BytesIO
 from keyword import kwlist
 
-from ply import lex
-from ply.lex import TOKEN, LexToken
+from ply.lex import LexToken
 
 from xonsh.tools import VER_3_5, VER_MAJOR_MINOR
 

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -17,8 +17,7 @@ from xonsh.tools import format_prompt_for_prompt_toolkit
 from xonsh.prompt_toolkit_completer import PromptToolkitCompleter
 from xonsh.prompt_toolkit_history import LimitedFileHistory
 from xonsh.prompt_toolkit_key_bindings import load_xonsh_bindings
-
-from .pyghooks import XonshLexer
+from xonsh.pyghooks import XonshLexer
 
 
 def setup_history():

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -11,13 +11,14 @@ from prompt_toolkit.filters import Condition
 from pygments.token import Token
 from pygments.style import Style
 from pygments.styles.default import DefaultStyle
-from pygments.lexers import PythonLexer
 
 from xonsh.base_shell import BaseShell
 from xonsh.tools import format_prompt_for_prompt_toolkit
 from xonsh.prompt_toolkit_completer import PromptToolkitCompleter
 from xonsh.prompt_toolkit_history import LimitedFileHistory
 from xonsh.prompt_toolkit_key_bindings import load_xonsh_bindings
+
+from .pyghooks import XonshLexer
 
 
 def setup_history():
@@ -85,7 +86,7 @@ class PromptToolkitShell(BaseShell):
                     get_prompt_tokens=token_func,
                     style=style_cls,
                     completer=completer,
-                    lexer=PygmentsLexer(PythonLexer),
+                    lexer=PygmentsLexer(XonshLexer),
                     history=self.history,
                     key_bindings_registry=self.key_bindings_manager.registry,
                     display_completions_in_columns=multicolumn)

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 """The prompt_toolkit based xonsh shell."""
-import os
 import builtins
 from warnings import warn
 
 from prompt_toolkit.shortcuts import prompt
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.filters import Condition
 from pygments.token import Token
 from pygments.style import Style
+from pygments.styles.default import DefaultStyle
+from pygments.lexers import PythonLexer
 
 from xonsh.base_shell import BaseShell
 from xonsh.tools import format_prompt_for_prompt_toolkit
@@ -83,6 +85,7 @@ class PromptToolkitShell(BaseShell):
                     get_prompt_tokens=token_func,
                     style=style_cls,
                     completer=completer,
+                    lexer=PygmentsLexer(PythonLexer),
                     history=self.history,
                     key_bindings_registry=self.key_bindings_manager.registry,
                     display_completions_in_columns=multicolumn)
@@ -108,14 +111,15 @@ class PromptToolkitShell(BaseShell):
             return list(zip(tokens, strings))
 
         class CustomStyle(Style):
-            styles = {
+            styles = DefaultStyle.styles.copy()
+            styles.update({
                 Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
                 Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
                 Token.Menu.Completions.ProgressButton: 'bg:#003333',
                 Token.Menu.Completions.ProgressBar: 'bg:#00aaaa',
                 Token.AutoSuggestion: '#666666',
                 Token.Aborted: '#888888',
-            }
+            })
             # update with the prompt styles
             styles.update({t: s for (t, s) in zip(tokens, cstyles)})
             # Update with with any user styles


### PR DESCRIPTION
rely on Pygments Python Lexer for now,
One need to write a XonshLexer, but lexers based on the current one dont'
work as they don't return whitespace.

<img width="424" alt="screen shot 2015-11-27 at 10 07 51" src="https://cloud.githubusercontent.com/assets/335567/11437537/cf6d4112-94ee-11e5-98e2-bb1b9989fc64.png">
--- 

Also cleanup unused import in lexer. I've tried to write a simple PygmentsLexer around lexer:get_tokens but the python tokenizer does not yield whitespace, which make it annoying. 

I suppose it would be possible to wrap the tokenizer, and in case of "missing" token, fill in the [literally] blanks.

We can also lookup the first token and see if it's the list of known executable and highlight it differently:

<img width="239" alt="screen shot 2015-11-27 at 10 17 46" src="https://cloud.githubusercontent.com/assets/335567/11437707/24a3eb1c-94f0-11e5-91ee-6c448b0d5936.png">

But that's more work. 

