### PR TITLE
Ensure that window and window.render_info exist.

### DIFF
--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -48,14 +48,15 @@ class PromptToolkitCompleter(Completer):
         except AttributeError:
             #new layout to become default
             window = cli.application.layout.children[1].content
-        h = window.render_info.content_height
-        r = builtins.__xonsh_env__.get('COMPLETIONS_MENU_ROWS')
-        size = h + r
-        def comp_height(cli):
-            # If there is an autocompletion menu to be shown, make sure that o
-            # layout has at least a minimal height in order to display it.
-            if not cli.is_done:
-                return LayoutDimension(min=size)
-            else:
-                return LayoutDimension()
-        window._height = comp_height
+        if window and window.render_info:
+            h = window.render_info.content_height
+            r = builtins.__xonsh_env__.get('COMPLETIONS_MENU_ROWS')
+            size = h + r
+            def comp_height(cli):
+                # If there is an autocompletion menu to be shown, make sure that o
+                # layout has at least a minimal height in order to display it.
+                if not cli.is_done:
+                    return LayoutDimension(min=size)
+                else:
+                    return LayoutDimension()
+            window._height = comp_height


### PR DESCRIPTION
This fixes a bug I got with the newest version of prompt_toolkit. 

The fix is to check that window and window.render_info are valid. This is what @jonathanslenders  does here:
https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/prompt_toolkit/key_binding/bindings/scroll.py#L67

```
mel@ANYBODY-MEL ~/Documents/xonsh                                                                              (master)
$ gi <tab>
Exception in thread Thread-12:
Traceback (most recent call last):
  File "C:\Users\mel\Anaconda3\lib\threading.py", line 914, in _bootstrap_inner
    self.run()
  File "C:\Users\mel\Anaconda3\lib\threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\mel\Anaconda3\lib\site-packages\prompt_toolkit\interface.py", line 742, in run
    completions = list(buffer.completer.get_completions(document, complete_event))
  File "c:\users\mel\documents\xonsh\xonsh\ptk\completer.py", line 38, in get_completions
    self.reserve_space()
  File "c:\users\mel\documents\xonsh\xonsh\ptk\completer.py", line 51, in reserve_space
    h = window.render_info.content_height
AttributeError: 'NoneType' object has no attribute 'content_height'
```