### PR TITLE
Add line wrapping to PTK multiline using arrows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Current Developments
   loading bash completions.
 * rc files are now compiled and cached, to avoid re-parsing when they haven't
   changed.
+* Left and Right arrows in the ``prompt_toolkit`` shell now wrap in multiline
+  environments
 
 **Deprecated:** None
 


### PR DESCRIPTION
In a multiline statement, the left- and right-arrow keys will now wrap
to the previous or next line, respectively.  If you are at the beginning
of the document, the left-arrow key does nothing.  Same for the
right-arrow at the end of the document.