### PR TITLE
Workaround bug in ConEmu/cmder (windows terminal emulators)

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -773,6 +773,12 @@ def get_git_branch(cwd=None):
                                         stderr=subprocess.PIPE,
                                         cwd=cwd,
                                         universal_newlines=True)
+            if len(s) == 0:
+                # Workaround for a bug in ConEMU/cmder 
+                # retry without redirection
+                s = subprocess.check_output(cmd,
+                                            cwd=cwd,
+                                            universal_newlines=True)
             s = s.strip()
             if len(s) > 0:
                 branch = s


### PR DESCRIPTION
Workaround bug in ConEmu/cmder which prevented get_git_branch() from working in these terminal emulators on windows. 