### PR TITLE
Improve double-star globing.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -96,3 +96,15 @@ manually use the ``$[]`` or ``$()`` operators on your code.
 Yes, context-sensitive parsing is gross. But the point of xonsh is that it uses xontext-sensitive parsing and 
 is ultimately a lot less gross than other shell languages, such as BASH.
 Furthermore, its use is heavily limited here.
+
+
+
+6. Gotchas
+----------
+
+There are a few gotchas when using xonsh across multiple versions of Python,
+where some behavior can differ, as the underlying Python might behave
+differently.
+
+For example double star globbing `**` will only work on Python 3.5+ (ie not on 3.4)
+as recursive globbing is `new in Python 3.5 <https://docs.python.org/3/library/glob.html#glob.glob>`_

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -167,19 +167,22 @@ def regexpath(s, pymode=False):
 
 def globpath(s, ignore_case=False):
     """Simple wrapper around glob that also expands home and env vars."""
-    s = expand_path(s)
-    if ignore_case:
-        s = expand_case_matching(s)
-    o = glob(s)
+    o, s = _iglobpath(s, ignore_case=ignore_case)
+    o = list(o)
     return o if len(o) != 0 else [s]
 
 
-def iglobpath(s, ignore_case=False):
-    """Simple wrapper around iglob that also expands home and env vars."""
+def _iglobpath(s, ignore_case=False):
     s = expand_path(s)
     if ignore_case:
         s = expand_case_matching(s)
-    return iglob(s)
+    if '**' in s and '**/*' not in s:
+        s = s.replace('**', '**/*')
+    return iglob(s, recursive=True), s
+
+def iglobpath(s, ignore_case=False):
+    """Simple wrapper around iglob that also expands home and env vars."""
+    return _iglobpath(s, ignore_case)[0]
 
 
 RE_SHEBANG = re.compile(r'#![ \t]*(.+?)$')

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -176,9 +176,13 @@ def _iglobpath(s, ignore_case=False):
     s = expand_path(s)
     if ignore_case:
         s = expand_case_matching(s)
-    if '**' in s and '**/*' not in s:
-        s = s.replace('**', '**/*')
-    return iglob(s, recursive=True), s
+    if sys.version_info > (3, 5):
+        if '**' in s and '**/*' not in s:
+            s = s.replace('**', '**/*')
+        # `recursive` is only a 3.5+ kwarg. 
+        return iglob(s, recursive=True), s
+    else:
+        return iglob(s), s
 
 def iglobpath(s, ignore_case=False):
     """Simple wrapper around iglob that also expands home and env vars."""


### PR DESCRIPTION
Not as advance as using a package like glob2, but allow simple use of
double start to match recursively in subdirectory.

e.g:
    $ ls -1 **p.py
    docs/cmdhelp.py
    setup.py

Which match both in CWD and Subdirectory.

See #451,

Also consolidate `globpath` and `iglobpath` (see #733)

---- 

I'm sure there are probably side effects, and It's just one of the annoying behavior that upset me,  so i'm just submitting for people to try it out.

Also the `recursive=True` kwarg-only is only a 3.5+ thing. So it might not be a good thing to get in now.