### PR TITLE
prevent completer from launching executables

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -397,7 +397,7 @@ class Completer(object):
                 opts.append(i)
             except:
                 continue
-        if len(attrs) == 0:
+        if len(attr) == 0:
             opts = [o for o in opts if not o.startswith('_')]
         else:
             csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -379,10 +379,10 @@ class Completer(object):
         expr = subexpr_from_unbalanced(expr, '[', ']')
         expr = subexpr_from_unbalanced(expr, '{', '}')
         try:
-            val = builtins.evalx(expr, glbs=ctx)
+            val = eval(expr, ctx)
         except:  # pylint:disable=bare-except
             try:
-                val = builtins.evalx(expr, glbs=builtins.__dict__)
+                val = eval(expr, builtins.__dict__)
             except:  # pylint:disable=bare-except
                 return attrs  # anything could have gone wrong!
         opts = dir(val)

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -378,15 +378,26 @@ class Completer(object):
         expr = subexpr_from_unbalanced(expr, '(', ')')
         expr = subexpr_from_unbalanced(expr, '[', ']')
         expr = subexpr_from_unbalanced(expr, '{', '}')
+        _ctx = None
         try:
             val = eval(expr, ctx)
+            _ctx = ctx
         except:  # pylint:disable=bare-except
             try:
                 val = eval(expr, builtins.__dict__)
+                _ctx = builtins.__dict__
             except:  # pylint:disable=bare-except
                 return attrs  # anything could have gone wrong!
-        opts = dir(val)
-        if len(attr) == 0:
+        _opts = dir(val)
+        # check whether these options actually work (e.g., disallow 7.imag)
+        opts = []
+        for i in _opts:
+            try:
+                v = eval('%s.%s' % (expr,i), _ctx)
+                opts.append(i)
+            except:
+                continue
+        if len(attrs) == 0:
             opts = [o for o in opts if not o.startswith('_')]
         else:
             csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')


### PR DESCRIPTION
I believe this should fix the issue in #364.

Since we only want attribute completion for Python objects, I think we can get away with using `eval` instead of `evalx`.

It also kind of bothered me that something like `7.<tab>` gave suggestions that are actually not valid Python, so I hacked in something to take care of that as well.  Maybe it's too hacky?

Really, I think it would be nice to avoid doing the `eval` at all (since, depending on what we are evaling, it might take time).  I had a version that just checked for `expr` as a key in `ctx` and `builtins.__dict__` and did completions based on that.  No `eval` involved, but it doesn't quite get us to the same place (e.g., if `c` is a number, we would lose `c.imag.<tab>`).  Maybe that's better anyway, though...
