### PR TITLE
fixes bash funcscmd to allow for spaces in filenames

### DIFF
--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -204,6 +204,8 @@ def parse_funcs(s, shell, sourcer=None):
     if m is None:
         return {}
     g1 = m.group(1)
+    import sys
+    print(g1, file=sys.stderr)
     namefiles = json.loads(g1.strip())
     sourcer = DEFAULT_SOURCERS.get(shell, 'source') if sourcer is None \
                                                     else sourcer

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -44,16 +44,18 @@ shopt -s extdebug
 namelocfilestr=$(declare -F $funcnames)
 shopt -u extdebug
 
-# print just name and file
+# print just names and files as JSON object 
 read -r -a namelocfile <<< $namelocfilestr
-namefile=""
-for((n=0;n<${#namelocfile[@]};n++)); do
-  if (( $(($n % 3 )) == 0 )); then
-    namefile="$namefile ${namelocfile[$n]}"
-  elif (( $(($n % 3 )) == 2 )); then
-    namefile="$namefile ${namelocfile[$n]}"
-  fi
-done
+sep=" "
+namefile="{"
+while IFS='' read -r line || [[ -n "$line" ]]; do
+  name=${line%%"$sep"*}
+  locfile=${line#*"$sep"}
+  loc=${locfile%%"$sep"*}
+  file=${locfile#*"$sep"}
+  namefile="${namefile}\\"${name}\\":\\"${file}\\","
+done <<< "$namelocfilestr"
+namefile="${namefile%?}}"
 echo $namefile
 """.strip()
 
@@ -102,8 +104,8 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd='env',
     funcscmd : str or None, optional
         This is a command or script that can be used to determine the names
         and locations of any functions that are native to the foreign shell.
-        This command should print *only* a whitespace separated sequence
-        of pairs function name & filenames where the functions are defined.
+        This command should print *only* a JSON object that maps
+        function names to the filenames where the functions are defined.
         If this is None, then a default script will attempted to be looked
         up based on the shell name. Callable wrappers for these functions
         will be returned in the aliases dictionary.
@@ -202,14 +204,11 @@ def parse_funcs(s, shell, sourcer=None):
     if m is None:
         return {}
     g1 = m.group(1)
-    funcs = {}
-    flatpairs = g1.strip().split()
-    if len(flatpairs) % 2 != 0:
-        warn('could not parse functions, malformed pairs', RuntimeWarning)
-        return funcs
+    namefiles = json.loads(g1.strip())
     sourcer = DEFAULT_SOURCERS.get(shell, 'source') if sourcer is None \
                                                     else sourcer
-    for funcname, filename in zip(flatpairs[::2], flatpairs[1::2]):
+    funcs = {}
+    for funcname, filename in namefiles.items():
         if funcname.startswith('_'):
             continue  # skip private functions
         wrapper = ForeignShellFunctionAlias(name=funcname, shell=shell,

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -204,8 +204,6 @@ def parse_funcs(s, shell, sourcer=None):
     if m is None:
         return {}
     g1 = m.group(1)
-    import sys
-    print(g1, file=sys.stderr)
     namefiles = json.loads(g1.strip())
     sourcer = DEFAULT_SOURCERS.get(shell, 'source') if sourcer is None \
                                                     else sourcer

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -53,7 +53,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
   locfile=${line#*"$sep"}
   loc=${locfile%%"$sep"*}
   file=${locfile#*"$sep"}
-  namefile="${namefile}\\"${name}\\":\\"${file}\\","
+  namefile="${namefile}\\"${name}\\":\\"${file//\\/\\\\}\\","
 done <<< "$namelocfilestr"
 namefile="${namefile%?}}"
 echo $namefile


### PR DESCRIPTION
@melund, maybe you could take this for a spin.  This is as an alternative to #552.  The reason that I wanted to do this solely in Bash is it simplifies the Python a lot if different shells know that they have to communicate this information in the same way.  I change the protocol from a whitespace separated list to a JSON object.  Testing this locally seems to work on files with spaces in the name.