### PR TITLE
Ensure line endings in git checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+tests/histories/*.json text eol=lf


### PR DESCRIPTION
I finally figured why some history tests were failing only for me. https://github.com/scopatz/xonsh/issues/758

My git is configured to automatically handle windows line-endings. `git config --global core.autocrlf true` which is the recomended default on windows. All text files are checkout with `crlf`and commited with only `lf`

Checking out with `crlf` screwed up the semi-binary json files in the history tests. Basically, the indexes were off because of the extra characters in the file. 

This PR adds a `.gitattributes` file to ensure that test/histories/*.json files are checked out with `lf` line-endings even on windows.