### PR TITLE
prompt-toolkit history now reads from xonsh history rather its own custom pickle method.

### DIFF
--- a/tests/test_prompt_toolkit_history.py
+++ b/tests/test_prompt_toolkit_history.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Tests for the LimitedFileHistory class."""
+"""Tests for the PromptToolkitHistory class."""
 import os
-from tempfile import NamedTemporaryFile
 
 import nose
 from nose.tools import assert_equal
@@ -19,90 +18,15 @@ if not is_prompt_toolkit_available():
     raise SkipTest('prompt_toolkit is not available')
 
 
-from xonsh.prompt_toolkit_history import LimitedFileHistory
+from xonsh.prompt_toolkit_history import PromptToolkitHistory
 
 
-def create_file(content):
-    with NamedTemporaryFile(delete=False) as tfile:
-        tfile.write(content.encode('utf-8'))
-        file_name = tfile.name
-    return file_name
-
-
-def check_op_sequence(op_sequence, start_file_content, desired_file_content):
-    file_name = create_file(start_file_content)
-    try:
-        op_sequence(file_name)
-        with open(file_name) as tfile:
-            content = tfile.read()
-            assert_equal(content, desired_file_content)
-    finally:
-        os.unlink(file_name)
-
-
-def create_file_content(start_line, stop_line):
-    content = []
-    for num in range(start_line, stop_line):
-        content.append('line{}'.format(num))
-    return '\n'.join(content) + '\n'
-
-
-def test_without_limit():
-    start_content = create_file_content(0, 10)
-    desired_content = start_content + 'line10\n'
-    def operation_sequence(history_file):
-        history_obj = LimitedFileHistory()
-        history_obj.read_history_file(history_file)
-        history_obj.append('line10')
-        history_obj.save_history_to_file(history_file)
-    yield check_op_sequence, operation_sequence, start_content, desired_content
-
-
-def test_smaller_limit():
-    start_content = create_file_content(0, 10)
-    desired_content = create_file_content(5, 10)
-    def operation_sequence(history_file):
-        history_obj = LimitedFileHistory()
-        history_obj.read_history_file(history_file)
-        history_obj.save_history_to_file(history_file, limit=5)
-    yield check_op_sequence, operation_sequence, start_content, desired_content
-
-
-def test_empty_initial_file():
-    start_content = ''
-    desired_content = create_file_content(0, 4)
-    def operation_sequence(history_file):
-        history_obj = LimitedFileHistory()
-        history_obj.read_history_file(history_file)
-        history_obj.append('line0')
-        history_obj.append('line1')
-        history_obj.append('line2')
-        history_obj.append('line3')
-        history_obj.save_history_to_file(history_file)
-    yield check_op_sequence, operation_sequence, start_content, desired_content
-
-
-def test_exact_limit():
-    start_content = create_file_content(0, 4)
-    desired_content = create_file_content(0, 4)
-    def operation_sequence(history_file):
-        history_obj = LimitedFileHistory()
-        history_obj.read_history_file(history_file)
-        history_obj.save_history_to_file(history_file, limit=4)
-    yield check_op_sequence, operation_sequence, start_content, desired_content
-
-
-def test_two_shells():
-    start_content = create_file_content(0, 4)
-    desired_content = create_file_content(0, 6)
-    def operation_sequence(history_file):
-        history1 = LimitedFileHistory()
-        history2 = LimitedFileHistory()
-        history1.append('line4')
-        history2.append('line5')
-        history1.save_history_to_file(history_file)
-        history2.save_history_to_file(history_file)
-    yield check_op_sequence, operation_sequence, start_content, desired_content
+def test_obj():
+    history_obj = PromptToolkitHistory(load_prev=False)
+    history_obj.append('line10')
+    yield assert_equal, ['line10'], history_obj.strings
+    yield assert_equal, 1, len(history_obj)
+    yield assert_equal, ['line10'], [x for x in history_obj]
 
 
 if __name__ == '__main__':

--- a/xonsh/prompt_toolkit_history.py
+++ b/xonsh/prompt_toolkit_history.py
@@ -1,40 +1,30 @@
 # -*- coding: utf-8 -*-
 """History object for use with prompt_toolkit."""
 import os
+import time
+import builtins
+from threading import Thread
 
-from prompt_toolkit.history import History
+import prompt_toolkit.history
 
-
-def load_file_into_list(store, filename):
-    """Load content of file filename into list store."""
-    if os.path.exists(filename):
-        with open(filename, 'rb') as hfile:
-            for line in hfile:
-                line = line.decode('utf-8')
-                # Drop trailing newline
-                store.append(line[:-1])
+from xonsh import lazyjson
 
 
-class LimitedFileHistory(History):
-
-    """History class that keeps entries in file with limit on number of those.
-
-    It handles only one-line entries.
+class PromptToolkitHistory(prompt_toolkit.history.History):
+    """History class that implements the promt-toolkit history interface
+    with the xonsh backend.
     """
 
