### PR TITLE
capturing redirection fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ None
 * Fixed issue with job management if a TTY existed but was not controlled
   by the process, posix only.
 * Jupyter kernel no longer times out when using foreign shells on startup.
+* Capturing redirections, e.g. ``$(echo hello > f.txt)``, no longer fails
+  with a decoding error.
 
 **Security:**
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -625,7 +625,7 @@ def run_subproc(cmds, captured=True):
     hist.last_cmd_rtn = prev_proc.returncode
     if write_target is None:
         # get output
-        output = ''
+        output = b''
         if prev_proc.stdout not in (None, sys.stdout):
             output = prev_proc.stdout.read()
         if captured:


### PR DESCRIPTION
This fixes the following problem:

```console
scopatz@localhost ~/fc-bench-method master $ $(echo "wow mom" > x)
Traceback (most recent call last):
  File "/home/scopatz/.local/lib/python3.5/site-packages/xonsh/base_shell.py", line 143, in default
    self.execer.exec(code, mode='single', glbs=self.ctx)  # no locals
  File "/home/scopatz/.local/lib/python3.5/site-packages/xonsh/execer.py", line 126, in exec
    return exec(code, glbs, locs)
  File "<xonsh-code>", line 1, in <module>
  File "/home/scopatz/.local/lib/python3.5/site-packages/xonsh/built_ins.py", line 646, in subproc_captured
    return run_subproc(cmds, captured=True)
  File "/home/scopatz/.local/lib/python3.5/site-packages/xonsh/built_ins.py", line 634, in run_subproc
    output = output.decode(encoding=ENV.get('XONSH_ENCODING'),
AttributeError: 'str' object has no attribute 'decode'
```

1 character fix :)