### PR TITLE
Fix case-insensitive match breaking for paths in Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,9 @@ Current Developments
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
+
+* Fixed path completion not working for absolute paths or for expanded paths on Windows.
 
 **Security:** None
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -185,12 +185,23 @@ def expand_path(s):
     return os.path.expanduser(s)
 
 
+WINDOWS_DRIVE_MATCHER = re.compile(r'^\w:')
+
+
 def expand_case_matching(s):
     """Expands a string to a case insenstive globable string."""
     t = []
     openers = {'[', '{'}
     closers = {']', '}'}
     nesting = 0
+
+    drive_part = WINDOWS_DRIVE_MATCHER.match(s) if ON_WINDOWS else None
+
+    if drive_part:
+        drive_part = drive_part.group(0)
+        t.append(drive_part)
+        s = s[len(drive_part):]
+
     for c in s:
         if c in openers:
             nesting += 1
@@ -211,8 +222,7 @@ def expand_case_matching(s):
                                              c)
                 c = newc
         t.append(c)
-    t = ''.join(t)
-    return t
+    return ''.join(t)
 
 
 def reglob(path, parts=None, i=None):

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -163,8 +163,6 @@ class Completer(object):
             (only used with prompt_toolkit)
         """
         space = ' '  # intern some strings for faster appending
-        slash = '/'
-        dot = '.'
         ctx = ctx or {}
         prefixlow = prefix.lower()
         _line = line
@@ -393,7 +391,6 @@ class Completer(object):
 
     def path_complete(self, prefix, start, end, cdpath=False):
         """Completes based on a path name."""
-        space = ' '  # intern some strings for faster appending
         tilde = '~'
         paths = set()
         csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -735,36 +735,6 @@ def history_tuple_to_str(x):
 #
 
 
-class FakeChar(str):
-    """Class that holds a single char and escape sequences that surround it.
-
-    It is used as a workaround for the fact that prompt_toolkit doesn't display
-    colorful prompts correctly.
-    It behaves like normal string created with prefix + char + suffix, but has
-    two differences:
-
-    * len() always returns 2
-
-    * iterating over instance of this class is the same as iterating over
-      the single char - prefix and suffix are ommited.
-    """
-    def __new__(cls, char, prefix='', suffix=''):
-        return str.__new__(cls, prefix + char + suffix)
-
-    def __init__(self, char, prefix='', suffix=''):
-        self.char = char
-        self.prefix = prefix
-        self.suffix = suffix
-        self.length = 2
-        self.iterated = False
-
-    def __len__(self):
-        return self.length
-
-    def __iter__(self):
-        return iter(self.char)
-
-
 COLOR_CODE_SPLIT_RE = re.compile(r'(\001\033\[[\d;m]+\002)')
 TERM_COLORS_REVERSED = {v: k for k, v in TERM_COLORS.items()}
 COLOR_NAME_REGEX = re.compile(r'(?:(\w+)_)?(\w+)')
@@ -868,17 +838,6 @@ def print_color(string, file=sys.stdout):
     `sys.stdout` is used as the output stream but an alternate can be specified
     by the `file` keyword argument."""
     print(format_color(string), file=file)
-
-
-def escape_color(string):
-    """Escapes color formatting, ie '{RED}' becomes '{{RED}}'."""
-    s = string
-    for color in TERM_COLORS.keys():
-        if color in s:
-            bc = '{' + color + '}'  # braced color
-            dbc = '{' + bc + '}'  # double-braced color
-            s = s.replace(bc, dbc)
-    return s
 
 
 _RE_STRING_START = "[bBrRuU]*"


### PR DESCRIPTION
When using `glob` on Windows, case-insensitive conversion converts a
glob path like `~\D*` to
`[cC]:\[uU][sS][eE][rR][sS]\[bB][yY][kK]\[dD]*`. The `[cC]` part at the
beginning breaks `glob` and fails to yield any results, probably because
it cannot extract the base path.

This patch fixes the issue by skipping the conversion for a sequence
like `\w:` at the beginning.