### PR TITLE
don't double-wrap things in $[...]

### DIFF
--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -186,6 +186,11 @@ class Execer(object):
                     if prev_indent == curr_indent:
                         raise original_error
                 maxcol = self._find_next_break(line, last_error_col)
+                if line.startswith('$['):
+                    # if we have already wrapped this in subproc tokens
+                    # and it still doesn't work, adding more won't help
+                    # anything
+                    raise original_error
                 sbpline = subproc_toks(line,
                                        returnline=True,
                                        maxcol=maxcol,


### PR DESCRIPTION
This should fix an infinite loop of wrapping certain syntactically-invalid subproc expressions with `$[...]`.

Previously, typing `(7+2<enter>` at the xonsh prompt would enter an infinite loop.