### PR TITLE
Raise subproc error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,12 @@ Xonsh Change Log
 Current Developments
 ====================
 
-**Added:** None
+**Added:** 
+
+* Added boolean ``$RAISE_SUBPROC_ERROR`` environment variable. If true
+  and a subprocess command exits with a non-zero return code, a 
+  CalledProcessError will be raised. This is useful in scripts that should
+  fail at the first error.
 
 **Changed:** None
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1018,6 +1018,11 @@ operates on a given argument, rather than on the string ``'xonsh'`` (notice how
     bash $ echo @(' '.join($(cat @('file%d.txt' % i)).strip() for i in range(6)))
     s n a i l s
 
+Additionally, if the script should exit if a command fails, set the 
+environment variable ``$RAISE_SUBPROC_ERROR = True`` at the top of the 
+file. Errors in Python mode will already raise exceptions and so this 
+is roughly equivelent to Bash's `set -e`.
+
 Importing Xonsh (``*.xsh``)
 ==============================
 You can import xonsh source files with the ``*.xsh`` file extension using

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -77,6 +77,7 @@ DEFAULT_ENSURERS = {
     'MOUSE_SUPPORT': (is_bool, to_bool, bool_to_str),
     re.compile('\w*PATH$'): (is_env_path, str_to_env_path, env_path_to_str),
     'PATHEXT': (is_env_path, str_to_env_path, env_path_to_str),
+    'RAISE_SUBPROC_ERROR': (is_bool, to_bool, bool_to_str),
     'TEEPTY_PIPE_DELAY': (is_float, float, str),
     'XONSHRC': (is_env_path, str_to_env_path, env_path_to_str),
     'XONSH_ENCODING': (is_string, ensure_string, ensure_string),
@@ -174,6 +175,7 @@ DEFAULT_VALUES = {
     'PROMPT_TOOLKIT_STYLES': None,
     'PUSHD_MINUS': False,
     'PUSHD_SILENT': False,
+    'RAISE_SUBPROC_ERROR': False,
     'SHELL_TYPE': 'prompt_toolkit' if ON_WINDOWS else 'readline',
     'SUGGEST_COMMANDS': True,
     'SUGGEST_MAX_NUM': 5,
@@ -341,6 +343,12 @@ DEFAULT_DOCS = {
         'behaviour.'),
     'PUSHD_SILENT': VarDocs(
         'Whether or not to suppress directory stack manipulation output.'),
+    'RAISE_SUBPROC_ERROR': VarDocs(
+        'Whether or not to raise an error if a subprocess (captured or '
+        'uncaptured) returns a non-zero exit status, which indicates failure.'
+        'This is most useful in xonsh scripts or modules where failures '
+        'should cause an end to execution. This is less useful at a terminal.'
+        'The error that is raised is a subprocess.CalledProcessError.'),
     'SHELL_TYPE': VarDocs(
         'Which shell is used. Currently two base shell types are supported:\n\n'
         "    - 'readline' that is backed by Python's readline module\n"

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -170,7 +170,8 @@ def main(argv=None):
             code = code if code.endswith('\n') else code + '\n'
             sys.argv = args.args
             env['ARGS'] = [args.file] + args.args
-            code = shell.execer.compile(code, mode='exec', glbs=shell.ctx)
+            code = shell.execer.compile(code, mode='exec', glbs=shell.ctx,
+                                        filename=args.file)
             shell.execer.exec(code, mode='exec', glbs=shell.ctx)
         else:
             print('xonsh: {0}: No such file or directory.'.format(args.file))
@@ -178,7 +179,8 @@ def main(argv=None):
         # run a script given on stdin
         code = sys.stdin.read()
         code = code if code.endswith('\n') else code + '\n'
-        code = shell.execer.compile(code, mode='exec', glbs=shell.ctx)
+        code = shell.execer.compile(code, mode='exec', glbs=shell.ctx,
+                                    filename='<stdin>')
         shell.execer.exec(code, mode='exec', glbs=shell.ctx)
     else:
         # otherwise, enter the shell


### PR DESCRIPTION
This adds the capability to raise a subprocess error whenever the subprocess returns a greater-than-zero exits status.  This is most useful for scripts and sometimes modules.

This was inspired by Bash's `set -e`.  For xonsh, it turns out, we only needed to add this behaviour for subproc mode, because Python mode will already throw an error.

Hopefully, `set -x` behaviour will come soon too, but that is a little more complicated.