### PR TITLE
include the command being run in the default title

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -849,6 +849,8 @@ By default, the following variables are available for use:
   * ``branch_color``: ``{BOLD_GREEN}`` if the current git branch is clean,
     otherwise ``{BOLD_RED}``
   * ``prompt_end``: `#` if the user has root/admin permissions `$` otherwise
+  * ``current_job``: The name of the command currently running in the
+    foreground, if any.
 
 You can also color your prompt easily by inserting keywords such as ``{GREEN}``
 or ``{BOLD_BLUE}``.  Colors have the form shown below:

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -10,6 +10,7 @@ from xonsh import built_ins
 from xonsh.execer import Execer
 from xonsh.built_ins import load_builtins, unload_builtins
 
+from tests.tools import mock_xonsh_env
 LOADED_HERE = False
 
 def setup():
@@ -24,21 +25,25 @@ def teardown():
         unload_builtins()
 
 def test_import():
-    import sample
-    assert_equal('hello mom jawaka\n', sample.x)
+    with mock_xonsh_env({}):
+        import sample
+        assert_equal('hello mom jawaka\n', sample.x)
 
 def test_absolute_import():
-    from xpack import sample
-    assert_equal('hello mom jawaka\n', sample.x)
+    with mock_xonsh_env({}):
+        from xpack import sample
+        assert_equal('hello mom jawaka\n', sample.x)
 
 def test_relative_import():
-    from xpack import relimp
-    assert_equal('hello mom jawaka\n', relimp.sample.x)
-    assert_equal('hello mom jawaka\ndark chest of wonders', relimp.y)
+    with mock_xonsh_env({}):
+        from xpack import relimp
+        assert_equal('hello mom jawaka\n', relimp.sample.x)
+        assert_equal('hello mom jawaka\ndark chest of wonders', relimp.y)
 
 def test_sub_import():
-    from xpack.sub import sample
-    assert_equal('hello mom jawaka\n', sample.x)
+    with mock_xonsh_env({}):
+        from xpack.sub import sample
+        assert_equal('hello mom jawaka\n', sample.x)
 
 
 if __name__ == '__main__':

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -21,9 +21,14 @@ ON_MAC = (platform.system() == 'Darwin')
 def sp(cmd):
     return subprocess.check_output(cmd, universal_newlines=True)
 
+class DummyShell:
+    def settitle():
+        pass
+
 @contextmanager
 def mock_xonsh_env(xenv):
     builtins.__xonsh_env__ = xenv
+    builtins.__xonsh_shell__ = DummyShell()
     builtins.__xonsh_help__ = lambda x: x
     builtins.__xonsh_glob__ = glob.glob
     builtins.__xonsh_exit__ = False
@@ -38,6 +43,7 @@ def mock_xonsh_env(xenv):
     builtins.aliases = {}
     yield
     del builtins.__xonsh_env__
+    del builtins.__xonsh_shell__
     del builtins.__xonsh_help__
     del builtins.__xonsh_glob__
     del builtins.__xonsh_exit__

--- a/xonsh/base_shell.py
+++ b/xonsh/base_shell.py
@@ -203,6 +203,7 @@ class BaseShell(object):
             os.system('title {}'.format(t))
         else:
             sys.stdout.write("\x1b]2;{0}\x07".format(t))
+            sys.stdout.flush()
 
     @property
     def prompt(self):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -613,7 +613,8 @@ def run_subproc(cmds, captured=True):
             'obj': prev_proc,
             'bg': background
         })
-    if ENV.get('XONSH_INTERACTIVE'):
+    if ENV.get('XONSH_INTERACTIVE') and not ENV.get('XONSH_STORE_STDOUT'):
+        # set title here to get current command running
         builtins.__xonsh_shell__.settitle()
     if background:
         return

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -613,6 +613,8 @@ def run_subproc(cmds, captured=True):
             'obj': prev_proc,
             'bg': background
         })
+    if ENV.get('XONSH_INTERACTIVE'):
+        builtins.__xonsh_shell__.settitle()
     if background:
         return
     if prev_is_proxy:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -98,8 +98,8 @@ else:
     DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
                       '{cwd}{branch_color}{curr_branch} '
                       '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
-                  
-DEFAULT_TITLE = '{user}@{hostname}: {cwd} | xonsh'
+
+DEFAULT_TITLE = '{current_job}{user}@{hostname}: {cwd} | xonsh'
 
 @default_value
 def xonsh_data_dir(env):
@@ -564,6 +564,15 @@ def _collapsed_pwd():
     return leader + sep.join(base)
 
 
+def _current_job():
+    j = builtins.__xonsh_active_job__
+    if j is not None:
+        j = builtins.__xonsh_all_jobs__[j]
+        if not j['bg']:
+            return '{} | '.format(j['cmds'][-1][0])
+    return ''
+
+
 if ON_WINDOWS:
     USER = 'USERNAME'
 else:
@@ -580,6 +589,7 @@ FORMATTER_DICT = dict(
     short_cwd=_collapsed_pwd,
     curr_branch=current_branch,
     branch_color=branch_color,
+    current_job=_current_job,
     **TERM_COLORS)
 DEFAULT_VALUES['FORMATTER_DICT'] = dict(FORMATTER_DICT)
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -569,7 +569,11 @@ def _current_job():
     if j is not None:
         j = builtins.__xonsh_all_jobs__[j]
         if not j['bg']:
-            return '{} | '.format(j['cmds'][-1][0])
+            cmd = j['cmds'][-1]
+            s = cmd[0]
+            if s == 'sudo' and len(cmd) > 1:
+                s = cmd[1]
+            return '{} | '.format(s)
     return ''
 
 


### PR DESCRIPTION
This is a little modification (again, another idea borrowed from fish) to make the console title, by default, show the name of the command being run (the current active foreground job).  I often have a bunch of terminals open, and this makes it easier for me to switch between them.

Normal title on my machine is:
`hartz@compy-488: ~ | xonsh`

Opening, e.g., `python` makes it:
`python | hartz@compy-488: ~ | xonsh`

Programs like `vim` that set titles themselves are unaffected.

Also works with pipelines.  So opening `echo "hello" | gedit -` makes it:
`gedit | hartz@compy-488: ~ | xonsh`

Tested to work with `fg`, `bg`, and friends.