### PR TITLE
"True" multiline in PTK (WIP)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Current Developments
 * timeit alias will now complete its arguments.
 * $COMPLETIONS_MENU_ROWS environment variable controls the size of the 
   tab-completion menu in prompt-toolkit.
+* Prompt-toolkit shell now supports true multiline input with the ability
+  to scroll up and down in the prompt.
 
 **Changed:**
 

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Key bindings for prompt_toolkit xonsh shell."""
-import re
 import builtins
 
 from prompt_toolkit.filters import Filter, IsMultiline
@@ -38,7 +37,6 @@ def load_xonsh_bindings(key_bindings_manager):
     handle = key_bindings_manager.registry.add_binding
     env = builtins.__xonsh_env__
     indent_ = env.get('INDENT')
-    parens = re.compile('["\'].*[\\(\\)]*.*["\']')
 
     DEDENT_TOKENS = frozenset(['raise', 'return', 'pass', 'break', 'continue'])
 


### PR DESCRIPTION
I'm not sure this is done but I wanted to put it in front of a few more eyes to see if there's anything big that's missing.  This is my crack at a more robust multiline environment in PTK, as per #507.  

It remaps `Enter` to run through a preliminary parser that tries to determine whether to send the current buffer off for evaluation, or to insert a newline instead.  

Current 'triggers' for inserting a newline are:
- Not on first line of buffer and line is non-empty
- Previous character is a colon (covers if, for, etc...) 
- User is in an open paren-block
- Line ends with backslash
- Any text exists below cursor position (relevant when editing previous multiline blocks)

(Anything big missing here?)

If the character before the cursor is a colon, it also indents the following line -- otherwise a newline maintains the current indent level.

I tweaked the `ptk/completer.py` to work with multiline prompts.

Up arrow will move up in history if the cursor is on the first line, otherwise it moves up a line within the current document buffer.  

`xonsh` already saves multiline inputs in its rich history format, but if you open a new terminal window, the up arrow won't bring up the multiline buffer in history.  Not totally sure what to do about this.