### PR TITLE
stop source alias from truncating filename

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -114,7 +114,7 @@ def source_alias(args, stdin=None):
     If sourced file isn't found in cwd, search for file along $PATH to source instead"""
     for fname in args:
         if not os.path.isfile(fname):
-            fname = locate_binary(fname)[:-1]
+            fname = locate_binary(fname)
         with open(fname, 'r') as fp:
             execx(fp.read(), 'exec', builtins.__xonsh_ctx__)
 


### PR DESCRIPTION
the replacement of `locate_binary` in #650 changed the way filenames are returned -- the `[:-1]` truncation in `source_alias` means that files not in the current directory are not found, despite being on `$PATH`