### PR TITLE
Better default colors for promt tk

### DIFF
--- a/tests/test_prompt_toolkit_tools.py
+++ b/tests/test_prompt_toolkit_tools.py
@@ -18,7 +18,7 @@ def test_format_prompt_for_prompt_toolkit():
     prompt = format_prompt(templ, TERM_COLORS)
     token_names, color_styles, strings = format_prompt_for_prompt_toolkit(prompt)
     assert_equal(token_names, ['NO_COLOR', 'BOLD_BLUE', 'WHITE', 'NO_COLOR'])
-    assert_equal(color_styles, ['', 'bold #0000FF', '#ffffff', ''])
+    assert_equal(color_styles, ['', 'bold #0000D2', '#ffffff', ''])
     assert_equal(strings, ['>>> ', '~/xonsh ', ' (main)', ''])
 
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -90,10 +90,15 @@ def default_value(f):
 def is_callable_default(x):
     """Checks if a value is a callable default."""
     return callable(x) and getattr(x, '_xonsh_callable_default', False)
-
-DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
-                  '{cwd}{branch_color}{curr_branch} '
-                  '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
+if ON_WINDOWS:
+    DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_CYAN} '
+                      '{cwd}{branch_color}{curr_branch} '
+                      '{BOLD_WHITE}{prompt_end}{NO_COLOR} ')
+else:
+    DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
+                      '{cwd}{branch_color}{curr_branch} '
+                      '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
+                  
 DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
 
 @default_value

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -731,16 +731,26 @@ class FakeChar(str):
 RE_HIDDEN_MAX = re.compile('(\001.*?\002)+')
 
 
-_PT_COLORS = {'BLACK': '#000000',
-              'RED': '#FF0000',
-              'GREEN': '#008000',
-              'YELLOW': '#FFFF00',
-              'BLUE': '#0000FF',
-              'PURPLE': '#0000FF',
-              'CYAN': '#00FFFF',
-              'WHITE': '#FFFFFF',
-              'GRAY': '#888888'}
+_PT_COLORS_DARK = {'BLACK': '#000000',
+                   'RED': '#ff1010',
+                   'GREEN': '#00FF18',
+                   'YELLOW': '#FFFF00',
+                   'BLUE': '#0000D2',
+                   'PURPLE': '#FF00FF',
+                   'CYAN': '#00FFFF',
+                   'WHITE': '#FFFFFF',
+                   'GRAY': '#c0c0c0'}
 
+_PT_COLORS_LIGHT = {'BLACK': '#000000',
+                    'RED': '#800000',
+                    'GREEN': '#008000',
+                    'YELLOW': '#808000',
+                    'BLUE': '#000080',
+                    'PURPLE': '#800080',
+                    'CYAN': '#008080',
+                    'WHITE': '#FFFFFF',
+                    'GRAY': '#008080'}              
+              
 _PT_STYLE = {'BOLD': 'bold',
              'UNDERLINE': 'underline',
              'INTENSE': 'italic'}
@@ -756,7 +766,7 @@ def _make_style(color_name):
     for k, v in _custom_colors.items():
         if k in color_name:
             style.append(v)
-    for k, v in _PT_COLORS.items():
+    for k, v in _PT_COLORS_DARK.items():
         if k not in _custom_colors and k in color_name:
             style.append(v)
     return ' '.join(style)


### PR DESCRIPTION
This updates the colors for prompt_toolkit to work better on a black background. On windows, it also changes the default prompt to use CYAN instead of BLUE, which is more readable in cmd.exe. 

On cmd.exe  (windows 10)
![image](https://cloud.githubusercontent.com/assets/1038978/11500912/96d47240-9830-11e5-90b3-2b36fdbeb4a3.png)

In cmder (windows 10)
![image](https://cloud.githubusercontent.com/assets/1038978/11501006/2f1fbfc8-9831-11e5-9e6d-003a51863593.png)

I also added a color mapping for colors that work best on light backgrounds. Just haven't made anything that uses it yet.
