### PR TITLE
Ignore untracked files when considering if git workdir is dirty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Current Developments
   capabilities.
 * New ``Token.Color`` token for xonsh color names, e.g. we now use
   ``Token.Color.RED`` rather than ``Token.RED``.
+* Untracked files in git are ignored when determining if a git workdir is 
+  is dirty. This affects the coloring of the branch label. 
 
 **Deprecated:** None
 

--- a/docs/xonshrc.rst
+++ b/docs/xonshrc.rst
@@ -15,5 +15,35 @@ at startup. The following is a real-world example of such a file.
     :code: xonsh
 
 
+Snippets for xonshrc
+=========================
+The following are usefull snippets and code that tweaks and adjust xonsh in various ways.
+If you have any useful tricks, feel free to share them. 
 
-    
+Adjust how git branch label behaves
+---------------------------------
+Xonsh adds a colored branch name to the prompt when working with git or hg repositories. 
+This behavior can be controlled with the ``$PROMPT`` environment variable. See how to `customize the prompt`_ . 
+The branch name changes color if the work dir is dirty or not. This is controlled by the ``{branch_color}`` formatter string. 
+
+
+The following snippet reimplements the formatter also to include untracked files when considering if a git directory is dirty. 
+
+.. code-block:: xonshcon
+
+    >>> from xonsh.environ import git_dirty_working_directory
+    >>> $FORMATTER_DICT['branch_color'] = lambda: ('{BOLD_INTENSE_RED}'
+                                                   if git_dirty_working_directory(include_untracked=True)
+                                                   else '{BOLD_INTENSE_GREEN}')
+
+                                                   
+.. _customize the prompt: http://xon.sh/tutorial.html#customizing-the-prompt
+
+
+Get better colors from the ``ls`` command
+----------------------------------------------
+The colors of the ``ls`` command may be hard to read in a dark terminal. If so, this is an excellent addition to the xonshrc file. 
+
+.. code-block:: xonshcon
+
+    >>> $LS_COLORS='rs=0:di=01;36:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:'

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -862,10 +862,13 @@ def current_branch(pad=True):
     return branch or ''
 
 
-@ensure_git
-def git_dirty_working_directory(cwd=None):
+def git_dirty_working_directory(cwd=None, include_untracked=False):
     try:
-        cmd = ['git', 'status', '--porcelain', '--untracked-files=no']
+        cmd = ['git', 'status', '--porcelain']
+        if include_untracked:
+            cmd.append('--untracked-files=yes')
+        else:
+            cmd.append('--untracked-files=no')
         s = subprocess.check_output(cmd,
                                     stderr=subprocess.PIPE,
                                     cwd=cwd,

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -865,7 +865,7 @@ def current_branch(pad=True):
 @ensure_git
 def git_dirty_working_directory(cwd=None):
     try:
-        cmd = ['git', 'status', '--porcelain']
+        cmd = ['git', 'status', '--porcelain', '--untracked-files=no']
         s = subprocess.check_output(cmd,
                                     stderr=subprocess.PIPE,
                                     cwd=cwd,


### PR DESCRIPTION
This is up for discussion... Most of my other tools don't consider the workdir to be dirty if there are untracked files. 