### PR TITLE
Update recipe to use git_url specification.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: {{ environ.get('GIT_DESCRIBE_TAG', '0.0.0') }}
 
 source:
-   path: ../
+   git_url: ../
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}


### PR DESCRIPTION
This fixes a problem when building on a anaconda.org. I hope anaconda.org will soon stabilize