### PR TITLE
Add numpy slicing to the parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -310,6 +310,75 @@ def test_str_slice_lower_other():
 def test_str_slice_upper_other():
     yield check_ast, '"hello"[3::2]'
 
+def test_str_2slice():
+    yield check_ast, '"hello"[0:3,0:3]', False
+
+def test_str_2step():
+    yield check_ast, '"hello"[0:3:1,0:4:2]', False
+
+def test_str_2slice_all():
+    yield check_ast, '"hello"[:,:]', False
+
+def test_str_2slice_upper():
+    yield check_ast, '"hello"[5:,5:]', False
+
+def test_str_2slice_lower():
+    yield check_ast, '"hello"[:3,:3]', False
+
+def test_str_2slice_lowerupper():
+    yield check_ast, '"hello"[5:,:3]', False
+
+def test_str_2slice_other():
+    yield check_ast, '"hello"[::2,::2]', False
+
+def test_str_2slice_lower_other():
+    yield check_ast, '"hello"[:3:2,:3:2]', False
+
+def test_str_2slice_upper_other():
+    yield check_ast, '"hello"[3::2,3::2]', False
+
+def test_str_3slice():
+    yield check_ast, '"hello"[0:3,0:3,0:3]', False
+
+def test_str_3step():
+    yield check_ast, '"hello"[0:3:1,0:4:2,1:3:2]', False
+
+def test_str_3slice_all():
+    yield check_ast, '"hello"[:,:,:]', False
+
+def test_str_3slice_upper():
+    yield check_ast, '"hello"[5:,5:,5:]', False
+
+def test_str_3slice_lower():
+    yield check_ast, '"hello"[:3,:3,:3]', False
+
+def test_str_3slice_lowerlowerupper():
+    yield check_ast, '"hello"[:3,:3,:3]', False
+
+def test_str_3slice_lowerupperlower():
+    yield check_ast, '"hello"[:3,5:,:3]', False
+
+def test_str_3slice_lowerupperupper():
+    yield check_ast, '"hello"[:3,5:,5:]', False
+
+def test_str_3slice_upperlowerlower():
+    yield check_ast, '"hello"[5:,5:,:3]', False
+
+def test_str_3slice_upperlowerupper():
+    yield check_ast, '"hello"[5:,:3,5:]', False
+
+def test_str_3slice_upperupperlower():
+    yield check_ast, '"hello"[5:,5:,:3]', False
+
+def test_str_3slice_other():
+    yield check_ast, '"hello"[::2,::2,::2]', False
+
+def test_str_3slice_lower_other():
+    yield check_ast, '"hello"[:3:2,:3:2,:3:2]', False
+
+def test_str_3slice_upper_other():
+    yield check_ast, '"hello"[3::2,3::2,3::2]', False
+
 def test_list_empty():
     yield check_ast, '[]'
 

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -5,7 +5,7 @@
 from ast import Module, Num, Expr, Str, Bytes, UnaryOp, UAdd, USub, Invert, \
     BinOp, Add, Sub, Mult, Div, FloorDiv, Mod, Pow, Compare, Lt, Gt, \
     LtE, GtE, Eq, NotEq, In, NotIn, Is, IsNot, Not, BoolOp, Or, And, \
-    Subscript, Load, Slice, List, Tuple, Set, Dict, AST, NameConstant, \
+    Subscript, Load, Slice, ExtSlice, List, Tuple, Set, Dict, AST, NameConstant, \
     Name, GeneratorExp, Store, comprehension, ListComp, SetComp, DictComp, \
     Assign, AugAssign, BitXor, BitAnd, BitOr, LShift, RShift, Assert, Delete, \
     Del, Pass, Raise, Import, alias, ImportFrom, Continue, Break, Yield, \

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1799,8 +1799,8 @@ class BaseParser(object):
         """subscriptlist : subscript comma_subscript_list_opt comma_opt"""
         p1, p2 = p[1], p[2]
         if isinstance(p1, ast.Slice):
