### PR TITLE
Add optional dependency on the win_unicode_console library

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Current Developments
 * Python mode output is now syntax highlighted if pygments is available.
 * New ``$RIGHT_PROMPT`` environment variable for displaying right-aligned
   text in prompt-toolkit shell.
+* Optional dependency on the win_unicode_console package to enable unicode
+  support in cmd.exe on Windows. This can be disabled/enabled with the
+  ``$WIN_UNICODE_CONSOLE`` environment variable.
 
 **Changed:**
 

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -108,7 +108,7 @@ Python's utf-8 unicode is not compatible with the default shell 'cmd.exe' on Win
 
 .. note:: Even with unicode support enabled the symbols available will depend on the font used in cmd.exe.
 
-The packages ``win_unicode_console`can be installed using pip or conda.
+The packages ``win_unicode_console`` can be installed using pip or conda.
 
 .. code-block:: bat
 

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -66,6 +66,10 @@ Next, run xonsh:
 
 Usage
 ================
+
+Name space conflicts
+--------------------
+
 Due to ambiguity with the Python ``dir`` builtin, to list the current
 directory via the ``cmd.exe`` builtin you must explicitly request
 the ``.``, like this:
@@ -95,3 +99,22 @@ typing and avoid the ambiguity altogether:
 
 You can add aliases to your ``~/.xonshrc`` to have it always
 available when xonsh starts.
+
+
+Unicode support for Windows
+----------------------------
+
+Python's utf-8 unicode is not compatible with the default shell 'cmd.exe' on Windows. The package ``win_unicode_console`` fixes this. Xonsh will use ``win_unicode_console`` if it is installed. This can be disabled/enabled with the ``$WIN_UNICODE_CONSOLE``` environment variable. 
+
+.. note:: Even with unicode support enabled the symbols available will depend on the font used in cmd.exe.
+
+The packages ``win_unicode_console`can be installed using pip or conda.
+
+.. code-block:: bat
+
+  > pip install win_unicode_console
+
+
+.. code-block:: bat
+
+  > conda install --channel xonsh win_unicode_console

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -86,13 +86,12 @@ the ``.``, like this:
 
 
 
-Many people create a ``d`` or ``ls`` alias for the ``dir`` command to save
+Many people create a ``d`` alias for the ``dir`` command to save
 typing and avoid the ambiguity altogether:
 
 .. code-block:: xonshcon
 
    >>> aliases['d'] = ['cmd', '/c', 'dir']
-   >>> aliases['ls'] = 'dir'
 
 You can add aliases to your ``~/.xonshrc`` to have it always
 available when xonsh starts.

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -23,7 +23,7 @@ from xonsh.tools import (
     history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING,
     is_completions_display_value, to_completions_display_value, is_string_set,
     csv_to_set, set_to_csv, get_sep, is_int, is_bool_seq, csv_to_bool_seq,
-    bool_seq_to_csv, DefaultNotGiven
+    bool_seq_to_csv, DefaultNotGiven, setup_win_unicode_console
 )
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
@@ -90,6 +90,7 @@ DEFAULT_ENSURERS = {
     'XONSH_STORE_STDOUT': (is_bool, to_bool, bool_to_str),
     'VI_MODE': (is_bool, to_bool, bool_to_str),
     'VIRTUAL_ENV': (is_string, ensure_string, ensure_string),
+    'WIN_UNICODE_CONSOLE': (always_false, setup_win_unicode_console, bool_to_str),
 }
 
 #
@@ -190,6 +191,7 @@ DEFAULT_VALUES = {
     'TEEPTY_PIPE_DELAY': 0.01,
     'TITLE': DEFAULT_TITLE,
     'VI_MODE': False,
+    'WIN_UNICODE_CONSOLE': True,
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
     'XDG_DATA_HOME': os.path.expanduser(os.path.join('~', '.local', 'share')),
     'XONSHCONFIG': xonshconfig,
@@ -398,6 +400,10 @@ DEFAULT_DOCS = {
         "Flag to enable 'vi_mode' in the 'prompt_toolkit' shell."),
     'VIRTUAL_ENV': VarDocs(
         'Path to the currently active Python environment.', configurable=False),
+    'WIN_UNICODE_CONSOLE': VarDocs(
+        "Enables unicode support in windows terminals. Requires the external "
+        "library 'win_unicode_console'.",
+        configurable=ON_WINDOWS),
     'XDG_CONFIG_HOME': VarDocs(
         'Open desktop standard configuration home dir. This is the same '
         'default as used in the standard.', configurable=False,

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -171,7 +171,7 @@ def premain(argv=None):
         env['XONSH_LOGIN'] = True
     env['XONSH_INTERACTIVE'] = False
     if ON_WINDOWS:
-        setup_win_unicode_console(env['WIN_UNICODE_CONSOLE'])
+        setup_win_unicode_console(env.get('WIN_UNICODE_CONSOLE', True))
     return args
 
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -15,7 +15,7 @@ from xonsh import __version__
 from xonsh.shell import Shell
 from xonsh.pretty import pprint, pretty
 from xonsh.jobs import ignore_sigtstp
-from xonsh.tools import HAVE_PYGMENTS, print_color
+from xonsh.tools import HAVE_PYGMENTS, setup_win_unicode_console, print_color, ON_WINDOWS
 
 if HAVE_PYGMENTS:
     import pygments
@@ -170,6 +170,8 @@ def premain(argv=None):
     if args.login:
         env['XONSH_LOGIN'] = True
     env['XONSH_INTERACTIVE'] = False
+    if ON_WINDOWS:
+        setup_win_unicode_console(env['WIN_UNICODE_CONSOLE'])
     return args
 
 
@@ -215,6 +217,8 @@ def main(argv=None):
 
 def postmain(args=None):
     """Teardown for main xonsh entry point, accepts parsed arguments."""
+    if ON_WINDOWS:
+        setup_win_unicode_console(enable=False)
     del builtins.__xonsh_shell__
 
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -50,6 +50,11 @@ else:
     string_types = (str, unicode)
     unicode_type = unicode
 
+try:
+    import win_unicode_console
+except ImportError:
+    win_unicode_console = None
+    
 
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
@@ -596,6 +601,16 @@ def to_completions_display_value(x):
     return x
 
 
+def setup_win_unicode_console(enable):
+    """"Enables or disables unicode display on windows."""
+    enable = to_bool(enable)
+    if ON_WINDOWS and win_unicode_console:
+        if enable:
+            win_unicode_console.enable()
+        else:
+            win_unicode_console.disable()
+    return enable
+    
 # history validation
 
 _min_to_sec = lambda x: 60.0 * float(x)


### PR DESCRIPTION
It enables utf-8 support in windows terminals. ( https://pypi.python.org/pypi/win_unicode_console )

It is only active if win_unicode_console is installed, and it can be disabled by setting `$WIN_UNICODE_CONSOLE` to False. Setting the env-var also enables/disables on the fly.

We better test for a while our self ( @BYK ) to see if there are any unwanted side-effects. 

Install with:
```
conda install -c xonsh win_unicode_console
pip install win_unicode_console
```

