### PR TITLE
Add option to update os.environ when __xonsh_env__ changes.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Current Developments
   on Windows. This functionality can be enabled/disabled with the
   $INTENSIFY_COLORS_ON_WIN environment variable. 
 * Added ``Ellipsis`` lookup to ``__xonsh_env__`` to allow environment variable checks, e.g. ``'HOME' in ${...}``
+* Added an option to update ``os.environ`` every time the xonsh environment changes.  
+  This disabled by default, but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to 
+  True.
   
   
 **Changed:**

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -195,7 +195,7 @@ DEFAULT_VALUES = {
     'SUGGEST_THRESHOLD': 3,
     'TEEPTY_PIPE_DELAY': 0.01,
     'TITLE': DEFAULT_TITLE,
-    'UPDATE_OS_ENVIRON': True,
+    'UPDATE_OS_ENVIRON': False,
     'VI_MODE': False,
     'WIN_UNICODE_CONSOLE': True,
     'XDG_CONFIG_HOME': os.path.expanduser(os.path.join('~', '.config')),
@@ -531,10 +531,19 @@ class Env(MutableMapping):
             os.environ.clear()
             os.environ.update(self.detype())
         else:
-            if key in self:
-                os.environ[key] = self.detype()[key]
-            else:
+            if key not in self._d:
+                if not isinstance(key, string_types):
+                    key = str(key)
                 os.environ.pop(key,None)
+            else:
+                val = self._d[key]
+                if callable(val) or isinstance(val, MutableMapping):
+                    return
+                if not isinstance(key, string_types):
+                    key = str(key)
+                ensurer = self.get_ensurer(key)
+                val = ensurer.detype(val)        
+                os.environ[key] = val
         
     def replace_env(self):
         """Replaces the contents of os.environ with a detyped version

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -521,14 +521,20 @@ class Env(MutableMapping):
         self._detyped = ctx
         return ctx
 
-    def update_env(self):
+    def update_env(self, key=None):
         """Updates the os.environ mapping with the 
         a detyped version of the xonsh environment.
         """
         if self._orig_env is None: 
             self.replace_env()
-        else:
+        elif key is None: 
+            os.environ.clear()
             os.environ.update(self.detype())
+        else:
+            if key in self:
+                os.environ[key] = self.detype()[key]
+            else:
+                os.environ.pop(key,None)
         
     def replace_env(self):
         """Replaces the contents of os.environ with a detyped version
@@ -640,13 +646,13 @@ class Env(MutableMapping):
         self._d[key] = val
         self._detyped = None
         if self.get('UPDATE_OS_ENVIRON'):
-            self.update_env()
+            self.update_env(key)
 
     def __delitem__(self, key):
         del self._d[key]
         self._detyped = None
         if self.get('UPDATE_OS_ENVIRON'):
-            self.update_env()
+            self.update_env(key)
 
     def get(self, key, default=None):
         """The environment will look up default values from its own defaults if a


### PR DESCRIPTION
This adds a new option `$UPDATE_OS_ENVIRON`. If set, it will update the os.environ mapping whenever the __xonsh_env__ mapping changes.

This could be useful if you are running scripts that use subprocess calls, and you don't have the option of modifying the code to parse in the `__xonsh_env__` 