-            if p2 is not None:
-                p1 = ast.ExtSlice(dims=[p1, *p2])
+            if p2 is not None and True in [isinstance(x, ast.Slice) for x in p2]:
+                p1 = ast.ExtSlice(dims=[p1]+p2)
         elif p2 is not None:
             p1.value = ast.Tuple(elts=[p1.value] + [x.value for x in p2],
                                  ctx=ast.Load(), lineno=p1.lineno,

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1798,7 +1798,10 @@ class BaseParser(object):
     def p_subscriptlist(self, p):
         """subscriptlist : subscript comma_subscript_list_opt comma_opt"""
         p1, p2 = p[1], p[2]
-        if p2 is not None:
+        if isinstance(p1, ast.Slice):
+            if p2 is not None:
+                p1 = ast.ExtSlice(dims=[p1, *p2])
+        elif p2 is not None:
             p1.value = ast.Tuple(elts=[p1.value] + [x.value for x in p2],
                                  ctx=ast.Load(), lineno=p1.lineno,
                                  col_offset=p1.col_offset)
@@ -1822,58 +1825,7 @@ class BaseParser(object):
         else:
             lineno, col = p1.lineno, p1.col_offset
         p[0] = ast.Slice(lower=p1, upper=p[3], step=p[4],
-                                            lineno=lineno, col_offset=col)
-
-    def p_subscript_2slice(self, p):
-        """subscript : test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt"""
-        p1 = p[1]
-        if p1 is None:
-            p2 = p[2]
-            lineno1, col1 = p2.lineno, p2.lexpos
-        else:
-            lineno1, col1 = p1.lineno, p1.col_offset
-
-        p6 = p[6]
-        if p6 is None:
-            p7 = p[7]
-            lineno2, col2 = p7.lineno, p7.lexpos
-        else:
-            lineno2, col2 = p6.lineno, p6.col_offset
-
-        p[0] = ast.ExtSlice(dims=[ast.Slice(lower=p1, upper=p[3], step=p[4],
-                                            lineno=lineno1, col_offset=col1),
-                                  ast.Slice(lower=p6, upper=p[8], step=p[9],
-                                            lineno=lineno2, col_offset=col2)])
-
-    def p_subscript_3slice(self, p):
-        """subscript : test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt"""
-        p1 = p[1]
-        if p1 is None:
-            p2 = p[2]
-            lineno1, col1 = p2.lineno, p2.lexpos
-        else:
-            lineno1, col1 = p1.lineno, p1.col_offset
-
-        p6 = p[6]
-        if p6 is None:
-            p7 = p[7]
-            lineno2, col2 = p7.lineno, p7.lexpos
-        else:
-            lineno2, col2 = p6.lineno, p6.col_offset
-
-        p11 = p[11]
-        if p11 is None:
-            p12 = p[12]
-            lineno3, col3 = p12.lineno, p12.lexpos
-        else:
-            lineno3, col3 = p11.lineno, p11.col_offset
-
-        p[0] = ast.ExtSlice(dims=[ast.Slice(lower=p1, upper=p[3], step=p[4],
-                                            lineno=lineno1, col_offset=col1),
-                                  ast.Slice(lower=p6, upper=p[8], step=p[9],
-                                            lineno=lineno2, col_offset=col2),
-                                  ast.Slice(lower=p11, upper=p[13], step=p[14],
-                                            lineno=lineno3, col_offset=col3)])
+                         lineno=lineno, col_offset=col)
 
     def p_sliceop(self, p):
         """sliceop : COLON test_opt"""

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1593,7 +1593,7 @@ class BaseParser(object):
             return leader
         p0 = leader
         for trailer in trailers:
-            if isinstance(trailer, (ast.Index, ast.Slice)):
+            if isinstance(trailer, (ast.Index, ast.Slice, ast.ExtSlice)):
                 p0 = ast.Subscript(value=leader,
                                    slice=trailer,
                                    ctx=ast.Load(),
@@ -1822,7 +1822,28 @@ class BaseParser(object):
         else:
             lineno, col = p1.lineno, p1.col_offset
         p[0] = ast.Slice(lower=p1, upper=p[3], step=p[4],
-                         lineno=lineno, col_offset=col)
+                                            lineno=lineno, col_offset=col)
+
+    def p_subscript_tok_slice(self, p):
+        """subscript : test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt"""
+        p1 = p[1]
+        if p1 is None:
+            p2 = p[2]
+            lineno1, col1 = p2.lineno, p2.lexpos
+        else:
+            lineno1, col1 = p1.lineno, p1.col_offset
+
+        p6 = p[6]
+        if p6 is None:
+            p7 = p[7]
+            lineno2, col2 = p7.lineno, p7.lexpos
+        else:
+            lineno2, col2 = p6.lineno, p6.col_offset
+
+        p[0] = ast.ExtSlice(dims=[ast.Slice(lower=p1, upper=p[3], step=p[4],
+                                            lineno=lineno1, col_offset=col1),
+                                  ast.Slice(lower=p6, upper=p[8], step=p[9],
+                                            lineno=lineno2, col_offset=col2)])
 
     def p_sliceop(self, p):
         """sliceop : COLON test_opt"""

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1824,7 +1824,7 @@ class BaseParser(object):
         p[0] = ast.Slice(lower=p1, upper=p[3], step=p[4],
                                             lineno=lineno, col_offset=col)
 
-    def p_subscript_tok_slice(self, p):
+    def p_subscript_2slice(self, p):
         """subscript : test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt"""
         p1 = p[1]
         if p1 is None:
@@ -1844,6 +1844,36 @@ class BaseParser(object):
                                             lineno=lineno1, col_offset=col1),
                                   ast.Slice(lower=p6, upper=p[8], step=p[9],
                                             lineno=lineno2, col_offset=col2)])
+
+    def p_subscript_3slice(self, p):
+        """subscript : test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt COMMA test_opt colon_tok test_opt sliceop_opt"""
+        p1 = p[1]
+        if p1 is None:
+            p2 = p[2]
+            lineno1, col1 = p2.lineno, p2.lexpos
+        else:
+            lineno1, col1 = p1.lineno, p1.col_offset
+
+        p6 = p[6]
+        if p6 is None:
+            p7 = p[7]
+            lineno2, col2 = p7.lineno, p7.lexpos
+        else:
+            lineno2, col2 = p6.lineno, p6.col_offset
+
+        p11 = p[11]
+        if p11 is None:
+            p12 = p[12]
+            lineno3, col3 = p12.lineno, p12.lexpos
+        else:
+            lineno3, col3 = p11.lineno, p11.col_offset
+
+        p[0] = ast.ExtSlice(dims=[ast.Slice(lower=p1, upper=p[3], step=p[4],
+                                            lineno=lineno1, col_offset=col1),
+                                  ast.Slice(lower=p6, upper=p[8], step=p[9],
+                                            lineno=lineno2, col_offset=col2),
+                                  ast.Slice(lower=p11, upper=p[13], step=p[14],
+                                            lineno=lineno3, col_offset=col3)])
 
     def p_sliceop(self, p):
         """sliceop : COLON test_opt"""


### PR DESCRIPTION
This adds support for 2d and 3d slicing to the xonsh parser.  This is my first outing with `yacc` and there's probably a cleaner way to do it, but this works.  