### PR TITLE
be less aggressive about adding newlines in multiline mode

### DIFF
--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -76,14 +76,15 @@ def load_xonsh_bindings(key_bindings_manager):
         b = event.cli.current_buffer
 
         at_end_of_line = b.document.current_line_after_cursor.strip() == ''
+        current_line_blank = (len(b.document.current_line) == 0 or
+                              b.document.current_line.isspace())
 
         # indent after a colon
         if (b.document.char_before_cursor == ':' and at_end_of_line):
             b.newline()
             b.insert_text(indent_, fire_event=False)
         # if current line isn't blank, check dedent tokens
-        elif (not (len(b.document.current_line) == 0 or
-                   b.document.current_line.isspace()) and
+        elif (not current_line_blank and
               b.document.current_line.split(maxsplit=1)[0] in DEDENT_TOKENS):
             b.newline(copy_margin=True)
             _ = b.delete_before_cursor(count=len(indent_))
@@ -95,7 +96,7 @@ def load_xonsh_bindings(key_bindings_manager):
             b.newline()
         elif b.document.find_next_word_beginning() is not None:
             b.newline(copy_margin=True)
-        elif not can_compile(b.document.text):
+        elif not current_line_blank and not can_compile(b.document.text):
             b.newline()
         else:
             b.accept_action.validate_and_handle(event.cli, b)

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -75,8 +75,10 @@ def load_xonsh_bindings(key_bindings_manager):
 
         b = event.cli.current_buffer
 
+        at_end_of_line = b.document.current_line_after_cursor.strip() == ''
+
         # indent after a colon
-        if b.document.char_before_cursor == ':':
+        if (b.document.char_before_cursor == ':' and at_end_of_line):
             b.newline()
             b.insert_text(indent_, fire_event=False)
         # if current line isn't blank, check dedent tokens

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -75,9 +75,8 @@ def load_xonsh_bindings(key_bindings_manager):
 
         b = event.cli.current_buffer
 
-        at_end_of_line = b.document.current_line_after_cursor.strip() == ''
-        current_line_blank = (len(b.document.current_line) == 0 or
-                              b.document.current_line.isspace())
+        at_end_of_line = _is_blank(b.document.current_line_after_cursor)
+        current_line_blank = _is_blank(b.document.current_line)
 
         # indent after a colon
         if (b.document.char_before_cursor == ':' and at_end_of_line):
@@ -94,9 +93,15 @@ def load_xonsh_bindings(key_bindings_manager):
             b.newline(copy_margin=True)
         elif b.document.char_before_cursor == '\\':
             b.newline()
-        elif b.document.find_next_word_beginning() is not None:
+        elif (b.document.find_next_word_beginning() is not None and
+                (any(not _is_blank(i)
+                     for i
+                     in b.document.lines_from_current[1:]))):
             b.newline(copy_margin=True)
         elif not current_line_blank and not can_compile(b.document.text):
             b.newline()
         else:
             b.accept_action.validate_and_handle(event.cli, b)
+
+def _is_blank(l):
+    return len(l.strip()) == 0

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -91,6 +91,8 @@ def load_xonsh_bindings(key_bindings_manager):
             b.newline(copy_margin=True)
         elif b.document.char_before_cursor == '\\':
             b.newline()
+        elif b.document.find_next_word_beginning() is not None:
+            b.newline(copy_margin=True)
         elif not can_compile(b.document.text):
             b.newline()
         else:

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -21,6 +21,7 @@ class TabShouldInsertIndentFilter(Filter):
 
 def can_compile(src):
     """Returns whether the code can be compiled, i.e. it is valid xonsh."""
+    src = src if src.endswith('\n') else '{}\n'.format(src)
     try:
         builtins.__xonsh_execer__.compile(src, mode='single', glbs=None,
                                           locs=builtins.__xonsh_ctx__)

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -79,7 +79,8 @@ def load_xonsh_bindings(key_bindings_manager):
         current_line_blank = _is_blank(b.document.current_line)
 
         # indent after a colon
-        if (b.document.char_before_cursor == ':' and at_end_of_line):
+        if (b.document.current_line_before_cursor.strip().endswith(':')
+                and at_end_of_line):
             b.newline()
             b.insert_text(indent_, fire_event=False)
         # if current line isn't blank, check dedent tokens

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -91,8 +91,6 @@ def load_xonsh_bindings(key_bindings_manager):
             b.newline(copy_margin=True)
         elif b.document.char_before_cursor == '\\':
             b.newline()
-        elif b.document.find_next_word_beginning() is not None:
-            b.newline(copy_margin=True)
         elif not can_compile(b.document.text):
             b.newline()
         else:

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -21,8 +21,6 @@ class TabShouldInsertIndentFilter(Filter):
 
 def can_compile(src):
     """Returns whether the code can be compiled, i.e. it is valid xonsh."""
-    if not src.endswith('\n') and not src.endswith('\''):
-        src = src + '\n'
     try:
         builtins.__xonsh_execer__.compile(src, mode='single', glbs=None,
                                           locs=builtins.__xonsh_ctx__)
@@ -89,8 +87,7 @@ def load_xonsh_bindings(key_bindings_manager):
             b.newline(copy_margin=True)
             _ = b.delete_before_cursor(count=len(indent_))
         elif (not b.document.on_first_line and
-              not (len(b.document.current_line) == 0 or
-                   b.document.current_line.isspace())):
+              not current_line_blank):
             b.newline(copy_margin=True)
         elif b.document.char_before_cursor == '\\':
             b.newline()


### PR DESCRIPTION
This change makes it so that hitting enter in the middle of a line does not create a newline, but rather runs the line as normal.

@gforsyth, was there a reason to include this case that I am not seeing?