### PR TITLE
Fix background colors for PTK

### DIFF
--- a/tests/test_ptk_tools.py
+++ b/tests/test_ptk_tools.py
@@ -11,15 +11,15 @@ from xonsh.tools import TERM_COLORS
 from xonsh.environ import format_prompt, Env
 
 builtins.__xonsh_env__ = Env()
-builtins.__xonsh_env__['PROMPT_TOOLKIT_COLORS'] = {'WHITE': '#ffffff'}
+builtins.__xonsh_env__['PROMPT_TOOLKIT_COLORS'] = {'WHITE': '#f0f0f0'}
 
 def test_format_prompt_for_prompt_toolkit():
-    templ = ('>>> {BOLD_BLUE}~/xonsh {WHITE} (main){NO_COLOR}')
+    templ = ('>>> {BOLD_INTENSE_BLUE}~/xonsh {WHITE} {BACKGROUND_RED} {INTENSE_RED}(main){NO_COLOR}')
     prompt = format_prompt(templ, TERM_COLORS)
     token_names, color_styles, strings = format_prompt_for_prompt_toolkit(prompt)
-    assert_equal(token_names, ['NO_COLOR', 'BOLD_BLUE', 'WHITE', 'NO_COLOR'])
-    assert_equal(color_styles, ['', 'bold #0000D2', '#ffffff', ''])
-    assert_equal(strings, ['>>> ', '~/xonsh ', ' (main)', ''])
+    assert_equal(token_names, ['NO_COLOR', 'BOLD_INTENSE_BLUE', 'WHITE', 'BACKGROUND_RED', 'INTENSE_RED', 'NO_COLOR'])
+    assert_equal(color_styles, ['noinherit', 'bold #0000d2', '#f0f0f0', 'bg:#800000', 'bg:#800000 #ff1010', 'noinherit'])
+    assert_equal(strings, ['>>> ', '~/xonsh ', ' ', ' ', '(main)', ''])
 
 
 if __name__ == '__main__':

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -99,12 +99,12 @@ def is_callable_default(x):
     """Checks if a value is a callable default."""
     return callable(x) and getattr(x, '_xonsh_callable_default', False)
 if ON_WINDOWS:
-    DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_CYAN} '
-                      '{cwd}{branch_color}{curr_branch} '
+    DEFAULT_PROMPT = ('{BOLD_INTENSE_GREEN}{user}@{hostname}{BOLD_INTENSE_CYAN} '
+                      '{cwd}{branch_color}{curr_branch}{NO_COLOR} '
                       '{BOLD_WHITE}{prompt_end}{NO_COLOR} ')
 else:
     DEFAULT_PROMPT = ('{BOLD_GREEN}{user}@{hostname}{BOLD_BLUE} '
-                      '{cwd}{branch_color}{curr_branch} '
+                      '{cwd}{branch_color}{curr_branch}{NO_COLOR} '
                       '{BOLD_BLUE}{prompt_end}{NO_COLOR} ')
 
 DEFAULT_TITLE = '{current_job}{user}@{hostname}: {cwd} | xonsh'
@@ -809,8 +809,14 @@ def dirty_working_directory(cwd=None):
 
 def branch_color():
     """Return red if the current branch is dirty, otherwise green"""
-    return (TERM_COLORS['BOLD_RED'] if dirty_working_directory() else
-            TERM_COLORS['BOLD_GREEN'])
+    return (TERM_COLORS['BOLD_INTENSE_RED'] if dirty_working_directory() else
+            TERM_COLORS['BOLD_INTENSE_GREEN'])
+
+
+def branch_bg_color():
+    """Return red if the current branch is dirty, otherwise green"""
+    return (TERM_COLORS['BACKGROUND_RED'] if dirty_working_directory() else
+            TERM_COLORS['BACKGROUND_GREEN'])
 
 
 def _replace_home(x):
@@ -870,6 +876,7 @@ FORMATTER_DICT = dict(
     short_cwd=_collapsed_pwd,
     curr_branch=current_branch,
     branch_color=branch_color,
+    branch_bg_color=branch_bg_color,
     current_job=_current_job,
     **TERM_COLORS)
 DEFAULT_VALUES['FORMATTER_DICT'] = dict(FORMATTER_DICT)

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -179,7 +179,7 @@ def _xonsh_style(tokens=tuple(), cstyles=tuple()):
             Token.Aborted: '#888888',
         })
         # update with the prompt styles
-        styles.update({t: s for (t, s) in zip(tokens, cstyles)})
+        styles.update(dict(zip(tokens, cstyles)))
         # Update with with any user styles
         userstyle = builtins.__xonsh_env__.get('PROMPT_TOOLKIT_STYLES')
         if userstyle is not None:

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Hooks for pygments syntax highlighting."""
 from pygments.lexer import inherit, bygroups, using, this
-from pygments.token import Name, Generic, Keyword, Text, String
+from pygments.token import Name, Generic, Keyword, String
 from pygments.lexers.shell import BashLexer
 from pygments.lexers.agile import PythonLexer
 
@@ -61,7 +61,7 @@ class XonshConsoleLexer(PythonLexer):
         'subproc': SUBPROC_TOKENS,
     }
 
-# XonshLexer & XonshSubprocLexer have to refernce each other
+# XonshLexer & XonshSubprocLexer have to reference each other
 XonshSubprocLexer.tokens['root'] = [
     (r'(\$\{)(.*)(\})', bygroups(Keyword, using(XonshLexer), Keyword)),
     (r'(@\()(.+)(\))', bygroups(Keyword, using(XonshLexer), Keyword)),


### PR DESCRIPTION
Background colors in PTK doesn't work at all. This patch makes a weak attempt to make them work. Definitely not a great or permanent solution but should be a good start.