### PR TITLE
set process title

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Current Developments
   and a subprocess command exits with a non-zero return code, a 
   CalledProcessError will be raised. This is useful in scripts that should
   fail at the first error.
+* If the ``setproctitle`` package is installed, the process title will be
+  set to ``'xonsh'`` rather than the path to the Python interpreter.
 
 **Changed:** None
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -232,6 +232,7 @@ Xonsh currently has the following external dependencies,
     #. PLY
     #. prompt-toolkit (optional)
     #. Jupyter (optional)
+    #. setproctitle (optional)
 
 *Documentation:*
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -130,7 +130,7 @@ def _pprint_displayhook(value):
 def premain(argv=None):
     """Setup for main xonsh entry point, returns parsed arguments."""
     if setproctitle is not None:
-        setproctitle('xonsh')
+        setproctitle(' '.join(['xonsh'] + sys.argv[1:]))
     args, other = parser.parse_known_args(argv)
     if args.file is not None:
         real_argv = (argv or sys.argv)

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -6,6 +6,11 @@ import builtins
 from argparse import ArgumentParser, ArgumentTypeError
 from contextlib import contextmanager
 
+try:
+    from setproctitle import setproctitle
+except ImportError:
+    setproctitle = None
+
 from xonsh import __version__
 from xonsh.shell import Shell
 from xonsh.pretty import pprint
@@ -124,6 +129,8 @@ def _pprint_displayhook(value):
 
 def premain(argv=None):
     """Setup for main xonsh entry point, returns parsed arguments."""
+    if setproctitle is not None:
+        setproctitle('xonsh')
     args, other = parser.parse_known_args(argv)
     if args.file is not None:
         real_argv = (argv or sys.argv)


### PR DESCRIPTION
This adds `setproctitle` as an optional dependency to enable setting the process (rather than terminal) title. This will make xonsh appear as `"xonsh"` to ps and other process monitors, rather than `/path/to/python /path/to/xonsh` 

Inspired by @asmeurer. Also @asmeurer, note: https://anaconda.org/asmeurer/setproctitle :)