### PR TITLE
make call_hg_command() use the correct environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Current Developments
 **Fixed:**
 
 * Fixed path completion not working for absolute paths or for expanded paths on Windows.
+* Fixed issue with hg dirty branches and $PATH.
 
 **Security:** None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -790,7 +790,7 @@ def get_git_branch(cwd=None):
 
 def call_hg_command(command, cwd):
     # Override user configurations settings and aliases
-    hg_env = os.environ.copy()
+    hg_env = builtins.__xonsh_env__.detype()
     hg_env['HGRCPATH'] = ""
 
     s = None


### PR DESCRIPTION
This should fix #661. @ngoldbaum and @moigagoo, would you mind taking a look please?