### PR TITLE
Fix colors for cmd exe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,11 @@ Current Developments
 * Added a new shell type ``'none'``, used to avoid importing ``readline`` or
   ``prompt_toolkit`` when running scripts or running a single command.
 * New: `sudo` functionality on Windows through an alias
-
+* Automatically enhance colors for readability in the default terminal (cmd.exe)
+  on Windows. This functionality can be enabled/disabled with the
+  $INTENSIFY_COLORS_ON_WIN environment variable. 
+  
+  
 **Changed:**
 
 * Running scripts through xonsh (or running a single command with ``-c``) no

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -181,7 +181,6 @@ DEFAULT_VALUES = {
     'PATH': (),
     'PATHEXT': (),
     'PROMPT': DEFAULT_PROMPT,
-    'PROMPT_TOOLKIT_STYLES': None,
     'PUSHD_MINUS': False,
     'PUSHD_SILENT': False,
     'RAISE_SUBPROC_ERROR': False,
@@ -334,10 +333,6 @@ DEFAULT_DOCS = {
         "auto-formatted, see 'Customizing the Prompt' at "
         'http://xon.sh/tutorial.html#customizing-the-prompt.',
         default='xonsh.environ.DEFAULT_PROMPT'),
-    'PROMPT_TOOLKIT_STYLES': VarDocs(
-        'This is a mapping of pygments tokens to user-specified styles for '
-        'prompt-toolkit. This can be used to override modify the color '
-        'in the XONSH_COLOR_STYLE. If None, this is skipped.'),
     'PUSHD_MINUS': VarDocs(
         'Flag for directory pushing functionality. False is the normal '
         'behavior.'),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -181,7 +181,6 @@ DEFAULT_VALUES = {
     'PATH': (),
     'PATHEXT': (),
     'PROMPT': DEFAULT_PROMPT,
-    'PROMPT_TOOLKIT_COLORS': {},
     'PROMPT_TOOLKIT_STYLES': None,
     'PUSHD_MINUS': False,
     'PUSHD_SILENT': False,
@@ -335,17 +334,10 @@ DEFAULT_DOCS = {
         "auto-formatted, see 'Customizing the Prompt' at "
         'http://xon.sh/tutorial.html#customizing-the-prompt.',
         default='xonsh.environ.DEFAULT_PROMPT'),
-    'PROMPT_TOOLKIT_COLORS': VarDocs(
-        'This is a mapping of from color names to HTML color codes. Whenever '
-        'prompt-toolkit would color a word a particular color (in the prompt, '
-        'or in syntax highlighting), it will use the value specified here to '
-        'represent that color, instead of its default.  If a color is not '
-        'specified here, prompt-toolkit uses the colors from '
-        "'xonsh.tools._PT_COLORS'.", configurable=False),
     'PROMPT_TOOLKIT_STYLES': VarDocs(
         'This is a mapping of pygments tokens to user-specified styles for '
-        'prompt-toolkit. See the prompt-toolkit and pygments documentation '
-        'for more details. If None, this is skipped.', configurable=False),
+        'prompt-toolkit. This can be used to override modify the color '
+        'in the XONSH_COLOR_STYLE. If None, this is skipped.'),
     'PUSHD_MINUS': VarDocs(
         'Flag for directory pushing functionality. False is the normal '
         'behavior.'),

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -25,7 +25,8 @@ from xonsh.tools import (
     history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING,
     is_completions_display_value, to_completions_display_value, is_string_set,
     csv_to_set, set_to_csv, get_sep, is_int, is_bool_seq, csv_to_bool_seq,
-    bool_seq_to_csv, DefaultNotGiven, setup_win_unicode_console
+    bool_seq_to_csv, DefaultNotGiven, setup_win_unicode_console,
+    intensify_colors_on_win_setter
 )
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
@@ -69,6 +70,7 @@ DEFAULT_ENSURERS = {
     'FORCE_POSIX_PATHS': (is_bool, to_bool, bool_to_str),
     'HISTCONTROL': (is_string_set, csv_to_set, set_to_csv),
     'IGNOREEOF': (is_bool, to_bool, bool_to_str),
+    'INTENSIFY_COLORS_ON_WIN':(always_false, intensify_colors_on_win_setter, bool_to_str),
     'LC_COLLATE': (always_false, locale_convert('LC_COLLATE'), ensure_string),
     'LC_CTYPE': (always_false, locale_convert('LC_CTYPE'), ensure_string),
     'LC_MESSAGES': (always_false, locale_convert('LC_MESSAGES'), ensure_string),
@@ -169,6 +171,7 @@ DEFAULT_VALUES = {
     'HISTCONTROL': set(),
     'IGNOREEOF': False,
     'INDENT': '    ',
+    'INTENSIFY_COLORS_ON_WIN': True,
     'LC_CTYPE': locale.setlocale(locale.LC_CTYPE),
     'LC_COLLATE': locale.setlocale(locale.LC_COLLATE),
     'LC_TIME': locale.setlocale(locale.LC_TIME),
@@ -307,6 +310,10 @@ DEFAULT_DOCS = {
         "exit status) to not be added to the history list."),
     'IGNOREEOF': VarDocs('Prevents Ctrl-D from exiting the shell.'),
     'INDENT': VarDocs('Indentation string for multiline input'),
+    'INTENSIFY_COLORS_ON_WIN': VarDocs('Enhance style colors for readability '
+        'when using the default terminal (cmd.exe) on winodws. Blue colors, '
+        'which are hard to read, are replaced with cyan. Other colors are '
+        'generally replaced by their bright counter parts.'),
     'LOADED_CONFIG': VarDocs('Whether or not the xonsh config file was loaded',
         configurable=False),
     'LOADED_RC_FILES': VarDocs(

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -334,7 +334,7 @@ def enhance_colors_for_cmd_exe():
     # Test if we are on WINDOWS with CMD.exe 
     # and PROMPT_TOOLKIT_STYLES is unset
     env = builtins.__xonsh_env__
-    if 'ConEmuANSI' not in env and env.get('PROMPT_TOOLKIT_STYLES') is None:
+    if 'CONEMUANSI' not in env and env.get('PROMPT_TOOLKIT_STYLES') is None:
         # Only change the style if $PROMPT_TOOLKIT_STYLES is not touched and
         # and we are not using ConEmu. 
         smap = {Token.Name.Variable:'#44ffff',

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -282,7 +282,7 @@ class XonshStyle(Style):
         style_name : str, optional
             The style name to initialize with.
         """
-        self.trap = builtins.__xonsh_env__.get('PROMPT_TOOLKIT_STYLES') or {}
+        self.trap = {}
         self._style_name = ''
         self.style_name = style_name
         super().__init__()
@@ -325,7 +325,7 @@ class XonshStyle(Style):
         # Ensure we are not using ConEmu
         if 'CONEMUANSI' not in env:
             self.styles.update({Token.AutoSuggestion:'#444444'})
-            if self._style_name == 'default' and env.get('PROMPT_TOOLKIT_STYLES') is None: 
+            if self._style_name == 'default': 
                 s = {Token.Name.Variable:'#44ffff',
                     Token.Generic.Prompt:'#44ffff',
                     Token.Name.Namespace:'#00aaaa',
@@ -337,7 +337,6 @@ class XonshStyle(Style):
                     Token.Name.Constant:'#ff4444',
                     Token.Keyword.Type:'#ff4444',
                     Token.Generic.Error:'#ff4444'}   
-            env['PROMPT_TOOLKIT_STYLES'] = s
             self.styles.update(s)
 
 

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -16,7 +16,8 @@ from pygments.style import Style
 from pygments.styles import get_style_by_name
 import pygments.util
 
-from xonsh.tools import ON_WINDOWS, intensify_colors_for_cmd_exe
+from xonsh.tools import (ON_WINDOWS, intensify_colors_for_cmd_exe,
+                         expand_gray_colors_for_cmd_exe)
 
 class XonshSubprocLexer(BashLexer):
     """Lexer for xonsh subproc mode."""
@@ -282,7 +283,7 @@ class XonshStyle(Style):
         style_name : str, optional
             The style name to initialize with.
         """
-        self.trap = {} # for traping custom colors set by user
+        self.trap = {}  # for traping custom colors set by user
         self._smap = {}
         self._style_name = ''
         self.style_name = style_name
@@ -311,7 +312,6 @@ class XonshStyle(Style):
         self._style_name = value
         if ON_WINDOWS:
             self.enhance_colors_for_cmd_exe()
-            
 
     @style_name.deleter
     def style_name(self):
@@ -321,7 +321,7 @@ class XonshStyle(Style):
         """ Enhance colors when using cmd.exe on windows.
             When using the default style all blue and dark red colors
             are changed to CYAN and intence red.
-        """          
+        """
         env = builtins.__xonsh_env__
         # Ensure we are not using ConEmu
         if 'CONEMUANSI' not in env:
@@ -329,8 +329,9 @@ class XonshStyle(Style):
             # from the default color
             self.styles[Token.AutoSuggestion] = '#444444'
             if env.get('INTENSIFY_COLORS_ON_WIN', False):
-                s = intensify_colors_for_cmd_exe(self._smap)
-                self._smap.update(s)
+                self._smap.update(expand_gray_colors_for_cmd_exe(self._smap))
+                self._smap.update(intensify_colors_for_cmd_exe(self._smap))
+
 
 def xonsh_style_proxy(styler):
     """Factory for a proxy class to a xonsh style."""
@@ -345,8 +346,7 @@ def xonsh_style_proxy(styler):
 
     return XonshStyleProxy
 
-    
-    
+
 PTK_STYLE = {
     Token.Menu.Completions.Completion.Current: 'bg:#00aaaa #000000',
     Token.Menu.Completions.Completion: 'bg:#008888 #ffffff',

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -747,11 +747,13 @@ def intensify_colors_for_cmd_exe(style_map, replace_colors = None):
     if not ON_WINDOWS or prompt_toolkit is None:
         return modified_style
     if replace_colors is None:
-        replace_colors = {1: '#44ffff', #subst dark blue with bright cyan
-                          2: '#44ff44', #subst dark green with bright green
-                          4: '#ff4444', #subst dark red with bright
-                          5: '#ff44ff', #subst dark magenta with bright
-                          6: '#ffff44', #subst dark yellow with bright
+        replace_colors = {1: '#44ffff', #subst blue with bright cyan
+                          2: '#44ff44', #subst green with bright green
+                          4: '#ff4444', #subst red with bright red
+                          5: '#ff44ff', #subst magenta with bright magenta
+                          6: '#ffff44', #subst yellow with bright yellow
+                          9: '#00aaaa', #subst intense blue (hard to read) 
+                                        #with dark cyan (which is readable) 
                           }
     table = prompt_toolkit.terminal.win32_output.ColorLookupTable()
     style = prompt_toolkit.styles.style_from_dict(style_map)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -55,12 +55,6 @@ try:
 except ImportError:
     win_unicode_console = None
 
-try:
-    import prompt_toolkit
-except ImportError:
-    prompt_toolkit = None
-
-    
 
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
@@ -739,39 +733,79 @@ def color_style():
     return builtins.__xonsh_shell__.shell.color_style()
 
 
-def intensify_colors_for_cmd_exe(style_map, replace_colors = None):
-    """Returns a modified style to where colors that maps to dark 
-       colors are replaced with brighter versions.  
+try:
+    import prompt_toolkit
+except ImportError:
+    prompt_toolkit = None
+
+
+def _get_color_indexes(style_map):
+    """ Generates the color and windows color index for a style """
+    table = prompt_toolkit.terminal.win32_output.ColorLookupTable()
+    pt_style = prompt_toolkit.styles.style_from_dict(style_map)
+    for token in style_map:
+        attr = pt_style.token_to_attrs[token]
+        if attr.color is not None:
+            index = table.lookup_color(attr.color, attr.bgcolor)
+            try:
+                rgb = (int(attr.color[0:2], 16),
+                       int(attr.color[2:4], 16),
+                       int(attr.color[4:6], 16))
+            except:
+                rgb = None
+            yield token, index, rgb
+
+
+def intensify_colors_for_cmd_exe(style_map, replace_colors=None):
+    """Returns a modified style to where colors that maps to dark
+       colors are replaced with brighter versions. Also expands the
+       range used by the gray colors
     """
     modified_style = {}
     if not ON_WINDOWS or prompt_toolkit is None:
         return modified_style
     if replace_colors is None:
-        replace_colors = {1: '#44ffff', #subst blue with bright cyan
-                          2: '#44ff44', #subst green with bright green
-                          4: '#ff4444', #subst red with bright red
-                          5: '#ff44ff', #subst magenta with bright magenta
-                          6: '#ffff44', #subst yellow with bright yellow
-                          9: '#00aaaa', #subst intense blue (hard to read) 
-                                        #with dark cyan (which is readable) 
+        replace_colors = {1: '#44ffff',  # subst blue with bright cyan
+                          2: '#44ff44',  # subst green with bright green
+                          4: '#ff4444',  # subst red with bright red
+                          5: '#ff44ff',  # subst magenta with bright magenta
+                          6: '#ffff44',  # subst yellow with bright yellow
+                          9: '#00aaaa',  # subst intense blue (hard to read)
+                                         # with dark cyan (which is readable)
                           }
-    table = prompt_toolkit.terminal.win32_output.ColorLookupTable()
-    style = prompt_toolkit.styles.style_from_dict(style_map)
-    for token, attr in style.token_to_attrs.items():
-        if attr.color is not None:
-            index = table.lookup_color(attr.color, 'black')
-            if index in replace_colors:
-                modified_style[token] = replace_colors[index]
+    for token, idx, _ in _get_color_indexes(style_map):
+        if idx in replace_colors:
+            modified_style[token] = replace_colors[idx]
     return modified_style
-    
+
+
+def expand_gray_colors_for_cmd_exe(style_map):
+    """ Expand the style's gray scale color range.
+        All gray scale colors has a tendency to map to the same default GRAY
+        in cmd.exe.
+    """
+    modified_style = {}
+    if not ON_WINDOWS or prompt_toolkit is None:
+        return modified_style
+    for token, idx, rgb in _get_color_indexes(style_map):
+        if idx == 7 and rgb:
+            if sum(rgb) <= 306:
+                # Equal and below '#666666 is reset to dark gray
+                modified_style[token] = '#444444'
+            elif sum(rgb) >= 408:
+                # Equal and above 0x888888 is reset to white
+                modified_style[token] = '#ffffff'
+    return modified_style
+
+
 def intensify_colors_on_win_setter(enable):
-    """ Resets the style when setting the INTENSIFY_COLORS_ON_WIN 
+    """ Resets the style when setting the INTENSIFY_COLORS_ON_WIN
         environment variable. """
     enable = to_bool(enable)
     delattr(builtins.__xonsh_shell__.shell.styler, 'style_name')
     return enable
-    
-    
+
+
 _RE_STRING_START = "[bBrRuU]*"
 _RE_STRING_TRIPLE_DOUBLE = '"""'
 _RE_STRING_TRIPLE_SINGLE = "'''"

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -324,6 +324,8 @@ def _tok_colors(cmap, cols):
 
 def _colors(ns):
     cols, _ = shutil.get_terminal_size()
+    if tools.ON_WINDOWS:
+        cols -= 1
     cmap = tools.color_style()
     akey = next(iter(cmap))
     if isinstance(akey, str):


### PR DESCRIPTION
This improves the usefullnes of xonsh in cmd.exe.

It eliminates some of the dark blue and dark red colors when using cmd.exe and the default style. 

I reused one of the old environment variables from the previous colors system ( $PROMPT_TOOLKIT_STYLES)  So it now does the same as it did before. We should consider changing the name though, to something more saying. Any good ideas?

