### PR TITLE
[Proof Of concept] Highlight first token in blue if know command

### DIFF
--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -8,7 +8,7 @@ import builtins
 
 from xonsh.tools import XonshError, escape_windows_title_string, ON_WINDOWS, \
     print_exception
-from xonsh.completer import Completer
+from xonsh.completer import Completer, KnownCommands
 from xonsh.environ import multiline_prompt, format_prompt
 
 
@@ -107,7 +107,8 @@ class BaseShell(object):
         super().__init__(**kwargs)
         self.execer = execer
         self.ctx = ctx
-        self.completer = Completer()
+        self.known_commands = KnownCommands()
+        self.completer = Completer(known_commands=self.known_commands)
         self.buffer = []
         self.need_more_lines = False
         self.mlprompt = None

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from collections import Sequence, MutableMapping, Iterable
 
 from xonsh.tools import suggest_commands, XonshError, ON_POSIX, ON_WINDOWS, \
-    string_types, _compute_known_commands
+    string_types
 from xonsh.inspectors import Inspector
 from xonsh.environ import Env, default_env, locate_binary
 from xonsh.aliases import DEFAULT_ALIASES
@@ -468,9 +468,6 @@ def _redirect_io(streams, r, loc=None):
 
     else:
         raise XonshError('Unrecognized redirection command: {}'.format(r))
-
-def known_commands():
-    return _compute_known_commands(ENV, builtins.aliases)
 
 
 def run_subproc(cmds, captured=True):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -86,7 +86,9 @@ class KnownCommands(object):
         self._path_mtime = -1
         self._cmds_cache = frozenset()
     
-    def _all_commands(self):
+    def all_commands(self):
+        """find all commands available in PATH
+        """
         path = builtins.__xonsh_env__.get('PATH', [])
         # did PATH change?
         path_hash = hash(tuple(path))
@@ -451,7 +453,7 @@ class Completer(object):
         return attrs
 
     def _all_commands(self):
-        return self._known_commands._all_commands()
+        return self._known_commands.all_commands()
 
 
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -78,16 +78,52 @@ def _normpath(p):
 
     return p
 
-class Completer(object):
-    """This provides a list of optional completions for the xonsh shell."""
+class KnownCommands(object):
 
     def __init__(self):
-        # initialize command cache
         self._path_checksum = None
         self._alias_checksum = None
         self._path_mtime = -1
         self._cmds_cache = frozenset()
+    
+    def _all_commands(self):
+        path = builtins.__xonsh_env__.get('PATH', [])
+        # did PATH change?
+        path_hash = hash(tuple(path))
+        cache_valid = path_hash == self._path_checksum
+        self._path_checksum = path_hash
+        # did aliases change?
+        al_hash = hash(tuple(sorted(builtins.aliases.keys())))
+        cache_valid = cache_valid and al_hash == self._alias_checksum
+        self._alias_checksum = al_hash
+        pm = self._path_mtime
+        # did the contents of any directory in PATH change?
+        for d in filter(os.path.isdir, path):
+            m = os.stat(d).st_mtime
+            if m > pm:
+                pm = m
+                cache_valid = False
+        self._path_mtime = pm
+        if cache_valid:
+            return self._cmds_cache
+        allcmds = set()
+        for d in filter(os.path.isdir, path):
+            allcmds |= set(os.listdir(d))
+        allcmds |= set(builtins.aliases.keys())
+        self._cmds_cache = frozenset(allcmds)
+        return self._cmds_cache
+
+class Completer(object):
+    """This provides a list of optional completions for the xonsh shell."""
+
+    def __init__(self, known_commands=None):
+        # initialize command cache
         self._man_completer = ManCompleter()
+
+        if not known_commands:
+            known_commands = KnownCommands()
+        self._known_commands = known_commands
+
         try:
             # FIXME this could be threaded for faster startup times
             self._load_bash_complete_funcs()
@@ -393,7 +429,7 @@ class Completer(object):
         opts = []
         for i in _opts:
             try:
-                v = eval('{0}.{1}'.format(expr, i), _ctx)
+                eval('{0}.{1}'.format(expr, i), _ctx)
                 opts.append(i)
             except:  # pylint:disable=bare-except
                 continue
@@ -415,31 +451,8 @@ class Completer(object):
         return attrs
 
     def _all_commands(self):
