### PR TITLE
ast.arg needs lineno and col_offset in Python 3.5.1

### DIFF
--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -709,7 +709,14 @@ class Parser(object):
 
     def p_vfpdef(self, p):
         """vfpdef : NAME"""
-        p[0] = ast.arg(arg=p[1], annotation=None)
+        kwargs = {'arg': p[1],
+                  'annotation': None}
+        if VER_FULL >= VER_3_5_1:
+            kwargs.update({
+                'lineno': self.lineno,
+                'col_offset': self.col,
+            })
+        p[0] = ast.arg(**kwargs)
 
     def p_comma_vfpdef(self, p):
         """comma_vfpdef : COMMA

--- a/xonsh/parser.py
+++ b/xonsh/parser.py
@@ -8,8 +8,9 @@ from ply import yacc
 
 from xonsh import ast
 from xonsh.lexer import Lexer
-from xonsh.tools import VER_3_4, VER_3_5, VER_MAJOR_MINOR, V_MAJOR_MINOR, \
-    docstring_by_version
+from xonsh.tools import (VER_3_4, VER_3_5, VER_3_5_1,
+                         VER_MAJOR_MINOR, VER_FULL,
+                         docstring_by_version)
 
 
 class Location(object):
@@ -582,7 +583,14 @@ class Parser(object):
 
     def p_tfpdef(self, p):
         """tfpdef : NAME colon_test_opt"""
-        p[0] = ast.arg(arg=p[1], annotation=p[2])
+        kwargs = {'arg': p[1],
+                  'annotation': p[2]}
+        if VER_FULL >= VER_3_5_1:
+            kwargs.update({
+                'lineno': self.lineno,
+                'col_offset': self.col,
+            })
+        p[0] = ast.arg(**kwargs)
 
     def p_comma_tfpdef(self, p):
         """comma_tfpdef : COMMA

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -48,6 +48,8 @@ IS_ROOT = ctypes.windll.shell32.IsUserAnAdmin() != 0 if ON_WINDOWS else os.getui
 
 VER_3_4 = (3, 4)
 VER_3_5 = (3, 5)
+VER_3_5_1 = (3, 5, 1)
+VER_FULL = sys.version_info[:3]
 VER_MAJOR_MINOR = sys.version_info[:2]
 V_MAJOR_MINOR = 'v{0}{1}'.format(*sys.version_info[:2])
 


### PR DESCRIPTION
I believe this should resolve the issue described in #569, which caused a `compile` error when running xonsh under Python 3.5.1.

Tested on Python 3.5.1 and 3.4 on my machine, but more eyes on it would be appreciated.