### PR TITLE
made obtaining buffer in history thread safe.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ None
 
 * First prompt in the prompt-toolkit shell now allows for up and down
   arrows to search through history.
+* Made obtaining the prompt-toolkit buffer thread-safe.
 
 **Security:**
 

--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -77,9 +77,10 @@ class PromptToolkitHistoryAdder(Thread):
                 continue
 
     def _buf(self):
-        if hasattr(builtins, '__xonsh_shell__'):
-            buf = builtins.__xonsh_shell__.shell.prompter.cli.application.buffer
-        else:
-            buf = None
+        # Thread-safe version of
+        # buf = builtins.__xonsh_shell__.shell.prompter.cli.application.buffer
+        buf = getattr(getattr(getattr(getattr(getattr(getattr(builtins, 
+               '__xonsh_shell__', None), 'shell', None), 'prompter', None),
+               'cli', None), 'application', None), 'buffer', None)
         return buf
         

--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -79,8 +79,12 @@ class PromptToolkitHistoryAdder(Thread):
     def _buf(self):
         # Thread-safe version of
         # buf = builtins.__xonsh_shell__.shell.prompter.cli.application.buffer
-        buf = getattr(getattr(getattr(getattr(getattr(getattr(builtins, 
-               '__xonsh_shell__', None), 'shell', None), 'prompter', None),
-               'cli', None), 'application', None), 'buffer', None)
+        path = ['__xonsh_shell__', 'shell', 'prompter', 'cli', 'application', 
+                'buffer']
+        buf = builtins
+        for a in path:
+            buf = getattr(buf, a, None)
+            if buf is None:
+                break
         return buf
         


### PR DESCRIPTION
This only affected prompt-toolkit.