### PR TITLE
fix ptk completer to allow completion earlier in line

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Current Developments
 **Fixed:**
 
 * Fixed bug with loading prompt-toolkit shell < v0.57.
+* Fixed bug with prompt-toolkit completion when the cursor is not at the end of the line
 
 **Security:** None
 

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -25,7 +25,7 @@ class PromptToolkitCompleter(Completer):
         if complete_event.completion_requested:
             line = document.current_line.lstrip()
             endidx = document.cursor_position_col
-            begidx = line.rfind(' ') + 1 if line.rfind(' ') >= 0 else 0
+            begidx = line[:endidx].rfind(' ') + 1 if line[:endidx].rfind(' ') >= 0 else 0
             prefix = line[begidx:endidx]
             completions, l = self.completer.complete(prefix,
                                                      line,


### PR DESCRIPTION
As reported by @asmeurer, the completer had incorrect index values for
completion when the cursor was located before a space, that is

`~/Do<C>emacsclient -nw`

would not offer file path completions (where the cursor is marked by
`<C>`). This was because of (my) naive searching for indices, now
slightly less naive.