### PR TITLE
best shell type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,14 @@ Xonsh Change Log
 
 Current Developments
 ====================
-**Added:** None
+**Added:**
 
-**Changed:** None
+* Added new valid ``$SHELL_TYPE`` called ``'best'``. This selects the best value
+  for the concrete shell type based on the availability on the user's machine.
+
+**Changed:**
+
+* Updated ``$SHELL_TYPE`` default to ``'best'``.
 
 **Deprecated:** None
 
@@ -20,18 +25,18 @@ Current Developments
 
 v0.2.6
 ====================
-**Added:** 
+**Added:**
 
-* ``trace`` alias added that enables users to turn on and off the printing 
+* ``trace`` alias added that enables users to turn on and off the printing
   of source code lines prior to their execution. This is useful for debugging scripts.
 * New ability to force callable alias functions to be run in the foreground, i.e.
-  the main thread from which the function was called. This is useful for debuggers 
+  the main thread from which the function was called. This is useful for debuggers
   and profilers which may require such access. Use the ``xonsh.proc.foreground``
   decorator on an alias function to flag it. ``ForegroundProcProxy`` and
   ``SimpleForegroundProcProxy`` classes have been added to support this feature.
   Normally, forcing a foreground alias is not needed.
 * Added boolean ``$RAISE_SUBPROC_ERROR`` environment variable. If true
-  and a subprocess command exits with a non-zero return code, a 
+  and a subprocess command exits with a non-zero return code, a
   CalledProcessError will be raised. This is useful in scripts that should
   fail at the first error.
 * If the ``setproctitle`` package is installed, the process title will be
@@ -51,7 +56,7 @@ v0.2.6
 * Fixed path completion not working for absolute paths or for expanded paths on Windows.
 * Fixed issue with hg dirty branches and $PATH.
 * Fixed issues related to foreign shell data in files with whitespace in the names.
-* Worked around bug in ConEmu/cmder which prevented ``get_git_branch()`` 
+* Worked around bug in ConEmu/cmder which prevented ``get_git_branch()``
   from working in these terminal emulators on Windows.
 
 
@@ -59,12 +64,12 @@ v0.2.5
 ===========
 **Added:**
 
-* New configuration utility 'xonfig' which reports current system 
+* New configuration utility 'xonfig' which reports current system
   setup information and creates config files through an interactive
   wizard.
 * Toolkit for creating wizards now available
 * timeit and which aliases will now complete their arguments.
-* $COMPLETIONS_MENU_ROWS environment variable controls the size of the 
+* $COMPLETIONS_MENU_ROWS environment variable controls the size of the
   tab-completion menu in prompt-toolkit.
 * Prompt-toolkit shell now supports true multiline input with the ability
   to scroll up and down in the prompt.
@@ -75,7 +80,7 @@ v0.2.5
   file is found.
 * BaseShell now has a singleline() method for prompting a single input.
 * Environment variable docs are now auto-generated.
-* Prompt-toolkit shell will now dynamically allocate space for the 
+* Prompt-toolkit shell will now dynamically allocate space for the
   tab-completion menu.
 * Looking up nonexistent environment variables now generates an error
   in Python mode, but produces a sane default value in subprocess mode.
@@ -84,7 +89,7 @@ v0.2.5
 
 **Removed:**
 
-* Removed ``xonsh.ptk.shortcuts.Prompter.create_prompt_layout()`` and 
+* Removed ``xonsh.ptk.shortcuts.Prompter.create_prompt_layout()`` and
   ``xonsh.ptk.shortcuts.Prompter.create_prompt_application()`` methods
   to reduce portion of xonsh that forks prompt-toolkit. This may require
   users to upgrade to prompt-toolkit v0.57+.
@@ -94,7 +99,7 @@ v0.2.5
 * First prompt in the prompt-toolkit shell now allows for up and down
   arrows to search through history.
 * Made obtaining the prompt-toolkit buffer thread-safe.
