### PR TITLE
fix buffer reset in ptk history

### DIFF
--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -70,7 +70,7 @@ class PromptToolkitHistoryAdder(Thread):
                             buf = self._buf()
                             if buf is None:
                                 continue
-                        buf.reset()
+                        buf.reset(initial_document=buf.document)
                 lj.close()
             except (IOError, OSError):
                 continue


### PR DESCRIPTION
If this is only `buf.reset()`, it's possible to begin entering text in a
new terminal window which is then cleared shortly after startup
(depending, I imagine, on how much history is being loaded and how long
that takes).  Passing in the current document as `initial_document`
fixes this and history is still accessible as before.