### PR TITLE
Random shell type

### DIFF
--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -113,10 +113,6 @@ applicable.
       - xonsh.environ.DEFAULT_PROMPT  
       - The prompt text.  May contain keyword arguments which are auto-formatted,
         see `Customizing the Prompt <tutorial.html#customizing-the-prompt>`_.
-    * - PROMPT_TOOLKIT_STYLES
-      - ``None``
-      - This is a mapping of user-specified styles for prompt-toolkit. See the 
-        prompt-toolkit documentation for more details. If None, this is skipped.
     * - PROMPT_TOOLKIT_COLORS
       - ``{}``
       - This is a mapping of from color names to HTML color codes.  Whenever
@@ -125,6 +121,10 @@ applicable.
         represent that color, instead of its default.  If a color is not
         specified here, prompt-toolkit uses the colors from
         ``xonsh.tools._PT_COLORS``.
+    * - PROMPT_TOOLKIT_STYLES
+      - ``None``
+      - This is a mapping of user-specified styles for prompt-toolkit. See the 
+        prompt-toolkit documentation for more details. If None, this is skipped.
     * - PUSHD_MINUS
       - ``False``
       - Flag for directory pushing functionality. False is the normal behaviour.
@@ -133,13 +133,14 @@ applicable.
       - Whether or not to supress directory stack manipulation output.
     * - SHELL_TYPE
       - ``'prompt_toolkit'`` if on Windows, otherwise ``'readline'``
-      - Which shell is used. Currently two shell types are supported: ``'readline'`` that
-        is backed by Python's readline module, and ``'prompt_toolkit'`` that uses 
-        external library of the same name. For using prompt_toolkit shell you need 
-        to have 
+      - Which shell is used. Currently two base shell types are supported: 
+        ``'readline'`` that is backed by Python's readline module, and 
+        ``'prompt_toolkit'`` that uses external library of the same name. 
+        To use the prompt_toolkit shell you need to have 
         `prompt_toolkit <https://github.com/jonathanslenders/python-prompt-toolkit>`_
         library installed. To specify which shell should be used, do so in the run 
-        control file.
+        control file. Additionally, you may also set this value to ``'random'``
+        to get a random choice of shell type on startup.
     * - SUGGEST_COMMANDS
       - ``True``
       - When a user types an invalid command, xonsh will try to offer suggestions of 
@@ -190,8 +191,8 @@ applicable.
       - ``('/etc/xonshrc', '~/.xonshrc')`` (Linux and OSX) 
     	``('%ALLUSERSPROFILE%\xonsh\xonshrc', '~/.xonshrc')`` (Windows)
       - A tuple of the locations of run control files, if they exist.  User defined
-	run control file will supercede values set in system-wide control file if there
-	is a naming collision.
+        run control file will supercede values set in system-wide control file if there
+        is a naming collision.
     * - XONSH_CONFIG_DIR
       - ``$XDG_CONFIG_HOME/xonsh``
       - This is location where xonsh configuration information is stored.

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -61,10 +61,10 @@ parser.add_argument('-D',
                     default=None)
 parser.add_argument('--shell-type',
                     help='What kind of shell should be used. '
-                         'Possible options: readline, prompt_toolkit. '
+                         'Possible options: readline, prompt_toolkit, random. '
                          'Warning! If set this overrides $SHELL_TYPE variable.',
                     dest='shell_type',
-                    choices=('readline', 'prompt_toolkit'),
+                    choices=('readline', 'prompt_toolkit', 'random'),
                     default=None)
 parser.add_argument('file',
                     metavar='script-file',

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """The xonsh shell"""
+import random
 import builtins
 from warnings import warn
 
@@ -31,6 +32,8 @@ class Shell(object):
         if shell_type is not None:
             env['SHELL_TYPE'] = shell_type
         shell_type = env.get('SHELL_TYPE')
+        if shell_type == 'random':
+            shell_type = random.choice(('readline', 'prompt_toolkit'))
         if shell_type == 'prompt_toolkit':
             if not is_prompt_toolkit_available():
                 warn('prompt_toolkit is not available, using readline instead.')


### PR DESCRIPTION
This implements a random shell type that decides randomly which shell type to use at start up.  This is mostly for devs (such as myself) who want to consistently use all shell interfaces.  I feel like I haven't been using prompt-toolkit as much as I would have liked just because I also feel it is important to maintain a high-quality readline shell.  Hopefully this will help balance these two problems.

Also some minor doc fixes.