### PR TITLE
remove (actually) unused imports

### DIFF
--- a/xonsh/diff_history.py
+++ b/xonsh/diff_history.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 from difflib import SequenceMatcher
 
 from xonsh import lazyjson
-from xonsh.tools import print_color, format_color
+from xonsh.tools import print_color
 
 NO_COLOR = '{NO_COLOR}'
 RED = '{RED}'

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh executer."""
-import re
-import os
 import types
 import inspect
 import builtins
-from collections import Iterable, Sequence, Mapping
+from collections import Iterable, Mapping
 
 from xonsh import ast
 from xonsh.parser import Parser

--- a/xonsh/jupyter_kernel.py
+++ b/xonsh/jupyter_kernel.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Hooks for Jupyter Xonsh Kernel."""
-import io
-import sys
 import builtins
 from pprint import pformat
 from tempfile import SpooledTemporaryFile

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Implements the base xonsh parser."""
-import os
-import sys
 from collections import Iterable, Sequence, Mapping
 
 from ply import yacc

--- a/xonsh/parsers/v34.py
+++ b/xonsh/parsers/v34.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh parser for Python v3.4."""
-import os
-import sys
-from collections import Iterable, Sequence, Mapping
+from collections import Iterable, Sequence
 
 from xonsh import ast
-from xonsh.lexer import LexToken
-from xonsh.parsers.base import BaseParser, xonsh_help, xonsh_superhelp
+from xonsh.parsers.base import BaseParser, xonsh_superhelp
 
 
 class Parser(BaseParser):

--- a/xonsh/parsers/v35.py
+++ b/xonsh/parsers/v35.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 """Implements the xonsh parser for Python v3.5."""
-import os
-import sys
-from collections import Iterable, Sequence, Mapping
+from collections import Iterable, Sequence
 
 from xonsh import ast
-from xonsh.lexer import LexToken
-from xonsh.parsers.base import BaseParser, xonsh_help, xonsh_superhelp
+from xonsh.parsers.base import BaseParser, xonsh_superhelp
 
 
 class Parser(BaseParser):

--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 """History object for use with prompt_toolkit."""
-import os
 import time
 import builtins
 from threading import Thread
 
 import prompt_toolkit.history
-from prompt_toolkit.buffer import Buffer
-
 from xonsh import lazyjson
 
 

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """The prompt_toolkit based xonsh shell."""
 import builtins
-from warnings import warn
 
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
@@ -15,7 +14,7 @@ from pygments.token import (Keyword, Name, Comment, String, Error, Number,
                             Operator, Generic, Whitespace, Token)
 
 from xonsh.base_shell import BaseShell
-from xonsh.tools import print_exception, format_color
+from xonsh.tools import print_exception
 from xonsh.environ import partial_format_prompt
 from xonsh.pyghooks import XonshLexer, XonshStyle, partial_color_tokenize, \
     xonsh_style_proxy

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 """The readline based xonsh shell."""
 import os
-import sys
 import time
 import select
 import builtins
 from cmd import Cmd
-from warnings import warn
-from threading import Thread, Lock
+from threading import Thread
 from collections import deque
 
 from xonsh import lazyjson

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -6,7 +6,7 @@ import json
 import builtins
 import textwrap
 from pprint import pformat
-from collections.abc import MutableSequence, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from xonsh.tools import to_bool, to_bool_or_break, backup_file, print_color
 

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -1,5 +1,4 @@
 """The xonsh configuration (xonfig) utility."""
-import os
 import ast
 import json
 import shutil


### PR DESCRIPTION
I should never have clicked on the Landscape icon...

But there are a bunch of unused imports lying around (and also a bunch that pylint misidentifies as unused) and it's good to keep the house in order.  