### PR TITLE
add ellipsis lookup to xonsh environ

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Current Developments
 * Automatically enhance colors for readability in the default terminal (cmd.exe)
   on Windows. This functionality can be enabled/disabled with the
   $INTENSIFY_COLORS_ON_WIN environment variable. 
+* Added ``Ellipsis`` lookup to ``__xonsh_env__`` to allow environment variable checks, e.g. ``'HOME' in ${...}``
   
   
 **Changed:**

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -197,6 +197,14 @@ examples in action:
 
 Not bad, xonsh, not bad.
 
+If you want to check if an environment variable is present in your current
+session (say, in your awesome new ``xonsh`` script) you can pass an Ellipsis to
+the ``${}`` operator:
+
+.. code-block:: xonshcon
+
+   >>> 'HOME' in ${...}
+   True
 
 Running Commands
 ==============================

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -585,6 +585,9 @@ class Env(MutableMapping):
     #
 
     def __getitem__(self, key):
+        if key is Ellipsis:
+            val = builtins.__xonsh_env__
+            return val
         m = self._arg_regex.match(key)
         if (m is not None) and (key not in self._d) and ('ARGS' in self._d):
             args = self._d['ARGS']

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -587,7 +587,7 @@ class Env(MutableMapping):
     def __getitem__(self, key):
         if key is Ellipsis:
             val = builtins.__xonsh_env__
-            return val
+            return self
         m = self._arg_regex.match(key)
         if (m is not None) and (key not in self._d) and ('ARGS' in self._d):
             args = self._d['ARGS']

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -586,7 +586,6 @@ class Env(MutableMapping):
 
     def __getitem__(self, key):
         if key is Ellipsis:
-            val = builtins.__xonsh_env__
             return self
         m = self._arg_regex.match(key)
         if (m is not None) and (key not in self._d) and ('ARGS' in self._d):


### PR DESCRIPTION
Supports usage of `'HOME' in ${...}`-style lookups as suggested by @melund