### PR TITLE
add temporary fix for diverging prompt_toolkit layout

### DIFF
--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -41,7 +41,11 @@ class PromptToolkitCompleter(Completer):
 
     def reserve_space(self):
         cli = builtins.__xonsh_shell__.shell.prompter.cli
-        window = cli.application.layout.children[1].children[1].content
+        #TODO remove after next prompt_toolkit release
+        try:
+            window = cli.application.layout.children[1].children[1].content
+        except AttributeError:
+            window = cli.application.layout.children[1].content
         h = window.render_info.content_height
         r = builtins.__xonsh_env__.get('COMPLETIONS_MENU_ROWS')
         size = h + r

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -43,8 +43,10 @@ class PromptToolkitCompleter(Completer):
         cli = builtins.__xonsh_shell__.shell.prompter.cli
         #TODO remove after next prompt_toolkit release
         try:
+            #old layout to be removed at next ptk release
             window = cli.application.layout.children[1].children[1].content
         except AttributeError:
+            #new layout to become default
             window = cli.application.layout.children[1].content
         h = window.render_info.content_height
         r = builtins.__xonsh_env__.get('COMPLETIONS_MENU_ROWS')


### PR DESCRIPTION
This is a temporary fix until there's a new release of `prompt_toolkit` to address the differences in the default `prompt` layout between 0.5.7 and current git master.  

This should address #643 