-    def __init__(self):
+    def __init__(self, load_prev=True, wait_for_gc=True, *args, **kwargs):
         """Initialize history object."""
+        super().__init__()
         self.strings = []
-        self.new_entries = []
-        self.old_history = []
+        if load_prev:
+            PromptToolkitHistoryAdder(self, wait_for_gc=wait_for_gc)
 
     def append(self, entry):
-        """Append new entry to the history.
-
-        Entry sould be a one-liner.
-        """
+        """Append new entry to the history."""
         self.strings.append(entry)
-        self.new_entries.append(entry)
 
     def __getitem__(self, index):
         return self.strings[index]
@@ -45,58 +35,34 @@ class LimitedFileHistory(History):
     def __iter__(self):
         return iter(self.strings)
 
-    def read_history_file(self, filename):
-        """Read history from given file into memory.
 
-        It first discards all history entries that were read by this function
-        before, and then tries to read entries from filename as history of
-        commands that happend before current session.
-        Entries that were appendend in current session are left unharmed.
+class PromptToolkitHistoryAdder(Thread):
 
-        Parameters
-        ----------
-        filename : str
-            Path to history file.
+    def __init__(self, ptkhist, wait_for_gc=True, *args, **kwargs):
+        """Thread responsible for adding inputs from history to the current 
+        prompt-toolkit history instance. May wait for the history garbage 
+        collector to finish.
         """
-        self.old_history = []
-        load_file_into_list(self.old_history, filename)
-        self.strings = self.old_history[:]
-        self.strings.extend(self.new_entries)
+        super(PromptToolkitHistoryAdder, self).__init__(*args, **kwargs)
+        self.daemon = True
+        self.ptkhist = ptkhist
+        self.wait_for_gc = wait_for_gc
+        self.start()
 
-    def save_history_to_file(self, filename, limit=-1):
-        """Save history to file.
-
-        It first reads existing history file again, so nothing is overrided. If
-        combined number of entries from history file and current session
-        exceeds limit old entries are dropped.
-        Not thread safe.
-
-        Parameters
-        ----------
-        filename : str
-            Path to file to save history to.
-        limit : int
-            Limit on number of entries in history file. Negative values imply
-            unlimited history.
-        """
-        def write_list(lst, file_obj):
-            """Write each element of list as separate lint into file_obj."""
-            text = ('\n'.join(lst)) + '\n'
-            file_obj.write(text.encode('utf-8'))
-
-        if limit < 0:
-            with open(filename, 'ab') as hfile:
-                write_list(self.new_entries, hfile)
-            return
-
-        new_history = []
-        load_file_into_list(new_history, filename)
-
-        if len(new_history) + len(self.new_entries) <= limit:
-            if self.new_entries:
-                with open(filename, 'ab') as hfile:
-                    write_list(self.new_entries, hfile)
-        else:
-            new_history.extend(self.new_entries)
-            with open(filename, 'wb') as hfile:
-                write_list(new_history[-limit:], hfile)
+    def run(self):
+        hist = builtins.__xonsh_history__
+        while self.wait_for_gc and hist.gc.is_alive():
+            time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer
+        files = hist.gc.unlocked_files()
+        for _, _, f in files:
+            try:
+                lj = lazyjson.LazyJSON(f, reopen=False)
+                for cmd in lj['cmds']:
+                    inp = cmd['inp'].splitlines()
+                    for line in inp:
+                        if line == 'EOF':
+                            continue
+                        self.ptkhist.append(line)
+                lj.close()
+            except (IOError, OSError):
+                continue

--- a/xonsh/prompt_toolkit_history.py
+++ b/xonsh/prompt_toolkit_history.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """History object for use with prompt_toolkit."""
 import os
+import gc
 import time
 import builtins
 from threading import Thread
 
 import prompt_toolkit.history
+from prompt_toolkit.buffer import Buffer
 
 from xonsh import lazyjson
 
@@ -20,7 +22,8 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
         super().__init__()
         self.strings = []
         if load_prev:
-            PromptToolkitHistoryAdder(self, wait_for_gc=wait_for_gc)
+            #PromptToolkitHistoryAdder(self, wait_for_gc=wait_for_gc)
+            self._load(wait_for_gc=wait_for_gc)
 
     def append(self, entry):
         """Append new entry to the history."""
@@ -34,6 +37,24 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
 
     def __iter__(self):
         return iter(self.strings)
+
+    def _load(self, wait_for_gc=True):
+        hist = builtins.__xonsh_history__
+        while wait_for_gc and hist.gc.is_alive():
+            time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer
+        files = hist.gc.unlocked_files()
+        for _, _, f in files:
+            try:
+                lj = lazyjson.LazyJSON(f, reopen=False)
+                for cmd in lj['cmds']:
+                    inp = cmd['inp'].splitlines()
+                    for line in inp:
+                        if line == 'EOF':
+                            continue
+                        self.append(line)
+                lj.close()
+            except (IOError, OSError):
+                continue
 
 
 class PromptToolkitHistoryAdder(Thread):
@@ -54,6 +75,7 @@ class PromptToolkitHistoryAdder(Thread):
         while self.wait_for_gc and hist.gc.is_alive():
             time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer
         files = hist.gc.unlocked_files()
+        #buf = self._find_buffer()
         for _, _, f in files:
             try:
                 lj = lazyjson.LazyJSON(f, reopen=False)
@@ -63,6 +85,19 @@ class PromptToolkitHistoryAdder(Thread):
                         if line == 'EOF':
                             continue
                         self.ptkhist.append(line)
+                        #if buf is None:
+                        #    buf = self._find_buffer()
+                        #if buf is not None:
+                        #    buf['_working_lines'] = self.ptkhist.strings[:]
+                        #    buf['_Buffer__working_index'] = len(self.ptkhist) - 1
                 lj.close()
             except (IOError, OSError):
                 continue
+
+    def _find_buffer(self):
+        # dirty hack to get the prompt-toolkit buffer
+        bufs = [o for o in gc.get_referrers(self.ptkhist) \
+                if '_Buffer__working_index' in o]
+        buf = bufs[-1] if len(bufs) > 0 else None
+        return buf
+        

--- a/xonsh/prompt_toolkit_shell.py
+++ b/xonsh/prompt_toolkit_shell.py
@@ -16,33 +16,10 @@ from pygments.token import (Keyword, Name, Comment, String, Error, Number,
 from xonsh.base_shell import BaseShell
 from xonsh.tools import format_prompt_for_prompt_toolkit, _make_style
 from xonsh.prompt_toolkit_completer import PromptToolkitCompleter
-from xonsh.prompt_toolkit_history import LimitedFileHistory
+from xonsh.prompt_toolkit_history import PromptToolkitHistory
 from xonsh.prompt_toolkit_key_bindings import load_xonsh_bindings
 from xonsh.pyghooks import XonshLexer
 
-
-def setup_history():
-    """Creates history object."""
-    env = builtins.__xonsh_env__
-    hfile = env.get('XONSH_HISTORY_FILE')
-    history = LimitedFileHistory()
-    try:
-        history.read_history_file(hfile)
-    except PermissionError:
-        warn('do not have read permissions for ' + hfile, RuntimeWarning)
-    return history
-
-
-def teardown_history(history):
-    """Tears down the history object."""
-    import builtins
-    env = builtins.__xonsh_env__
-    hsize = env.get('XONSH_HISTORY_SIZE')[0]
-    hfile = env.get('XONSH_HISTORY_FILE')
-    try:
-        history.save_history_to_file(hfile, hsize)
-    except PermissionError:
-        warn('do not have write permissions for ' + hfile, RuntimeWarning)
 
 
 class PromptToolkitShell(BaseShell):
@@ -50,7 +27,7 @@ class PromptToolkitShell(BaseShell):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.history = setup_history()
+        self.history = PromptToolkitHistory()
         self.pt_completer = PromptToolkitCompleter(self.completer, self.ctx)
         self.key_bindings_manager = KeyBindingManager(
             enable_auto_suggest_bindings=True,
@@ -59,10 +36,6 @@ class PromptToolkitShell(BaseShell):
             enable_vi_mode=Condition(lambda cli: builtins.__xonsh_env__.get('VI_MODE')),
             enable_open_in_editor=True)
         load_xonsh_bindings(self.key_bindings_manager)
-
-    def __del__(self):
-        if self.history is not None:
-            teardown_history(self.history)
 
     def cmdloop(self, intro=None):
         """Enters a loop that reads and execute input from user."""


### PR DESCRIPTION
This addresses #551.