### PR TITLE
some logic fixes to ndslicing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ Current Developments
 
 **Fixed:**
 
+* Multidimensional slicing, as in numpy, no longer throws SyntaxErrors.
 * Some minor zsh fixes for more platforms and setups.
 * The ``BaseShell.settitle`` method no longer has its commands captured by
   ``$(...)``

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -58,7 +58,7 @@ def assert_nodes_equal(x, y, include_attributes=True):
         print(pdump(x, include_attributes=include_attributes), '\n')
         print('y:\n==')
         print(pdump(y, include_attributes=include_attributes), '\n')
-    assert_equal(pdump(x, include_attributes=include_attributes), 
+    assert_equal(pdump(x, include_attributes=include_attributes),
                  pdump(y, include_attributes=include_attributes))
 
 def check_ast(inp, run=True, mode='eval'):
@@ -378,6 +378,12 @@ def test_str_3slice_lower_other():
 
 def test_str_3slice_upper_other():
     yield check_ast, '"hello"[3::2,3::2,3::2]', False
+
+def test_str_slice_true():
+    yield check_ast, '"hello"[0:3,True]', False
+
+def test_str_true_slice():
+    yield check_ast, '"hello"[True,0:3]', False
 
 def test_list_empty():
     yield check_ast, '[]'

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1798,10 +1798,12 @@ class BaseParser(object):
     def p_subscriptlist(self, p):
         """subscriptlist : subscript comma_subscript_list_opt comma_opt"""
         p1, p2 = p[1], p[2]
-        if isinstance(p1, ast.Slice):
-            if p2 is not None and True in [isinstance(x, ast.Slice) for x in p2]:
-                p1 = ast.ExtSlice(dims=[p1]+p2)
-        elif p2 is not None:
+        if p2 is None:
+            pass
+        elif isinstance(p1, ast.Slice) or \
+                any([isinstance(x, ast.Slice) for x in p2]):
+            p1 = ast.ExtSlice(dims=[p1]+p2)
+        else:
             p1.value = ast.Tuple(elts=[p1.value] + [x.value for x in p2],
                                  ctx=ast.Load(), lineno=p1.lineno,
                                  col_offset=p1.col_offset)
@@ -2177,7 +2179,7 @@ class BaseParser(object):
                         lineno=p1.lineno, col=p1.lexpos)
         p0._cliarg_action = 'splitlines'
         p[0] = p0
-    
+
     def p_subproc_atom_captured_hiddenobject(self, p):
         """subproc_atom : bang_lbracket_tok subproc RBRACKET"""
         p1 = p[1]


### PR DESCRIPTION
Also enables slicing like `[True,0:42]` where booleans and masks are mixed in with slices.  Probably for @gforsyth to take a look at.