### PR TITLE
modify twiddle replacement to happen only at the start of the path

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -528,14 +528,18 @@ def _replace_home(x):
     if ON_WINDOWS:
         home = (builtins.__xonsh_env__['HOMEDRIVE'] +
                 builtins.__xonsh_env__['HOMEPATH'][0])
-        cwd = x.replace(home, '~')
+        if x.startswith(home):
+            x = x.replace(home, '~', 1)
 
         if builtins.__xonsh_env__.get('FORCE_POSIX_PATHS'):
-            cwd = cwd.replace(os.sep, os.altsep)
+            x = x.replace(os.sep, os.altsep)
 
-        return cwd
+        return x
     else:
-        return x.replace(builtins.__xonsh_env__['HOME'], '~')
+        home = builtins.__xonsh_env__['HOME']
+        if x.startswith(home):
+            x = x.replace(home, '~', 1)
+        return x
 
 _replace_home_cwd = lambda: _replace_home(builtins.__xonsh_env__['PWD'])
 


### PR DESCRIPTION
In the prompt and in the title, `$HOME` is currently replaced everywhere in the PWD, when it should really only be replaced at the very beginning.  This changeset implements this fix.  Not yet tested on Windows.

Examples:

Old:
```
hartz@compy-488 ~ $ cd backups/
hartz@compy-488 ~/backups $ cd home/
hartz@compy-488 ~/backups/home $ cd hartz/
hartz@compy-488 ~/backups~ $ 
```

New:
```
hartz@compy-488 ~ $ cd backups/
hartz@compy-488 ~/backups $ cd home/
hartz@compy-488 ~/backups/home $ cd hartz/
hartz@compy-488 ~/backups/home/hartz $ 
```