### PR TITLE
modify regular expression globbing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,9 @@ Current Developments
   ``Token.Color.RED`` rather than ``Token.RED``.
 * Untracked files in git are ignored when determining if a git workdir is 
   is dirty. This affects the coloring of the branch label. 
+* Regular expression globbing now uses ``re.fullmatch`` instead of
+  ``re.match``, and the result of an empty regex glob does not cause the
+  argument to be deleted.
 
 **Deprecated:** None
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -253,12 +253,12 @@ def reglob(path, parts=None, i=None):
     if i1 == len(parts):
         for f in files:
             p = os.path.join(base, f)
-            if regex.match(p) is not None:
+            if regex.fullmatch(p) is not None:
                 paths.append(p)
     else:
         for f in files:
             p = os.path.join(base, f)
-            if regex.match(p) is None or not os.path.isdir(p):
+            if regex.fullmatch(p) is None or not os.path.isdir(p):
                 continue
             paths += reglob(p, parts=parts, i=i1)
     return paths
@@ -269,7 +269,8 @@ def regexpath(s):
     paths that match the regex.
     """
     s = expand_path(s)
-    return reglob(s)
+    o = reglob(s)
+    return o if len(o) != 0 else [s]
 
 
 def globpath(s, ignore_case=False):


### PR DESCRIPTION
This patch modifies regular expression globbing as per the discussion in #711 .  For experimentation/discussion.

Also fixes a separate issue I had with regex globbing, whereby returning an empty list would result in that argument disappearing from the args list. 