### PR TITLE
disable multiline for '\' on windows without POSIX

### DIFF
--- a/tests/test_ptk_multiline.py
+++ b/tests/test_ptk_multiline.py
@@ -90,5 +90,15 @@ def test_can_compile_and_executes():
         carriage_return(buffer, cli)
         assert bufaccept.mock_calls is not None
 
+def test_trailing_slash_on_windows():
+    mock = MagicMock(return_value = True)
+    with patch('xonsh.ptk.key_bindings.can_compile', mock):
+        with patch('xonsh.tools.ON_WINDOWS', mock):
+            builtins.__xonsh_env__['FORCE_POSIX_PATHS'] = True
+            document = Document('this shouldnt newline \\')
+            buffer.set_document(document)
+            carriage_return(buffer, cli)
+            assert bufaccept.mock_calls is not None
+
 if __name__ == '__main__':
     nose.runmodule()

--- a/tests/test_ptk_multiline.py
+++ b/tests/test_ptk_multiline.py
@@ -8,6 +8,7 @@ from prompt_toolkit.interface import CommandLineInterface
 from prompt_toolkit.document import Document
 from prompt_toolkit.buffer import Buffer, AcceptAction
 from xonsh.environ import Env
+from xonsh.tools import ON_WINDOWS
 
 def setup():
     global indent_
@@ -69,10 +70,15 @@ def test_continuation_line():
     assert_equal(buffer.document.current_line, '')
 
 def test_trailing_slash():
-    document = Document('this line will \\')
-    buffer.set_document(document)
-    carriage_return(buffer, cli)
-    assert_equal(buffer.document.current_line, '')
+    mock = MagicMock(return_value = True)
+    with patch('xonsh.ptk.key_bindings.can_compile', mock):
+        document = Document('this line will \\')
+        buffer.set_document(document)
+        carriage_return(buffer, cli)
+        if not ON_WINDOWS:
+            assert_equal(buffer.document.current_line, '')
+        else:
+            assert bufaccept.mock_calls is not None
 
 def test_cant_compile_newline():
     mock = MagicMock(return_value = False)
@@ -89,16 +95,6 @@ def test_can_compile_and_executes():
         buffer.set_document(document)
         carriage_return(buffer, cli)
         assert bufaccept.mock_calls is not None
-
-def test_trailing_slash_on_windows():
-    mock = MagicMock(return_value = True)
-    with patch('xonsh.ptk.key_bindings.can_compile', mock):
-        with patch('xonsh.tools.ON_WINDOWS', mock):
-            builtins.__xonsh_env__['FORCE_POSIX_PATHS'] = True
-            document = Document('this shouldnt newline \\')
-            buffer.set_document(document)
-            carriage_return(buffer, cli)
-            assert bufaccept.mock_calls is not None
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -4,6 +4,7 @@ import builtins
 
 from prompt_toolkit.filters import Filter, IsMultiline
 from prompt_toolkit.keys import Keys
+from xonsh.tools import ON_WINDOWS
 
 env = builtins.__xonsh_env__
 indent_ = env.get('INDENT')
@@ -41,7 +42,9 @@ def carriage_return(b, cli):
     elif (not b.document.on_first_line and
             not current_line_blank):
         b.newline(copy_margin=True)
-    elif b.document.char_before_cursor == '\\':
+    elif (b.document.char_before_cursor == '\\' and 
+            not (not builtins.__xonsh_env__.get('FORCE_POSIX_PATHS') 
+                and ON_WINDOWS)):
         b.newline()
     elif (b.document.find_next_word_beginning() is not None and
             (any(not _is_blank(i)


### PR DESCRIPTION
Partial fix for #644 

If user is on Windows and has `FORCE_POSIX_PATHS` set to False, then
trailing backslash will not enter multiline mode as this messes up
directory navigation

@melund, can you see if this works on your end?  

Note that this doesn't preclude changing the default of `FORCE_POSIX_PATHS` to `True`