### PR TITLE
Removal of dollar from completions

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -65,7 +65,7 @@ XONSH_TOKENS = {
     '...'
 }
 
-CHARACTERS_NEED_QUOTES = ' `\t\r\n${}*()'
+CHARACTERS_NEED_QUOTES = ' `\t\r\n{}*()'
 if ON_WINDOWS:
     CHARACTERS_NEED_QUOTES += '%'
 


### PR DESCRIPTION
In the new completer, anything with a dollar sign will be quoted upon tab-completion. This is breaks Python-mode evaluation of variable lookup (and isn't really needed in subproc mode).  

```console
scopatz@localhost ~ $ $XONSH_[tab]
'$XONSH_INTERACTIVE'     '$XONSH_STORE_STDOUT'
'$XONSH_SHOW_TRACEBACK'  '$XONSH_VERSION'
```

These are all then evaluated as the literal string, rather than the envvar lookup.  This removed the dollar sign from the quotable characters.  I wouldn't mind if it went back in, pending a fix to this issue.