### PR TITLE
better check for avoiding double-wrapping with $[...]

### DIFF
--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -185,15 +185,15 @@ class Execer(object):
                     if prev_indent == curr_indent:
                         raise original_error
                 maxcol = self._find_next_break(line, last_error_col)
-                if line.startswith('$['):
-                    # if we have already wrapped this in subproc tokens
-                    # and it still doesn't work, adding more won't help
-                    # anything
-                    raise original_error
                 sbpline = subproc_toks(line,
                                        returnline=True,
                                        maxcol=maxcol,
                                        lexer=self.parser.lexer)
+                if line.startswith('$[$['):
+                    # if we have already wrapped this in subproc tokens
+                    # and it still doesn't work, adding more won't help
+                    # anything
+                    raise original_error
                 if sbpline is None:
                     # subprocess line had no valid tokens, likely because
                     # it only contained a comment.

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -189,7 +189,7 @@ class Execer(object):
                                        returnline=True,
                                        maxcol=maxcol,
                                        lexer=self.parser.lexer)
-                if line.startswith('$[$['):
+                if sbpline.startswith('$[$['):
                     # if we have already wrapped this in subproc tokens
                     # and it still doesn't work, adding more won't help
                     # anything


### PR DESCRIPTION
This slight change modifies the way we check for double-wrapping lines in `$[...]`, to avoid the issue in #710 while still preserving the benefits of the original fix.