### PR TITLE
add `tempfile` import to try statement to fail py27 gracefully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,13 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 import json
+
 try:
     from tempfile import TemporaryDirectory
+except ImportError:
+    pass
+
+try:
     from setuptools import setup
     from setuptools.command.sdist import sdist
     from setuptools.command.install import install

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 import json
-from tempfile import TemporaryDirectory
 try:
+    from tempfile import TemporaryDirectory
     from setuptools import setup
     from setuptools.command.sdist import sdist
     from setuptools.command.install import install


### PR DESCRIPTION
one line change to move `from tempfile import TemporaryDirectory` inside
the try statement so that the install will reach the `sys.version_info`
check and let a user know that Legacy Python is not supported in xonsh.

as per @tmbdev's request in #646