### PR TITLE
help `compile` not lose its mind

### DIFF
--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -21,6 +21,8 @@ class TabShouldInsertIndentFilter(Filter):
 
 def can_compile(src):
     """Returns whether the code can be compiled, i.e. it is valid xonsh."""
+    if not src.endswith('\n') and not src.endswith('\''):
+        src = src + '\n'
     try:
         builtins.__xonsh_execer__.compile(src, mode='single', glbs=None,
                                           locs=builtins.__xonsh_ctx__)


### PR DESCRIPTION
Another fix here for multiline.  

I noticed some strange behavior, like typing `import os` would trigger a newline insertion instead of just running.  It turns out that `'import os'` comes back as a `SyntaxError` from `execer.compile` which was a little confusing but, in fact, it's just that `execer.compile` expects to be run after someone hits Enter, so it also expects a newline at the end of the input.  

One other odd thing -- in trying to fix this I was trying out different "typos" and when I typed

```
print('abc'
```
and his Enter `xonsh` froze up completely -- some kind of trouble with adding a newline character to the end of a single quote.

Anyway, this fixes all the cases I came up with.
