### PR TITLE
bug fix for cache validation in completer

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -422,8 +422,8 @@ class Completer(object):
         self._path_checksum = path_hash
         # did aliases change?
         al_hash = hash(tuple(sorted(builtins.aliases.keys())))
-        self._alias_checksum = al_hash
         cache_valid = cache_valid and al_hash == self._alias_checksum
+        self._alias_checksum = al_hash
         pm = self._path_mtime
         # did the contents of any directory in PATH change?
         for d in filter(os.path.isdir, path):


### PR DESCRIPTION
This should fix a silly bug in the cache validation code for the completer (whereby changes in the alias dictionary during runtime would not be noticed).