-        path = builtins.__xonsh_env__.get('PATH', [])
-        # did PATH change?
-        path_hash = hash(tuple(path))
-        cache_valid = path_hash == self._path_checksum
-        self._path_checksum = path_hash
-        # did aliases change?
-        al_hash = hash(tuple(sorted(builtins.aliases.keys())))
-        cache_valid = cache_valid and al_hash == self._alias_checksum
-        self._alias_checksum = al_hash
-        pm = self._path_mtime
-        # did the contents of any directory in PATH change?
-        for d in filter(os.path.isdir, path):
-            m = os.stat(d).st_mtime
-            if m > pm:
-                pm = m
-                cache_valid = False
-        self._path_mtime = pm
-        if cache_valid:
-            return self._cmds_cache
-        allcmds = set()
-        for d in filter(os.path.isdir, path):
-            allcmds |= set(os.listdir(d))
-        allcmds |= set(builtins.aliases.keys())
-        self._cmds_cache = frozenset(allcmds)
-        return self._cmds_cache
+        return self._known_commands._all_commands()
+
 
 
 OPTIONS_PATH = os.path.expanduser('~') + "/.xonsh_man_completions"

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -68,6 +68,11 @@ class PromptToolkitShell(BaseShell):
         if intro:
             print(intro)
         _auto_suggest = AutoSuggestFromHistory()
+
+        # no way in prompt_toolkit to pass extra args to the lexer. 
+        lexer = PygmentsLexer(XonshLexer)
+        lexer.known_commands = self.known_commands
+        
         while not builtins.__xonsh_exit__:
             try:
                 token_func, style_cls = self._get_prompt_tokens_and_style()
@@ -85,7 +90,7 @@ class PromptToolkitShell(BaseShell):
                     get_prompt_tokens=token_func,
                     style=style_cls,
                     completer=completer,
-                    lexer=PygmentsLexer(XonshLexer),
+                    lexer=lexer,
                     history=self.history,
                     enable_history_search=True,
                     key_bindings_registry=self.key_bindings_manager.registry,

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -9,7 +9,6 @@ from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.layout.lexers import PygmentsLexer
 from prompt_toolkit.filters import Condition
 from pygments.style import Style
-from pygments.styles.default import DefaultStyle
 from pygments.token import (Keyword, Name, Comment, String, Error, Number,
                             Operator, Generic, Whitespace, Token)
 

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -71,7 +71,7 @@ class PromptToolkitShell(BaseShell):
 
         # no way in prompt_toolkit to pass extra args to the lexer. 
         lexer = PygmentsLexer(XonshLexer)
-        lexer.known_commands = self.known_commands
+        lexer.pygments_lexer.known_commands = self.known_commands
         
         while not builtins.__xonsh_exit__:
             try:

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -109,6 +109,7 @@ class PromptToolkitShell(BaseShell):
         token_names, cstyles, strings = format_prompt_for_prompt_toolkit(self.prompt)
         tokens = [getattr(Token, n) for n in token_names]
 
+
         def get_tokens(cli):
             return list(zip(tokens, strings))
 
