### PR TITLE
Fixes for !() and ![]

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1568,6 +1568,12 @@ def test_ls_nest_ls():
 def test_ls_nest_ls_dashl():
     yield check_xonsh_ast, {}, '$(ls $(ls) -l)', False
 
+def test_ls_envvar_strval():
+    yield check_xonsh_ast, {'WAKKA': '.'}, '$(ls $WAKKA)', False
+
+def test_ls_envvar_listval():
+    yield check_xonsh_ast, {'WAKKA': ['.', '.']}, '$(ls $WAKKA)', False
+
 def test_bang_sub():
     yield check_xonsh_ast, {}, '!(ls)', False
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1568,11 +1568,35 @@ def test_ls_nest_ls():
 def test_ls_nest_ls_dashl():
     yield check_xonsh_ast, {}, '$(ls $(ls) -l)', False
 
-def test_ls_envvar_strval():
-    yield check_xonsh_ast, {'WAKKA': '.'}, '$(ls $WAKKA)', False
+def test_bang_sub():
+    yield check_xonsh_ast, {}, '!(ls)', False
 
-def test_ls_envvar_listval():
-    yield check_xonsh_ast, {'WAKKA': ['.', '.']}, '$(ls $WAKKA)', False
+def test_bang_sub_space():
+    yield check_xonsh_ast, {}, '!(ls )', False
+
+def test_bang_ls_dot():
+    yield check_xonsh_ast, {}, '!(ls .)', False
+
+def test_bang_ls_dot_nesting():
+    yield check_xonsh_ast, {}, '!(ls @(None or "."))', False
+
+def test_bang_ls_dot_nesting_var():
+    yield check_xonsh, {}, 'x = "."; !(ls @(None or x))', False
+
+def test_bang_ls_dot_str():
+    yield check_xonsh_ast, {}, '!(ls ".")', False
+
+def test_bang_ls_nest_ls():
+    yield check_xonsh_ast, {}, '!(ls $(ls))', False
+
+def test_bang_ls_nest_ls_dashl():
+    yield check_xonsh_ast, {}, '!(ls $(ls) -l)', False
+
+def test_bang_ls_envvar_strval():
+    yield check_xonsh_ast, {'WAKKA': '.'}, '!(ls $WAKKA)', False
+
+def test_bang_ls_envvar_listval():
+    yield check_xonsh_ast, {'WAKKA': ['.', '.']}, '!(ls $WAKKA)', False
 
 def test_question():
     yield check_xonsh_ast, {}, 'range?'
@@ -1591,6 +1615,50 @@ def test_backtick():
 
 def test_uncaptured_sub():
     yield check_xonsh_ast, {}, '$[ls]', False
+
+def test_hiddenobj_sub():
+    yield check_xonsh_ast, {}, '![ls]', False
+
+def test_bang_two_cmds_one_pipe():
+    yield check_xonsh_ast, {}, '!(ls | grep wakka)', False
+
+def test_bang_three_cmds_two_pipes():
+    yield check_xonsh_ast, {}, '!(ls | grep wakka | grep jawaka)', False
+
+def test_bang_one_cmd_write():
+    yield check_xonsh_ast, {}, '!(ls > x.py)', False
+
+def test_bang_one_cmd_append():
+    yield check_xonsh_ast, {}, '!(ls >> x.py)', False
+
+def test_bang_two_cmds_write():
+    yield check_xonsh_ast, {}, '!(ls | grep wakka > x.py)', False
+
+def test_bang_two_cmds_append():
+    yield check_xonsh_ast, {}, '!(ls | grep wakka >> x.py)', False
+
+def test_bang_cmd_background():
+    yield check_xonsh_ast, {}, '!(emacs ugggh &)', False
+
+def test_bang_cmd_background_nospace():
+    yield check_xonsh_ast, {}, '!(emacs ugggh&)', False
+
+def test_bang_git_quotes_no_space():
+    yield check_xonsh_ast, {}, '![git commit -am "wakka"]', False
+
+def test_bang_git_quotes_space():
+    yield check_xonsh_ast, {}, '![git commit -am "wakka jawaka"]', False
+
+def test_bang_git_two_quotes_space():
+    yield check_xonsh, {}, ('![git commit -am "wakka jawaka"]\n'
+                            '![git commit -am "flock jawaka"]\n'), False
+
+def test_bang_git_two_quotes_space_space():
+    yield check_xonsh, {}, ('![git commit -am "wakka jawaka" ]\n'
+                            '![git commit -am "flock jawaka milwaka" ]\n'), False
+
+def test_bang_ls_quotes_3_space():
+    yield check_xonsh_ast, {}, '![ls "wakka jawaka baraka"]', False
 
 def test_two_cmds_one_pipe():
     yield check_xonsh_ast, {}, '$(ls | grep wakka)', False

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -497,6 +497,7 @@ def run_subproc(cmds, captured=False):
     prev_proc = None
     _capture_streams = captured in {'stdout', 'object'}
     for ix, cmd in enumerate(cmds):
+        starttime = time.time()
         procinfo['args'] = list(cmd)
         stdin = None
         stderr = None
@@ -683,6 +684,7 @@ def run_subproc(cmds, captured=False):
     elif captured is not False:
         procinfo['pid'] = prev_proc.pid
         procinfo['returncode'] = prev_proc.returncode
+        procinfo['timestamp'] = (starttime, time.time())
         if captured == 'object':
             procinfo['stdout'] = output
             if _stdin_file is not None:

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2172,22 +2172,6 @@ class BaseParser(object):
         p0._cliarg_action = 'splitlines'
         p[0] = p0
 
-    def p_subproc_atom_captured_object(self, p):
-        """subproc_atom : bang_lparen_tok subproc RPAREN"""
-        p1 = p[1]
-        p0 = xonsh_call('__xonsh_subproc_captured_object__', args=p[2],
-                        lineno=p1.lineno, col=p1.lexpos)
-        p0._cliarg_action = 'splitlines'
-        p[0] = p0
-
-    def p_subproc_atom_captured_hiddenobject(self, p):
-        """subproc_atom : bang_lbracket_tok subproc RBRACKET"""
-        p1 = p[1]
-        p0 = xonsh_call('__xonsh_subproc_captured_hiddenobject__', args=p[2],
-                        lineno=p1.lineno, col=p1.lexpos)
-        p0._cliarg_action = 'splitlines'
-        p[0] = p0
-
     def p_subproc_atom_pyenv_lookup(self, p):
         """subproc_atom : dollar_lbrace_tok test RBRACE"""
         p1 = p[1]

--- a/xonsh/proc.py
+++ b/xonsh/proc.py
@@ -539,7 +539,8 @@ _CCTuple = namedtuple("_CCTuple", ["stdin",
                                    "alias",
                                    "stdin_redirect",
                                    "stdout_redirect",
-                                   "stderr_redirect"])
+                                   "stderr_redirect",
+                                   "timestamp"])
 
 class CompletedCommand(_CCTuple):
     """Represents a completed subprocess-mode command."""


### PR DESCRIPTION
This changeset includes a couple of fixes:

* It addresses #738 by removing erroneous cases from the parser.
* It addresses #737 by adding some test cases related to the new syntax (mostly copied and modified from the $() and $[] tests).
* It addresses #740 by adding timestamps to the `CompletedCommand` object.