-* Now always set non-detypable environment variables when sourcing 
+* Now always set non-detypable environment variables when sourcing
   foreign shells.
 * Fixed issue with job management if a TTY existed but was not controlled
   by the process, posix only.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -72,7 +72,7 @@ DEFAULT_ENSURERS = {
     'LC_MESSAGES': (always_false, locale_convert('LC_MESSAGES'), ensure_string),
     'LC_MONETARY': (always_false, locale_convert('LC_MONETARY'), ensure_string),
     'LC_NUMERIC': (always_false, locale_convert('LC_NUMERIC'), ensure_string),
-    'LC_TIME': (always_false, locale_convert('LC_TIME'), ensure_string),    
+    'LC_TIME': (always_false, locale_convert('LC_TIME'), ensure_string),
     'LOADED_CONFIG': (is_bool, to_bool, bool_to_str),
     'LOADED_RC_FILES': (is_bool_seq, csv_to_bool_seq, bool_seq_to_csv),
     'MOUSE_SUPPORT': (is_bool, to_bool, bool_to_str),
@@ -177,7 +177,7 @@ DEFAULT_VALUES = {
     'PUSHD_MINUS': False,
     'PUSHD_SILENT': False,
     'RAISE_SUBPROC_ERROR': False,
-    'SHELL_TYPE': 'prompt_toolkit' if ON_WINDOWS else 'readline',
+    'SHELL_TYPE': 'best',
     'SUGGEST_COMMANDS': True,
     'SUGGEST_MAX_NUM': 5,
     'SUGGEST_THRESHOLD': 3,
@@ -206,7 +206,7 @@ if hasattr(locale, 'LC_MESSAGES'):
 
 VarDocs = namedtuple('VarDocs', ['docstr', 'configurable', 'default'])
 VarDocs.__doc__ = """Named tuple for environment variable documentation
-    
+
 Parameters
 ----------
 docstr : str
@@ -215,7 +215,7 @@ configurable : bool, optional
     Flag for whether the environment variable is configurable or not.
 default : str, optional
     Custom docstring for the default value for complex defaults.
-    Is this is DefaultNotGiven, then the default will be looked up 
+    Is this is DefaultNotGiven, then the default will be looked up
     from DEFAULT_VALUES and converted to a str.
 """
 VarDocs.__new__.__defaults__ = (True, DefaultNotGiven)  # iterates from back
@@ -285,7 +285,7 @@ DEFAULT_DOCS = {
     'FORMATTER_DICT': VarDocs(
         'Dictionary containing variables to be used when formatting $PROMPT '
         "and $TITLE. See 'Customizing the Prompt' "
-        'http://xon.sh/tutorial.html#customizing-the-prompt', 
+        'http://xon.sh/tutorial.html#customizing-the-prompt',
         configurable=False, default='xonsh.environ.FORMATTER_DICT'),
     'HISTCONTROL': VarDocs(
         'A set of strings (comma-separated list in string form) of options '
@@ -328,7 +328,7 @@ DEFAULT_DOCS = {
         'or in syntax highlighting), it will use the value specified here to '
         'represent that color, instead of its default.  If a color is not '
         'specified here, prompt-toolkit uses the colors from '
-        "'xonsh.tools._PT_COLORS'.", configurable=False), 
+        "'xonsh.tools._PT_COLORS'.", configurable=False),
     'PROMPT_TOOLKIT_STYLES': VarDocs(
         'This is a mapping of user-specified styles for prompt-toolkit. See '
         'the prompt-toolkit documentation for more details. If None, this is '
@@ -347,8 +347,10 @@ DEFAULT_DOCS = {
     'SHELL_TYPE': VarDocs(
         'Which shell is used. Currently two base shell types are supported:\n\n'
         "    - 'readline' that is backed by Python's readline module\n"
-        "    - 'prompt_toolkit' that uses external library of the same name\n" 
-        "    - 'random' selects a random shell from the above on startup\n\n"
+        "    - 'prompt_toolkit' that uses external library of the same name\n"
+        "    - 'random' selects a random shell from the above on startup\n"
+        "    - 'best' selects the most feature-rich shell available on the\n"
+        "       user's system\n\n"
         'To use the prompt_toolkit shell you need to have prompt_toolkit '
         '(https://github.com/jonathanslenders/python-prompt-toolkit) '
         'library installed. To specify which shell should be used, do so in '
@@ -386,7 +388,7 @@ DEFAULT_DOCS = {
         "Flag to enable 'vi_mode' in the 'prompt_toolkit' shell."),
     'XDG_CONFIG_HOME': VarDocs(
         'Open desktop standard configuration home dir. This is the same '
-        'default as used in the standard.', configurable=False, 
+        'default as used in the standard.', configurable=False,
         default="'~/.config'"),
     'XDG_DATA_HOME': VarDocs(
         'Open desktop standard data home dir. This is the same default as '
@@ -415,7 +417,7 @@ DEFAULT_DOCS = {
         'Any string flag that has been previously registered with Python '
         "is allowed. See the 'Python codecs documentation' "
         "(https://docs.python.org/3/library/codecs.html#error-handlers) "
-        'for more information and available options.', 
+        'for more information and available options.',
         default="'surrogateescape'"),
     'XONSH_HISTORY_FILE': VarDocs('Location of history file (deprecated).',
         configurable=False, default="'~/.xonsh_history'"),
@@ -774,7 +776,7 @@ def get_git_branch(cwd=None):
                                         cwd=cwd,
                                         universal_newlines=True)
             if len(s) == 0:
-                # Workaround for a bug in ConEMU/cmder 
+                # Workaround for a bug in ConEMU/cmder
                 # retry without redirection
                 s = subprocess.check_output(cmd,
                                             cwd=cwd,
@@ -964,7 +966,7 @@ def is_template_string(template, formatter_dict=None):
         fmtter = formatter_dict
     known_names = set(fmtter.keys())
     return included_names <= known_names
-    
+
 
 def format_prompt(template=DEFAULT_PROMPT, formatter_dict=None):
     """Formats a xonsh prompt template string."""
@@ -1027,9 +1029,9 @@ def load_static_config(ctx, config=None):
     if config is not None:
         env['XONSHCONFIG'] = ctx['XONSHCONFIG'] = config
     elif 'XONSHCONFIG' in ctx:
-        config = env['XONSHCONFIG'] = ctx['XONSHCONFIG'] 
+        config = env['XONSHCONFIG'] = ctx['XONSHCONFIG']
     else:
-        # don't set in ctx in order to maintain default 
+        # don't set in ctx in order to maintain default
         config = env['XONSHCONFIG'] = xonshconfig(env)
     if os.path.isfile(config):
         with open(config, 'r') as f:

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -354,8 +354,7 @@ DEFAULT_DOCS = {
         'To use the prompt_toolkit shell you need to have prompt_toolkit '
         '(https://github.com/jonathanslenders/python-prompt-toolkit) '
         'library installed. To specify which shell should be used, do so in '
-        'the run control file.', default=("'prompt_toolkit' if on Windows, "
-        "and 'readline' otherwise.")),
+        'the run control file.'),
     'SUGGEST_COMMANDS': VarDocs(
         'When a user types an invalid command, xonsh will try to offer '
         'suggestions of similar valid commands if this is True.'),

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -76,7 +76,7 @@ parser.add_argument('--shell-type',
                          'Possible options: readline, prompt_toolkit, random. '
                          'Warning! If set this overrides $SHELL_TYPE variable.',
                     dest='shell_type',
-                    choices=('readline', 'prompt_toolkit', 'random'),
+                    choices=('readline', 'prompt_toolkit', 'best', 'random'),
                     default=None)
 parser.add_argument('file',
                     metavar='script-file',
@@ -93,7 +93,7 @@ parser.add_argument('args',
 
 
 def arg_undoers():
-    au = { 
+    au = {
         '-h': (lambda args: setattr(args, 'help', False)),
         '-V': (lambda args: setattr(args, 'version', False)),
         '-c': (lambda args: setattr(args, 'command', None)),

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -6,7 +6,7 @@ from warnings import warn
 
 from xonsh.execer import Execer
 from xonsh.environ import xonshrc_context
-from xonsh.tools import XonshError
+from xonsh.tools import XonshError, ON_WINDOWS
 
 
 def is_readline_available():
@@ -33,6 +33,15 @@ def prompt_toolkit_version():
     return getattr(prompt_toolkit, '__version__', '<0.57')
 
 
+def best_shell_type():
+    """Gets the best shell type that is available"""
+    if ON_WINDOWS or is_prompt_toolkit_available():
+        shell_type = 'prompt_toolkit'
+    else:
+        shell_type = 'readline'
+    return shell_type
+
+
 class Shell(object):
     """Main xonsh shell.
 
@@ -40,7 +49,7 @@ class Shell(object):
     readline version of shell should be used.
     """
 
-    def __init__(self, ctx=None, shell_type=None, config=None, rc=None, 
+    def __init__(self, ctx=None, shell_type=None, config=None, rc=None,
                  **kwargs):
         """
         Parameters
@@ -48,10 +57,10 @@ class Shell(object):
         ctx : Mapping, optional
             The execution context for the shell (e.g. the globals namespace).
             If none, this is computed by loading the rc files. If not None,
-            this no additional context is computed and this is used 
+            this no additional context is computed and this is used
             directly.
         shell_type : str, optional
-            The shell type to start, such as 'readline', 'prompt_toolkit', 
+            The shell type to start, such as 'readline', 'prompt_toolkit',
             or 'random'.
         config : str, optional
             Path to configuration file.
@@ -64,7 +73,9 @@ class Shell(object):
         if shell_type is not None:
             env['SHELL_TYPE'] = shell_type
         shell_type = env.get('SHELL_TYPE')
-        if shell_type == 'random':
+        if shell_type == 'best':
+            shell_type = best_shell_type()
+        elif shell_type == 'random':
             shell_type = random.choice(('readline', 'prompt_toolkit'))
         if shell_type == 'prompt_toolkit':
             if not is_prompt_toolkit_available():


### PR DESCRIPTION
This adds a 'best' shell type that tries to discover the best available shell from those available on the system. This PR also changes the default to 'best'.  This is meant to address the issue of people needing to manually switch to prompt-toolkit, if it is available.  If and when future shells are implemented, best can be adjusted as needed.

This is a relatively minor change, but I think it is worth it.