### PR TITLE
Workaround bug in ConEmu/cmder (windows terminal emulators) 

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -870,6 +870,12 @@ def git_dirty_working_directory(cwd=None):
                                     stderr=subprocess.PIPE,
                                     cwd=cwd,
                                     universal_newlines=True)
+        if len(s) == 0:
+            # Workaround for a bug in ConEMU/cmder 
+ +          # retry without redirection
+            s = subprocess.check_output(cmd,
+                                        cwd=cwd,
+                                        universal_newlines=True)
         return bool(s)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -872,7 +872,7 @@ def git_dirty_working_directory(cwd=None):
                                     universal_newlines=True)
         if len(s) == 0:
             # Workaround for a bug in ConEMU/cmder 
- +          # retry without redirection
+            # retry without redirection
             s = subprocess.check_output(cmd,
                                         cwd=cwd,
                                         universal_newlines=True)


### PR DESCRIPTION
This is similar to #667, but this one fixes git_dirty_working_directory() 