### PR TITLE
Bash Completer $XONSH_TOKEN wrapping

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -316,7 +316,12 @@ class Completer(object):
             out = ''
 
         space = ' '
-        rtn = {s + space if s[-1:].isalnum() else s for s in out.splitlines()}
+        slash = '/'
+        rtn = {_normpath(repr(s + (slash if os.path.isdir(s) else '')))
+               if space in s else
+               s + space
+               if s[-1:].isalnum() else
+               s for s in out.splitlines()}
         return rtn
 
     def _source_completions(self):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -30,6 +30,8 @@ XONSH_TOKENS = {
 
 COMPLETION_SKIP_TOKENS = {'sudo', 'time'}
 
+COMPLETION_WRAP_TOKENS = {' ',',','[',']','(',')','{','}'}
+
 BASH_COMPLETE_SCRIPT = """source {filename}
 COMP_WORDS=({line})
 COMP_LINE={comp_line}
@@ -318,7 +320,7 @@ class Completer(object):
         space = ' '
         slash = '/'
         rtn = {_normpath(repr(s + (slash if os.path.isdir(s) else '')))
-               if space in s else
+               if (COMPLETION_WRAP_TOKENS.intersection(s) != set()) else
                s + space
                if s[-1:].isalnum() else
                s for s in out.splitlines()}

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 from xonsh.built_ins import iglobpath
-from xonsh.tools import subexpr_from_unbalanced
+from xonsh.tools import subexpr_from_unbalanced, get_sep
 from xonsh.tools import ON_WINDOWS
 
 
@@ -85,7 +85,7 @@ def completionwrap(s):
     a 'problem' token that will confuse the xonsh parser
     """
     space = ' '
-    slash = '/'
+    slash = get_sep()
     return (_normpath(repr(s + (slash if os.path.isdir(s) else '')))
            if COMPLETION_WRAP_TOKENS.intersection(s) else
            s + space

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -320,7 +320,7 @@ class Completer(object):
         space = ' '
         slash = '/'
         rtn = {_normpath(repr(s + (slash if os.path.isdir(s) else '')))
-               if (COMPLETION_WRAP_TOKENS.intersection(s) != set()) else
+               if COMPLETION_WRAP_TOKENS.intersection(s) else
                s + space
                if s[-1:].isalnum() else
                s for s in out.splitlines()}

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -80,6 +80,18 @@ def _normpath(p):
 
     return p
 
+def completionwrap(s):
+    """ Returns the repr of input string s if that string contains 
+    a 'problem' token that will confuse the xonsh parser
+    """
+    space = ' '
+    slash = '/'
+    return (_normpath(repr(s + (slash if os.path.isdir(s) else '')))
+           if COMPLETION_WRAP_TOKENS.intersection(s) else
+           s + space
+           if s[-1:].isalnum() else
+           s) 
+
 class Completer(object):
     """This provides a list of optional completions for the xonsh shell."""
 
@@ -317,13 +329,7 @@ class Completer(object):
         except subprocess.CalledProcessError:
             out = ''
 
-        space = ' '
-        slash = '/'
-        rtn = {_normpath(repr(s + (slash if os.path.isdir(s) else '')))
-               if COMPLETION_WRAP_TOKENS.intersection(s) else
-               s + space
-               if s[-1:].isalnum() else
-               s for s in out.splitlines()}
+        rtn = set(map(completionwrap, out.splitlines()))
         return rtn
 
     def _source_completions(self):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -204,6 +204,14 @@ def indent(instr, nspaces=4, ntabs=0, flatten=False):
     else:
         return outstr
 
+def get_sep():
+    """ Returns the appropriate filepath separator char depending on OS and
+    xonsh options set
+    """
+    return (os.altsep if ON_WINDOWS 
+            and builtins.__xonsh_env__.get('FORCE_POSIX_PATHS') else
+            os.sep)
+
 
 TERM_COLORS = {
     # Reset


### PR DESCRIPTION
This supercedes #560 

From #560 --
> On Linux, if there's a foldername with a space in it, like "bad folder"
> then tab-completion using `cd` will wrap single quotes around the name,
> e.g.
> 
> ```
> cd bad(TAB)
> ```
> 
> completes to
> 
> ```
> cd 'bad folder/'
> ```
> 
> This behavior is encoded in `path_complete` in `completer.py`.  But if
> you want to remove that poorly named folder, the argument to `rm` is
> completed by `bash_complete` which didn't have this tweak and so the
> result is
> 
> ```
> rm -r bad(TAB)
> ```
> leads to
> 
> ```
> rm -r bad folder
> /usr/bin/rm: cannot remove 'bad': No such file or directory
> /usr/bin/rm: cannot remove 'folder/': No such file or directory
> ```
> 
> This tweaks the `bash_complete` function so that
> 
> ```
> rm -r bad(TAB)
> ```
> 
> returns
> 
> ```
> rm -r 'bad folder/'
> ```
> 
> I don't think this is insane but it might(?) have unintended side-effects?  It would be great if @melund or another Windows user could try this out and make sure that the trailing slash gets treated correctly.

While working on this I went through a couple of very poorly named files, filenames that contained commas, square brackets, etc. and all of these have similar trouble because of the xonsh parser fighting with bash completion.  

This PR instead adds a tokenset that, if a token is found in the completed string, `Completer.bash_complete` will return the `repr` of the string instead and the wrapping single quotes will stop the xonsh parser from having trouble.  

For now, the problem tokens I've added in are 
```
' ',',','[',']','(',')','{','}'
```