### PR TITLE
fish-style shortened cwd as short_cwd

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ the xonsh shell
         "It is pronounced <i>quanxh</i>",
         "It is pronounced <i>zonsch</i>",
         "It is pronounced <i>jeaunsch</i>",
+        "It is pronounced <i>măjˈĭk</i>",
         "The shell, bourne again",
         "Snailed it",
         "Starfish loves you",

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -57,6 +57,7 @@ DEFAULT_ENSURERS = {
     'CASE_SENSITIVE_COMPLETIONS': (is_bool, to_bool, bool_to_str),
     re.compile('\w*DIRS'): (is_env_path, str_to_env_path, env_path_to_str),
     'COMPLETIONS_DISPLAY': (is_completions_display_value, to_completions_display_value, str),
+    'FORCE_POSIX_PATHS': (is_bool, to_bool, bool_to_str),
     'IGNOREEOF': (is_bool, to_bool, bool_to_str),
     'LC_COLLATE': (always_false, locale_convert('LC_COLLATE'), ensure_string),
     'LC_CTYPE': (always_false, locale_convert('LC_CTYPE'), ensure_string),


### PR DESCRIPTION
Not sure whether this should just stay at home in my `.xonshrc` or whether it's something worth including...

I do a lot of work deep in directory trees, and so I found fish's shortening of the CWD in the prompt to be useful.  This changeset implements a shortened CWD as a new entry in the formatter dict, `short_cwd`.

If it's not useful (or too adqm-specific) to have this in the main codebase, I'm happy to close this and just leave it to live on my own machines, but I thought it might be useful.