### PR TITLE
Eliminate `locate_binary` and use a native Python implementation instead

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -108,12 +108,13 @@ def source_bash(args, stdin=None):
     args.append('--sourcer=source')
     return source_foreign(args, stdin=stdin)
 
+
 def source_alias(args, stdin=None):
     """Executes the contents of the provided files in the current context.
     If sourced file isn't found in cwd, search for file along $PATH to source instead"""
     for fname in args:
         if not os.path.isfile(fname):
-            fname = locate_binary(fname, cwd=None)[:-1]
+            fname = locate_binary(fname)[:-1]
         with open(fname, 'r') as fp:
             execx(fp.read(), 'exec', builtins.__xonsh_ctx__)
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -7,7 +7,6 @@ special Python builtins module.
 import os
 import re
 import sys
-import stat
 import time
 import shlex
 import atexit
@@ -292,68 +291,6 @@ def iglobpath(s, ignore_case=False):
 RE_SHEBANG = re.compile(r'#![ \t]*(.+?)$')
 
 
-def _is_executable_file(path):
-    """Checks that path is an executable regular file (or a symlink to a file).
-
-    This is roughly ``os.path isfile(path) and os.access(path, os.X_OK)``, but
-    on some platforms :func:`os.access` gives us the wrong answer, so this
-    checks permission bits directly.
-    """
-    # follow symlinks,
-    fpath = os.path.realpath(path)
-
-    # return False for non-files (directories, fifo, etc.)
-    if not os.path.isfile(fpath):
-        return False
-
-    # On Solaris, etc., "If the process has appropriate privileges, an
-    # implementation may indicate success for X_OK even if none of the
-    # execute file permission bits are set."
-    #
-    # For this reason, it is necessary to explicitly check st_mode
-
-    # get file mode using os.stat, and check if `other',
-    # that is anybody, may read and execute.
-    mode = os.stat(fpath).st_mode
-    if mode & stat.S_IROTH and mode & stat.S_IXOTH:
-        return True
-
-    # get current user's group ids, and check if `group',
-    # when matching ours, may read and execute.
-    user_gids = os.getgroups() + [os.getgid()]
-    if (os.stat(fpath).st_gid in user_gids and
-            mode & stat.S_IRGRP and mode & stat.S_IXGRP):
-        return True
-
-    # finally, if file owner matches our effective userid,
-    # check if `user', may read and execute.
-    user_gids = os.getgroups() + [os.getgid()]
-    if (os.stat(fpath).st_uid == os.geteuid() and
-            mode & stat.S_IRUSR and mode & stat.S_IXUSR):
-        return True
-
-    return False
-
-
-def _get_runnable_name(fname):
-    if os.path.isfile(fname) and fname != os.path.basename(fname):
-        return fname
-    for d in builtins.__xonsh_env__.get('PATH'):
-        if os.path.isdir(d):
-            files = os.listdir(d)
-            if ON_WINDOWS:
-                PATHEXT = builtins.__xonsh_env__.get('PATHEXT')
-                for dirfile in files:
-                    froot, ext = os.path.splitext(dirfile)
-                    if fname == froot and ext.upper() in PATHEXT:
-                        return os.path.join(d, dirfile)
-            if fname in files:
-                path = os.path.join(d, fname)
-                if _is_executable_file(path):
-                    return path
-    return None
-
-
 def _is_binary(fname, limit=80):
     with open(fname, 'rb') as f:
         for i in range(limit):
@@ -599,7 +536,7 @@ def run_subproc(cmds, captured=True):
             and builtins.__xonsh_env__.get('AUTO_CD')
             and len(cmd) == 1
             and os.path.isdir(cmd[0])
-            and locate_binary(cmd[0], cwd=None) is None):
+            and locate_binary(cmd[0]) is None):
             cmd.insert(0, 'cd')
             alias = builtins.aliases.get('cd', None)
 
@@ -608,7 +545,7 @@ def run_subproc(cmds, captured=True):
         else:
             if alias is not None:
                 cmd = alias + cmd[1:]
-            n = _get_runnable_name(cmd[0])
+            n = locate_binary(cmd[0])
             if n is None:
                 aliased_cmd = cmd
             else:


### PR DESCRIPTION
We already had a Python implementation for `which`/`where`
functionality but for some reason we were not making enough use of it.
This patch moves ` built_ins._get_runnable_name` to
`environ.locate_binary` and makes everything use it. This improves `git`
and `hg` querying speeds for prompt on Windows.