### PR TITLE
fix collision with ptk multiline dedent and `pass`

### DIFF
--- a/tests/test_ptk_multiline.py
+++ b/tests/test_ptk_multiline.py
@@ -53,15 +53,32 @@ def test_colon_indent():
     assert_equal(buffer.document.current_line, indent_)
 
 def test_dedent():
-    document = Document(indent_+'pass')
+    document = Document('\n'+indent_+'pass')
     buffer.set_document(document)
     carriage_return(buffer, cli)
     assert_equal(buffer.document.current_line, '')
 
-    document = Document(2*indent_+'continue')
+    document = Document('\n'+2*indent_+'continue')
     buffer.set_document(document)
     carriage_return(buffer, cli)
     assert_equal(buffer.document.current_line,indent_)
+
+def test_nodedent():
+    '''don't dedent if first line of buffer'''
+    mock = MagicMock(return_value = True)
+    with patch('xonsh.ptk.key_bindings.can_compile', mock):
+        document = Document('pass')
+        buffer.set_document(document)
+        carriage_return(buffer, cli)
+        assert bufaccept.mock_calls is not None
+
+
+    mock = MagicMock(return_value = True)
+    with patch('xonsh.ptk.key_bindings.can_compile', mock):
+        document = Document(indent_+'pass')
+        buffer.set_document(document)
+        carriage_return(buffer, cli)
+        assert bufaccept.mock_calls is not None
 
 def test_continuation_line():
     document = Document('\nsecond line')

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -36,7 +36,8 @@ def carriage_return(b, cli):
         b.insert_text(indent_, fire_event=False)
     # if current line isn't blank, check dedent tokens
     elif (not current_line_blank and
-            b.document.current_line.split(maxsplit=1)[0] in DEDENT_TOKENS):
+            b.document.current_line.split(maxsplit=1)[0] in DEDENT_TOKENS and
+            b.document.line_count > 1):
         b.newline(copy_margin=True)
         _ = b.delete_before_cursor(count=len(indent_))
     elif (not b.document.on_first_line and


### PR DESCRIPTION
This is a bit of an edge case, but the password manager `pass` causes a
few headaches with the multiline carriage return logic.  Specifically,
because `pass` is a `DEDENT_TOKEN` when running `pass` as the password
manager the prompt will delete one indent-length's worth of characters
on a `<ENTER>` press.  This is a one-line fix to make sure that people
 can use `pass` in the PTK shell by assuming (correctly) that if the buffer 
document is only one line long, then dedenting is meaningless.
Just running `pass` will be interpreted as a Pythonic `pass`, but
commands like `pass git init` will work.

If someone has a xsh script that uses `pass` it should be wrapped in
`$[]`.