### PR TITLE
check correct env (denv may not persist some Python objects)

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -91,7 +91,7 @@ def source_foreign(args, stdin=None):
     env = builtins.__xonsh_env__
     denv = env.detype()
     for k, v in fsenv.items():
-        if k in env and v == denv[k]:
+        if k in denv and v == denv[k]:
             continue  # no change from original
         env[k] = v
     baliases = builtins.aliases


### PR DESCRIPTION
Reported by @frol [here](https://github.com/scopatz/xonsh/issues/108#issuecomment-169996770), this fixes and issue with source-foreign if the envvar is callable, not peristable, or otherwise not detypable.

1 char change.