@@ -161,6 +162,7 @@ def _xonsh_style(tokens=tuple(), cstyles=tuple()):
         }
         styles = {k: _make_style(v) for k, v in styles.items()}
         styles.update({
+            Token.Name.KnowExecuteble : '#005FD7',
             Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
             Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',
             Token.Menu.Completions.ProgressButton: 'bg:#003333',

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Hooks for pygments syntax highlighting."""
 from pygments.lexer import inherit, bygroups, using, this
-from pygments.token import Name, Generic, Keyword, Text, String
+from pygments.token import Name, Generic, Keyword, String
 from pygments.lexers.shell import BashLexer
 from pygments.lexers.agile import PythonLexer
 
@@ -43,6 +43,24 @@ class XonshLexer(PythonLexer):
         'pymode': PYMODE_TOKENS,
         'subproc': SUBPROC_TOKENS,
     }
+
+    def get_tokens_unprocessed(self, text):
+        super_iter =  super().get_tokens_unprocessed(text)
+        # import pdb; pdb.set_trace()
+        #if not super_iter:
+        #    return super_iter
+        first=  next(super_iter)
+        from pygments.token import Token
+        from xonsh.built_ins import known_commands
+        if first:
+            if(first[1] == Token.Name) and (first[2] in known_commands()):
+                yield first[0], Token.Name.KnowExecuteble, first[2]
+            else :
+                yield first
+        else:
+            yield first
+
+        yield from super_iter
 
 
 class XonshConsoleLexer(PythonLexer):

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -47,12 +47,10 @@ class XonshLexer(PythonLexer):
     def get_tokens_unprocessed(self, text):
         super_iter =  super().get_tokens_unprocessed(text)
         first = next(super_iter)
-        if first:
-            if(first[1] == Token.Name) and (first[2] in self.known_commands._all_commands()):
-                yield first[0], Token.Name.KnowExecuteble, first[2]
-            else :
-                yield first
-        else:
+        
+        if first and (first[1] == Token.Name) and (first[2] in self.known_commands.all_commands()):
+            yield first[0], Token.Name.KnowExecuteble, first[2]
+        else :
             yield first
 
         yield from super_iter

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Hooks for pygments syntax highlighting."""
 from pygments.lexer import inherit, bygroups, using, this
-from pygments.token import Name, Generic, Keyword, String
+from pygments.token import Name, Generic, Keyword, String, Token
 from pygments.lexers.shell import BashLexer
 from pygments.lexers.agile import PythonLexer
 
@@ -46,14 +46,9 @@ class XonshLexer(PythonLexer):
 
     def get_tokens_unprocessed(self, text):
         super_iter =  super().get_tokens_unprocessed(text)
-        # import pdb; pdb.set_trace()
-        #if not super_iter:
-        #    return super_iter
-        first=  next(super_iter)
-        from pygments.token import Token
-        from xonsh.built_ins import known_commands
+        first = next(super_iter)
         if first:
-            if(first[1] == Token.Name) and (first[2] in known_commands()):
+            if(first[1] == Token.Name) and (first[2] in self.known_commands._all_commands()):
                 yield first[0], Token.Name.KnowExecuteble, first[2]
             else :
                 yield first

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -47,12 +47,13 @@ class XonshLexer(PythonLexer):
     def get_tokens_unprocessed(self, text):
         super_iter =  super().get_tokens_unprocessed(text)
         first = next(super_iter)
-        
-        if first and (first[1] == Token.Name) and (first[2] in self.known_commands.all_commands()):
-            yield first[0], Token.Name.KnowExecuteble, first[2]
-        else :
-            yield first
-
+        try: 
+            if first and (first[1] == Token.Name) and (first[2] in self.known_commands.all_commands()):
+                yield first[0], Token.Name.KnowExecuteble, first[2]
+            else :
+                yield first
+        except :
+            import pdb;pdb.set_trace()
         yield from super_iter
 
 
@@ -72,7 +73,7 @@ class XonshConsoleLexer(PythonLexer):
         'subproc': SUBPROC_TOKENS,
     }
 
-# XonshLexer & XonshSubprocLexer have to refernce each other
+# XonshLexer & XonshSubprocLexer have to reference each other
 XonshSubprocLexer.tokens['root'] = [
     (r'(\$\{)(.*)(\})', bygroups(Keyword, using(XonshLexer), Keyword)),
     (r'(@\()(.+)(\))', bygroups(Keyword, using(XonshLexer), Keyword)),

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -343,6 +343,16 @@ def command_not_found(cmd):
     return s
 
 
+def _compute_known_commands(env, aliases):
+    list_ = []
+    list_.extend(aliases)
+    for d in filter(os.path.isdir, env.get('PATH')):
+        for f in os.scandir(d):
+            list_.append(f.name)
+    return list_
+
+
+
 def suggest_commands(cmd, env, aliases):
     """Suggests alternative commands given an environment and aliases."""
     suggest_cmds = env.get('SUGGEST_COMMANDS')

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -343,16 +343,6 @@ def command_not_found(cmd):
     return s
 
 
-def _compute_known_commands(env, aliases):
-    list_ = []
-    list_.extend(aliases)
-    for d in filter(os.path.isdir, env.get('PATH')):
-        for f in os.scandir(d):
-            list_.append(f.name)
-    return list_
-
-
-
 def suggest_commands(cmd, env, aliases):
     """Suggests alternative commands given an environment and aliases."""
     suggest_cmds = env.get('SUGGEST_COMMANDS')


### PR DESCRIPTION
Mostly playing around, just prototype (as it scan the disk at each keystroke) 

When using prompt-toolkit, if the first command is a known executable, highlight it in blueish.

See `git` and `hub` blue in screenshot, `foo` is not.

<img width="493" alt="screen shot 2015-11-28 at 22 40 41" src="https://cloud.githubusercontent.com/assets/335567/11454044/27f46756-9621-11e5-8f62-fd3e5efed8f2.png">

if it does not match, first token could be highlighted in red (to avoid typo earlier, like fish does) but we would need to inspect python's user namespace also first for assigned variable, and do a bit of look ahead to not paint red on assignment.