### PR TITLE
Improvements for Completer: Names with Spaces, and Partial Strings

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -311,7 +311,7 @@ class Completer(object):
     def path_complete(self, prefix, start, end, cdpath=False):
         """Completes based on a path name."""
         space = ' '  # intern some strings for faster appending
-        slash = '/'
+        slash = get_sep()
         tilde = '~'
         paths = set()
         csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -24,13 +24,18 @@ def _path_from_partial_string(inp, pos=None):
         pos = len(inp)
     partial = inp[:pos]
     startix, endix, quote = check_for_partial_string(partial)
+    _post = ""
     if startix is None:
         return None
     elif endix is None:
         string = partial[startix:]
     else:
         if endix != pos:
-            return None
+            _test = partial[endix:pos]
+            if not any(i == ' ' for i in _test):
+                _post = _test
+            else:
+                return None
         string = partial[startix:endix]
     end = re.sub(RE_STRING_START,'',quote)
     _string = string
@@ -44,7 +49,7 @@ def _path_from_partial_string(inp, pos=None):
         env = builtins.__xonsh_env__
         val = val.decode(encoding=env.get('XONSH_ENCODING'),
                          errors=env.get('XONSH_ENCODING_ERRORS'))
-    return string, val, quote, end
+    return string + _post, val + _post, quote, end
 
 
 XONSH_TOKENS = {

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -139,7 +139,7 @@ class Completer(object):
         prefixlow = prefix.lower()
         line = builtins.aliases.expand_alias(line)
         cmd = line.split(' ', 1)[0]
-        if cmd in COMPLETION_SKIP_TOKENS:
+        while cmd in COMPLETION_SKIP_TOKENS:
             begidx -= len(cmd)+1
             endidx -= len(cmd)+1
             cmd = line.split(' ', 2)[1]

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -2,11 +2,12 @@
 """A (tab-)completer for xonsh."""
 import os
 import re
-import builtins
-import pickle
-import shlex
-import subprocess
+import ast
 import sys
+import shlex
+import pickle
+import builtins
+import subprocess
 
 from xonsh.built_ins import iglobpath
 from xonsh.tools import subexpr_from_unbalanced, get_sep, partial_string_finder, RE_STRING_START
@@ -38,8 +39,8 @@ def _path_from_partial_string(inp, pos=None):
     if not _s.endswith(end):
         _s = _s + end
     try:
-        val = eval(_s)
-    except:
+        val = ast.literal_eval(_s)
+    except SyntaxError:
         return None
     if isinstance(val, bytes):
         val = val.decode()

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -322,7 +322,8 @@ class Completer(object):
         double_backslash = '\\\\'
         slash = get_sep()
         for s in paths:
-            if (space in s or backslash in s) and start == '':
+            if (start == '' and
+                    (space in s or (backslash in s and slash != backslash))):
                 start = "'"
                 end = "'"
             if os.path.isdir(s):
@@ -332,10 +333,11 @@ class Completer(object):
             else:
                 _tail = ''
             s = s + _tail
-            if "r" not in start.lower():
-                s = s.replace(backslash, double_backslash)
-            elif s.endswith(backslash):
-                s += backslash
+            if end != '':
+                if "r" not in start.lower():
+                    s = s.replace(backslash, double_backslash)
+                elif s.endswith(backslash):
+                    s += backslash
             out.add(start + s + end)
         return out
 

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -320,7 +320,13 @@ class Completer(object):
             if space in s and start == '':
                 s = repr(s + (slash if os.path.isdir(s) else ''))
             else:
-                s = start + s + (slash if os.path.isdir(s) else space) + end
+                if os.path.isdir(s):
+                    _tail = slash
+                elif end == '':
+                    _tail = space
+                else:
+                    _tail = ''
+                s = start + s + _tail + end
             paths.add(s)
         if tilde in prefix:
             home = os.path.expanduser(tilde)

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -171,14 +171,12 @@ class Completer(object):
         path_str_start = ''
         path_str_end = ''
         p = _path_from_partial_string(_line, endidx)
-        in_partial_str = False
         lprefix = len(prefix)
         if p is not None:
             lprefix = len(p[0])
             prefix = p[1]
             path_str_start = p[2]
             path_str_end = p[3]
-            in_partial_str = True
         cmd = line.split(' ', 1)[0]
         while cmd in COMPLETION_SKIP_TOKENS:
             begidx -= len(cmd)+1
@@ -316,16 +314,18 @@ class Completer(object):
         csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
         # look for being inside a string
         for s in iglobpath(prefix + '*', ignore_case=(not csc)):
-            if space in s and start == '':
-                s = repr(s + (slash if os.path.isdir(s) else ''))
+            if (space in s or "\\" in s) and start == '':
+                start = "'"
+                end = "'"
+            if os.path.isdir(s):
+                _tail = slash
+            elif end == '':
+                _tail = space
             else:
-                if os.path.isdir(s):
-                    _tail = slash
-                elif end == '':
-                    _tail = space
-                else:
-                    _tail = ''
-                s = start + s + _tail + end
+                _tail = ''
+            s = start + s + _tail + end
+            if "r" not in start.lower():
+                s = s.replace('\\','\\\\')
             paths.add(s)
         if tilde in prefix:
             home = os.path.expanduser(tilde)

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 from xonsh.built_ins import iglobpath
-from xonsh.tools import subexpr_from_unbalanced, get_sep, partial_string_finder
+from xonsh.tools import subexpr_from_unbalanced, get_sep, partial_string_finder, RE_STRING_START
 from xonsh.tools import ON_WINDOWS
 
 
@@ -33,7 +33,7 @@ def _path_from_partial_string(inp, pos=None):
             return None
         s = partial[x[-2]:x[-1]]
     b = b[-1]
-    end = re.sub('[rRbBuU]*','',b)
+    end = re.sub(RE_STRING_START,'',b)
     _s = s
     if not _s.endswith(end):
         _s = _s + end

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -29,16 +29,22 @@ def _path_from_partial_string(inp, pos=None):
         pos = len(inp)
     partial = inp[:pos]
     for (regex, end) in STRINGS:
-        x = re.findall(regex, partial)
+        x = list(re.finditer(regex, partial))
         if len(x) > 0:
-            s = x[-1][0]
-            _s = x[-1][0]
+            m = x[-1]
+            s = m.group(0)
+            if m.end() != pos:
+                continue
+            _s = s
             if not _s.endswith(end):
                 _s = _s+end
-            val = eval(_s)
+            try:
+                val = eval(_s)
+            except:
+                continue
             if isinstance(val, bytes):
                 val = val.decode()
-            return s, val, x[-1][1], end
+            return s, val, m.group(2), end
 
 
 XONSH_TOKENS = {

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -159,6 +159,9 @@ class Completer(object):
         -------
         rtn : list of str
             Possible completions of prefix, sorted alphabetically.
+        lprefix : int
+            Length of the prefix to be replaced in the completion
+            (only used with prompt_toolkit)
         """
         space = ' '  # intern some strings for faster appending
         slash = '/'
@@ -201,14 +204,14 @@ class Completer(object):
             # python mode explicitly
             rtn = set()
         elif prefix.startswith('-'):
-            return lprefix, sorted(self._man_completer.option_complete(prefix, cmd))
+            return sorted(self._man_completer.option_complete(prefix, cmd)), lprefix
         elif cmd not in ctx:
             if cmd == 'import' and begidx == len('import '):
                 # completing module to import
-                return lprefix, sorted(self.module_complete(prefix))
+                return sorted(self.module_complete(prefix)), lprefix
             if cmd in self._all_commands():
                 # subproc mode; do path completions
-                return lprefix, sorted(self.path_complete(prefix, path_str_start, path_str_end, cdpath=True))
+                return sorted(self.path_complete(prefix, path_str_start, path_str_end, cdpath=True)), lprefix
             else:
                 # if we're here, could be anything
                 rtn = set()
@@ -225,7 +228,7 @@ class Completer(object):
         rtn |= {s + space for s in builtins.aliases
                 if startswither(s, prefix, prefixlow)}
         rtn |= self.path_complete(prefix, path_str_start, path_str_end)
-        return lprefix, sorted(rtn)
+        return sorted(rtn), lprefix
 
 
     def find_and_complete(self, line, idx, ctx=None):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -41,7 +41,9 @@ def _path_from_partial_string(inp, pos=None):
     except SyntaxError:
         return None
     if isinstance(val, bytes):
-        val = val.decode()
+        env = builtins.__xonsh_env__
+        val = val.decode(encoding=env.get('XONSH_ENCODING'),
+                         errors=env.get('XONSH_ENCODING_ERRORS'))
     return string, val, quote, end
 
 

--- a/xonsh/prompt_toolkit_completer.py
+++ b/xonsh/prompt_toolkit_completer.py
@@ -27,10 +27,10 @@ class PromptToolkitCompleter(Completer):
             else:
                 begidx = space_pos + endidx + 1
             prefix = line[begidx:endidx]
-            completions = self.completer.complete(prefix,
-                                                  line,
-                                                  begidx,
-                                                  endidx,
-                                                  self.ctx)
+            l, completions = self.completer.complete(prefix,
+                                                     line,
+                                                     begidx,
+                                                     endidx,
+                                                     self.ctx)
             for comp in completions:
-                yield Completion(comp, -len(prefix))
+                yield Completion(comp, -l)

--- a/xonsh/prompt_toolkit_completer.py
+++ b/xonsh/prompt_toolkit_completer.py
@@ -27,7 +27,7 @@ class PromptToolkitCompleter(Completer):
             else:
                 begidx = space_pos + endidx + 1
             prefix = line[begidx:endidx]
-            l, completions = self.completer.complete(prefix,
+            completions, l = self.completer.complete(prefix,
                                                      line,
                                                      begidx,
                                                      endidx,

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -112,7 +112,7 @@ class ReadlineShell(BaseShell, Cmd):
         offs = len(mline) - len(text)
         x = [i[offs:] for i in self.completer.complete(text, line,
                                                        begidx, endidx,
-                                                       ctx=self.ctx)[1]]
+                                                       ctx=self.ctx)[0]]
         return x
 
     # tab complete on first index too

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -110,9 +110,10 @@ class ReadlineShell(BaseShell, Cmd):
         rl_completion_suppress_append()  # this needs to be called each time
         mline = line.partition(' ')[2]
         offs = len(mline) - len(text)
-        x = [i[offs:] for i in self.completer.complete(text, line,
-                                                       begidx, endidx,
-                                                       ctx=self.ctx)[0]]
+        x = [(i[offs:] if " " in i[:-1] else i)
+             for i in self.completer.complete(text, line,
+                                              begidx, endidx,
+                                              ctx=self.ctx)[0]]
         return x
 
     # tab complete on first index too

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -12,7 +12,7 @@ from collections import deque
 
 from xonsh import lazyjson
 from xonsh.base_shell import BaseShell
-from xonsh.tools import ON_WINDOWS, print_color, partial_string_finder
+from xonsh.tools import ON_WINDOWS, print_color
 
 RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
 RL_CAN_RESIZE = False

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -12,7 +12,7 @@ from collections import deque
 
 from xonsh import lazyjson
 from xonsh.base_shell import BaseShell
-from xonsh.tools import ON_WINDOWS, print_color
+from xonsh.tools import ON_WINDOWS, print_color, partial_string_finder
 
 RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
 RL_CAN_RESIZE = False
@@ -108,9 +108,12 @@ class ReadlineShell(BaseShell, Cmd):
     def completedefault(self, text, line, begidx, endidx):
         """Implements tab-completion for text."""
         rl_completion_suppress_append()  # this needs to be called each time
-        return self.completer.complete(text, line,
-                                       begidx, endidx,
-                                       ctx=self.ctx)
+        mline = line.partition(' ')[2]
+        offs = len(mline) - len(text)
+        x = [i[offs:] for i in self.completer.complete(text, line,
+                                                       begidx, endidx,
+                                                       ctx=self.ctx)[1]]
+        return x
 
     # tab complete on first index too
     completenames = completedefault

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -835,6 +835,7 @@ RE_STRING_CONT = {
 
 def partial_string_finder(x):
     o = []
+    o2 = []
     s = 0
     match = re.search(RE_BEGIN_STRING, x)
     while match is not None:
@@ -844,6 +845,7 @@ def partial_string_finder(x):
         lg = len(g)
         s += start
         o.append(s)
+        o2.append(g)
         ender = re.sub(RE_STRING_START, '', g)
         x = x[start + lg:]
         s += lg
@@ -856,4 +858,4 @@ def partial_string_finder(x):
             o.append(s)
         x = x[lg + len(ender):]
         match = re.search(RE_BEGIN_STRING, x)
-    return o
+    return o, o2

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -819,18 +819,19 @@ RE_STRING_TRIPLE_DOUBLE = '"""'
 RE_STRING_TRIPLE_SINGLE = "'''"
 RE_STRING_DOUBLE = '"'
 RE_STRING_SINGLE = "'"
-_STRINGS = [RE_STRING_TRIPLE_DOUBLE,
+_STRINGS = (RE_STRING_TRIPLE_DOUBLE,
             RE_STRING_TRIPLE_SINGLE,
             RE_STRING_DOUBLE,
-            RE_STRING_SINGLE]
-RE_BEGIN_STRING = "(" + RE_STRING_START + "|".join(_STRINGS) + ')'
+            RE_STRING_SINGLE)
+RE_BEGIN_STRING = re.compile("(" + RE_STRING_START + "|".join(_STRINGS) + ')')
+RE_STRING_START = re.compile(RE_STRING_START)
 
-RE_STRING_CONT = {
+RE_STRING_CONT = {k: re.compile(v) for k,v in {
     '"': r'((\\(.|\n))|([^"\\]))*',
     "'": r"((\\(.|\n))|([^'\\]))*",
     '"""': r'((\\(.|\n))|([^"\\])|("(?!""))|\n)*',
     "'''": r"((\\(.|\n))|([^'\\])|('(?!''))|\n)*",
-}
+}.items()}
 
 
 def partial_string_finder(x):

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -814,17 +814,22 @@ def print_color(string, file=sys.stdout):
     print(string.format(**TERM_COLORS).replace('\001', '').replace('\002', ''),
           file=file)
 
-RE_STRING_START = "[bBrRuU]*"
-RE_STRING_TRIPLE_DOUBLE = '"""'
-RE_STRING_TRIPLE_SINGLE = "'''"
-RE_STRING_DOUBLE = '"'
-RE_STRING_SINGLE = "'"
-_STRINGS = (RE_STRING_TRIPLE_DOUBLE,
-            RE_STRING_TRIPLE_SINGLE,
-            RE_STRING_DOUBLE,
-            RE_STRING_SINGLE)
-RE_BEGIN_STRING = re.compile("(" + RE_STRING_START + "|".join(_STRINGS) + ')')
-RE_STRING_START = re.compile(RE_STRING_START)
+_RE_STRING_START = "[bBrRuU]*"
+_RE_STRING_TRIPLE_DOUBLE = '"""'
+_RE_STRING_TRIPLE_SINGLE = "'''"
+_RE_STRING_DOUBLE = '"'
+_RE_STRING_SINGLE = "'"
+_STRINGS = (_RE_STRING_TRIPLE_DOUBLE,
+            _RE_STRING_TRIPLE_SINGLE,
+            _RE_STRING_DOUBLE,
+            _RE_STRING_SINGLE)
+RE_BEGIN_STRING = re.compile("(" + _RE_STRING_START + "|".join(_STRINGS) + ')')
+"""Regular expression matching the start of a string, including quotes and
+leading characters (r, b, or u)"""
+
+RE_STRING_START = re.compile(_RE_STRING_START)
+"""Regular expression matching the characters before the quotes when starting a
+string (r, b, or u, case insensitive)"""
 
 RE_STRING_CONT = {k: re.compile(v) for k,v in {
     '"': r'((\\(.|\n))|([^"\\]))*',
@@ -832,9 +837,38 @@ RE_STRING_CONT = {k: re.compile(v) for k,v in {
     '"""': r'((\\(.|\n))|([^"\\])|("(?!""))|\n)*',
     "'''": r"((\\(.|\n))|([^'\\])|('(?!''))|\n)*",
 }.items()}
+"""Dictionary mapping starting quote sequences to regular expressions that
+match the contents of a string beginning with those quotes (not including the
+terminating quotes)"""
 
 
 def check_for_partial_string(x):
+    """
+    Returns the starting index (inclusive), ending index (exclusive), and
+    starting quote string of the most recent Python string found in the input.
+
+    check_for_partial_string(x) -> (startix, endix, quote)
+
+    Parameters
+    ----------
+    x : str
+        The string to be checked (representing a line of terminal input)
+
+    Returns
+    -------
+    startix : int (or None)
+        The index where the most recent Python string found started
+        (inclusive), or None if no strings exist in the input
+
+    endix : int (or None)
+        The index where the most recent Python string found ended (exclusive),
+        or None if no strings exist in the input OR if the input ended in the
+        middle of a Python string
+
+    quote : str (or None)
+        A string containing the quote used to start the string (e.g., b", ",
+        '''), or None if no string was found.
+    """
     string_indices = []
     starting_quote = []
     current_index = 0

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -823,7 +823,9 @@ _STRINGS = (_RE_STRING_TRIPLE_DOUBLE,
             _RE_STRING_TRIPLE_SINGLE,
             _RE_STRING_DOUBLE,
             _RE_STRING_SINGLE)
-RE_BEGIN_STRING = re.compile("(" + _RE_STRING_START + "|".join(_STRINGS) + ')')
+RE_BEGIN_STRING = re.compile("(" + _RE_STRING_START +
+                             '(' + "|".join(_STRINGS) +
+                             '))')
 """Regular expression matching the start of a string, including quotes and
 leading characters (r, b, or u)"""
 


### PR DESCRIPTION
This changeset is a long-overdue continuation of #72.  It implements a couple of fixes/changes for the completer, basically trying to mimic the way Windows cmd.exe handles quoted paths:
* implements completion of partial strings (e.g, `"name with spa<tab>` will now complete to include the full name, as well as the proper ending quote)
* implements completion of full strings (e.g. `"name with spaces/"<tab>` will complete to show subdirectories of `name with spaces`, properly quoted [I think])

As it always has (modulo the issue in #181), it still wraps names containing spaces in quotes if they aren't already there.

The main reason I am marking as a work-in-progress is that I haven't yet gotten it to work in readline mode (nor have I tried yet).  Also, I'm not 100% sure I haven't broken something along the way.  Happy for other suggestions as well.