### PR TITLE
quick fix for empty xonshrc files

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1208,6 +1208,8 @@ def xonshrc_context(rcfiles=None, execer=None):
                 continue
             finally:
                 execer.filename = fname
+        if ccode is None:
+            return env
         exec(ccode, env, None)
     return env
 


### PR DESCRIPTION
If a user has an empty `xonshrc` file lying around, the `exec(ccode, env, None)` prevents `xonsh` from starting