### PR TITLE
add space escaping to bash completion function

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -316,7 +316,12 @@ class Completer(object):
             out = ''
 
         space = ' '
-        rtn = {s + space if s[-1:].isalnum() else s for s in out.splitlines()}
+        slash = '/'
+        rtn = {_normpath(repr(s + (slash if os.path.isdir(s) else '')))
+               if space in s else
+               s + space
+               if s[-1:].isalnum() else
+               s for s in out.splitlines()}
         return rtn
 
     def _source_completions(self):


### PR DESCRIPTION
On Linux, if there's a foldername with a space in it, like "bad folder"
then tab-completion using `cd` will wrap single quotes around the name,
e.g.

```
cd bad(TAB)
```

completes to

```
cd 'bad folder/'
```

This behavior is encoded in `path_complete` in `completer.py`.  But if
you want to remove that poorly named folder, the argument to `rm` is
completed by `bash_complete` which didn't have this tweak and so the
result is

```
rm -r bad(TAB)
```
leads to

```
rm -r bad folder
/usr/bin/rm: cannot remove 'bad': No such file or directory
/usr/bin/rm: cannot remove 'folder/': No such file or directory
```

This tweaks the `bash_complete` function so that

```
rm -r bad(TAB)
```

returns

```
rm -r 'bad folder/'
```

I don't think this is insane but it might(?) have unintended side-effects?  It would be great if @melund or another Windows user could try this out and make sure that the trailing slash gets treated correctly.