### PR TITLE
Fix regexpath

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Current Developments
 * Changed the way regular rxpression filename globbing with backticks behave.
   It previously returned the regex expression when no match was found. Now it 
   returns and empty list.
+* Regexpath matching with backticks, now returns an empty list in python mode.
 
 
 
@@ -39,6 +40,7 @@ Current Developments
 **Removed:** None
 
 **Fixed:**
+
 
 * Fixed bug with loading prompt-toolkit shell < v0.57.
 * Fixed bug with prompt-toolkit completion when the cursor is not at the end of the line

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,13 +11,13 @@ Current Developments
 * New: `sudo` functionality on Windows through an alias
 * Automatically enhance colors for readability in the default terminal (cmd.exe)
   on Windows. This functionality can be enabled/disabled with the
-  $INTENSIFY_COLORS_ON_WIN environment variable. 
+  $INTENSIFY_COLORS_ON_WIN environment variable.
 * Added ``Ellipsis`` lookup to ``__xonsh_env__`` to allow environment variable checks, e.g. ``'HOME' in ${...}``
-* Added an option to update ``os.environ`` every time the xonsh environment changes.  
-  This disabled by default, but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to 
+* Added an option to update ``os.environ`` every time the xonsh environment changes.
+  This disabled by default, but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to
   True.
-  
-  
+
+
 **Changed:**
 
 * Running scripts through xonsh (or running a single command with ``-c``) no
@@ -28,9 +28,6 @@ Current Developments
   changed.
 * Left and Right arrows in the ``prompt_toolkit`` shell now wrap in multiline
   environments
-* Changed the way regular rxpression filename globbing with backticks behave.
-  It previously returned the regex expression when no match was found. Now it 
-  returns and empty list.
 * Regexpath matching with backticks, now returns an empty list in python mode.
 
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,11 @@ Current Developments
   changed.
 * Left and Right arrows in the ``prompt_toolkit`` shell now wrap in multiline
   environments
+* Changed the way regular rxpression filename globbing with backticks behave.
+  It previously returned the regex expression when no match was found. Now it 
+  returns and empty list.
+
+
 
 **Deprecated:** None
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -272,7 +272,7 @@ def regexpath(s):
     """
     s = expand_path(s)
     o = reglob(s)
-    return o if len(o) != 0 else [s]
+    return o if len(o) != 0 else []
 
 
 def globpath(s, ignore_case=False):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -266,7 +266,7 @@ def reglob(path, parts=None, i=None):
     return paths
 
 
-def regexpath(s, pymode=True):
+def regexpath(s, pymode=False):
     """Takes a regular expression string and returns a list of file
     paths that match the regex.
     """

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -266,13 +266,14 @@ def reglob(path, parts=None, i=None):
     return paths
 
 
-def regexpath(s):
+def regexpath(s, pymode=True):
     """Takes a regular expression string and returns a list of file
     paths that match the regex.
     """
     s = expand_path(s)
     o = reglob(s)
-    return o if len(o) != 0 else []
+    no_match = [] if pymode else o
+    return no_match if len(o) != 0 else [s]
 
 
 def globpath(s, ignore_case=False):

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -272,8 +272,8 @@ def regexpath(s, pymode=False):
     """
     s = expand_path(s)
     o = reglob(s)
-    no_match = [] if pymode else o
-    return no_match if len(o) != 0 else [s]
+    no_match = [] if pymode else [s]
+    return o if len(o) != 0 else no_match
 
 
 def globpath(s, ignore_case=False):

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -126,10 +126,10 @@ def xonsh_superhelp(x, lineno=None, col=None):
     return xonsh_call('__xonsh_superhelp__', [x], lineno=lineno, col=col)
 
 
-def xonsh_regexpath(x, lineno=None, col=None):
+def xonsh_regexpath(x, pymode, lineno=None, col=None):
     """Creates the AST node for calling the __xonsh_regexpath__() function."""
-    return xonsh_call('__xonsh_regexpath__', [x], lineno=lineno, col=col)
-
+    return xonsh_call('__xonsh_regexpath__', [x, pymode], lineno=lineno,
+                      col=col)
 
 def load_ctx(x):
     """Recursively sets ctx to ast.Load()"""
@@ -1720,7 +1720,9 @@ class BaseParser(object):
         """atom : REGEXPATH"""
         p1 = ast.Str(s=p[1].strip('`'), lineno=self.lineno,
                      col_offset=self.col)
-        p[0] = xonsh_regexpath(p1, lineno=self.lineno, col=self.col)
+        pymode = True
+        p[0] = xonsh_regexpath(p1, pymode, lineno=self.lineno,
+                               col=self.col)
 
     def p_atom_dname(self, p):
         """atom : DOLLAR_NAME"""
@@ -2214,7 +2216,9 @@ class BaseParser(object):
         """subproc_atom : REGEXPATH"""
         p1 = ast.Str(s=p[1].strip('`'), lineno=self.lineno,
                      col_offset=self.col)
-        p0 = xonsh_regexpath(p1, lineno=self.lineno, col=self.col)
+        pymode = False
+        p0 = xonsh_regexpath(p1, pymode, lineno=self.lineno,
+                             col=self.col)
         p0._cliarg_action = 'extend'
         p[0] = p0
 

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -126,10 +126,11 @@ def xonsh_superhelp(x, lineno=None, col=None):
     return xonsh_call('__xonsh_superhelp__', [x], lineno=lineno, col=col)
 
 
-def xonsh_regexpath(x, pymode, lineno=None, col=None):
+def xonsh_regexpath(x, pymode=False, lineno=None, col=None):
     """Creates the AST node for calling the __xonsh_regexpath__() function."""
-    return xonsh_call('__xonsh_regexpath__', [x, pymode], lineno=lineno,
+    return xonsh_call('__xonsh_regexpath__', args=[x, pymode], lineno=lineno,
                       col=col)
+
 
 def load_ctx(x):
     """Recursively sets ctx to ast.Load()"""
@@ -1720,8 +1721,7 @@ class BaseParser(object):
         """atom : REGEXPATH"""
         p1 = ast.Str(s=p[1].strip('`'), lineno=self.lineno,
                      col_offset=self.col)
-        pymode = True
-        p[0] = xonsh_regexpath(p1, pymode, lineno=self.lineno,
+        p[0] = xonsh_regexpath(p1, pymode=True, lineno=self.lineno,
                                col=self.col)
 
     def p_atom_dname(self, p):
@@ -2216,8 +2216,7 @@ class BaseParser(object):
         """subproc_atom : REGEXPATH"""
         p1 = ast.Str(s=p[1].strip('`'), lineno=self.lineno,
                      col_offset=self.col)
-        pymode = False
-        p0 = xonsh_regexpath(p1, pymode, lineno=self.lineno,
+        p0 = xonsh_regexpath(p1, pymode=False, lineno=self.lineno,
                              col=self.col)
         p0._cliarg_action = 'extend'
         p[0] = p0

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -127,7 +127,9 @@ def xonsh_superhelp(x, lineno=None, col=None):
 
 
 def xonsh_regexpath(x, pymode=False, lineno=None, col=None):
-    """Creates the AST node for calling the __xonsh_regexpath__() function."""
+    """Creates the AST node for calling the __xonsh_regexpath__() function.
+    The pymode argument indicate if it is called from subproc or python mode"""
+    pymode = ast.NameConstant(value=pymode, lineno=lineno, col_offset=col)
     return xonsh_call('__xonsh_regexpath__', args=[x, pymode], lineno=lineno,
                       col=col)
 


### PR DESCRIPTION
Return an empty list instead of the regex expression when regexpath doesn't find any matches