### PR TITLE
Sourcing Windows batch files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,13 @@ Current Developments
   $INTENSIFY_COLORS_ON_WIN environment variable.
 * Added ``Ellipsis`` lookup to ``__xonsh_env__`` to allow environment variable checks, e.g. ``'HOME' in ${...}``
 * Added an option to update ``os.environ`` every time the xonsh environment changes.
-  This disabled by default, but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to
+  This is disabled by default but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to
   True.
+* Added Windows 'cmd.exe' as a foreign shell. This gives xonsh the ability to source 
+  Windows Batch files (.bat and .cmd). Calling ``source-cmd script.bat`` will call 
+  the bat file and changes to the environment variables will be reflected in xonsh.
+* Added an alias for the conda environment activate/deactivate batch scripts when 
+  running the Anaconda python distribution on Windows.
 
 
 **Changed:**

--- a/tests/batch.bat
+++ b/tests/batch.bat
@@ -1,0 +1,3 @@
+echo on
+set ENV_TO_BE_ADDED=Hallo world
+set ENV_TO_BE_REMOVED=

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -252,6 +252,8 @@ def source_cmd(args, stdin=None):
     args = list(args)
     fpath = locate_binary(args[0])
     args[0] = fpath if fpath else args[0]
+    if not os.path.isfile(args[0]):
+        raise FileNotFoundError(args[0])
     args.insert(0, 'cmd')
     args.append('--interactive=0')
     args.append('--sourcer=call')

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -285,7 +285,6 @@ if ON_WINDOWS:
         DEFAULT_ALIASES[alias] = ['cmd', '/c', alias]
 
     DEFAULT_ALIASES['which'] = ['where']
-    DEFAULT_ALIASES['source-cmd'] = source_cmd
 
     if not locate_binary('sudo'):
         import xonsh.winutils as winutils

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -254,6 +254,8 @@ def source_cmd(args, stdin=None):
     args[0] = fpath if fpath else args[0]
     if not os.path.isfile(args[0]):
         raise FileNotFoundError(args[0])
+    prevcmd = 'call "{}"\necho off'.format(args[0])
+    args.append('--prevcmd={}'.format(prevcmd))
     args.insert(0, 'cmd')
     args.append('--interactive=0')
     args.append('--sourcer=call')

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -3,6 +3,7 @@
 
 import builtins
 import os
+import sys
 from argparse import ArgumentParser
 
 from xonsh.dirstack import cd, pushd, popd, dirs, _get_cwd
@@ -263,8 +264,20 @@ if ON_WINDOWS:
         'rmdir',
         'time',
         'type',
-        'vol'
+        'vol',
     }
+
+    if 'Anaconda' in sys.version:
+        def _source_cmd_keep_prompt(args,stdin=None, ):
+            p = builtins.__xonsh_env__.get('PROMPT')
+            source_cmd(args,stdin=stdin)
+            builtins.__xonsh_env__['PROMPT'] = p
+
+        DEFAULT_ALIASES['_source_cmd_keep_prompt'] = _source_cmd_keep_prompt
+
+        DEFAULT_ALIASES['activate'] = ['_source_cmd_keep_prompt', 'activate.bat']
+        DEFAULT_ALIASES['deactivate'] = ['_source_cmd_keep_prompt', 'deactivate.bat']
+
 
     for alias in WINDOWS_CMD_ALIASES:
         DEFAULT_ALIASES[alias] = ['cmd', '/c', alias]

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -20,6 +20,7 @@ from xonsh.vox import Vox
 
 DEFAULT_ALIASES = {}
 
+
 def exit(args, stdin=None):  # pylint:disable=redefined-builtin,W0622
     """Sends signal to exit shell."""
     builtins.__xonsh_exit__ = True
@@ -29,6 +30,7 @@ def exit(args, stdin=None):  # pylint:disable=redefined-builtin,W0622
 
 
 _SOURCE_FOREIGN_PARSER = None
+
 
 def _ensure_source_foreign_parser():
     global _SOURCE_FOREIGN_PARSER
@@ -66,8 +68,8 @@ def _ensure_source_foreign_parser():
                         help='code to find locations of all native functions '
                              'in the shell language.')
     parser.add_argument('--sourcer', default=None, dest='sourcer',
-                        help='the source command in the target shell language, '
-                             'default: source.')
+                        help='the source command in the target shell '
+                        'language, default: source.')
     parser.add_argument('--use-tmpfile', type=to_bool, default=False,
                         help='whether the commands for source shell should be '
                              'written to a temporary file.',
@@ -84,16 +86,20 @@ def source_foreign(args, stdin=None):
         pass  # don't change prevcmd if given explicitly
     elif os.path.isfile(ns.files_or_code[0]):
         # we have filename to source
-        ns.prevcmd = '{0} "{1}"'.format(ns.sourcer, '" "'.join(ns.files_or_code))
+        ns.prevcmd = '{} "{}"'.format(ns.sourcer, '" "'.join(ns.files_or_code))
     elif ns.prevcmd is None:
         ns.prevcmd = ' '.join(ns.files_or_code)  # code to run, no files
     foreign_shell_data.cache_clear()  # make sure that we don't get prev src
     fsenv, fsaliases = foreign_shell_data(shell=ns.shell, login=ns.login,
-                            interactive=ns.interactive, envcmd=ns.envcmd,
-                            aliascmd=ns.aliascmd, extra_args=ns.extra_args,
-                            safe=ns.safe, prevcmd=ns.prevcmd,
-                            postcmd=ns.postcmd, funcscmd=ns.funcscmd,
-                            sourcer=ns.sourcer, use_tmpfile=ns.use_tmpfile)
+                                          interactive=ns.interactive,
+                                          envcmd=ns.envcmd,
+                                          aliascmd=ns.aliascmd,
+                                          extra_args=ns.extra_args,
+                                          safe=ns.safe, prevcmd=ns.prevcmd,
+                                          postcmd=ns.postcmd,
+                                          funcscmd=ns.funcscmd,
+                                          sourcer=ns.sourcer,
+                                          use_tmpfile=ns.use_tmpfile)
     # apply results
     env = builtins.__xonsh_env__
     denv = env.detype()
@@ -116,7 +122,8 @@ def source_foreign(args, stdin=None):
 
 def source_alias(args, stdin=None):
     """Executes the contents of the provided files in the current context.
-    If sourced file isn't found in cwd, search for file along $PATH to source instead"""
+    If sourced file isn't found in cwd, search for file along $PATH to source
+    instead"""
     for fname in args:
         if not os.path.isfile(fname):
             fname = locate_binary(fname)
@@ -209,6 +216,7 @@ def vox(args, stdin=None):
     vox = Vox()
     return vox(args, stdin=stdin)
 
+
 @foreground
 def mpl(args, stdin=None):
     """Hooks to matplotlib"""
@@ -273,13 +281,11 @@ if ON_WINDOWS:
                                        'activate.bat']
         DEFAULT_ALIASES['deactivate'] = ['_source-cmd-preserve-prompt',
                                          'deactivate.bat']
-
-
     for alias in WINDOWS_CMD_ALIASES:
         DEFAULT_ALIASES[alias] = ['cmd', '/c', alias]
 
     DEFAULT_ALIASES['which'] = ['where']
-    DEFAULT_ALIASES ['source-cmd'] = source_cmd
+    DEFAULT_ALIASES['source-cmd'] = source_cmd
 
     if not locate_binary('sudo'):
         import xonsh.winutils as winutils

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -281,9 +281,11 @@ if ON_WINDOWS:
                                        'activate.bat']
         DEFAULT_ALIASES['deactivate'] = ['_source-cmd-preserve-prompt',
                                          'deactivate.bat']
+
     for alias in WINDOWS_CMD_ALIASES:
         DEFAULT_ALIASES[alias] = ['cmd', '/c', alias]
 
+    DEFAULT_ALIASES['call'] = ['source-cmd']
     DEFAULT_ALIASES['which'] = ['where']
 
     if not locate_binary('sudo'):

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -279,7 +279,7 @@ if ON_WINDOWS:
         DEFAULT_ALIASES[alias] = ['cmd', '/c', alias]
 
     DEFAULT_ALIASES['which'] = ['where']
-    DEFAULT_ALIASES ['source_cmd'] = source_cmd
+    DEFAULT_ALIASES ['source-cmd'] = source_cmd
 
     if not locate_binary('sudo'):
         import xonsh.winutils as winutils

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1014,6 +1014,7 @@ def env_name(pre_chars='(', post_chars=') '):
     env_name = os.path.basename(env_path)
     return pre_chars + env_name + post_chars if env_name else ''
 
+
 if ON_WINDOWS:
     USER = 'USERNAME'
 else:
@@ -1034,8 +1035,6 @@ FORMATTER_DICT = dict(
     current_job=_current_job,
     env_name=env_name,
     )
-
-
 
 DEFAULT_VALUES['FORMATTER_DICT'] = dict(FORMATTER_DICT)
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -505,11 +505,11 @@ class Env(MutableMapping):
         for key, val in dict(*args, **kwargs).items():
             self[key] = val
         self._detyped = None
-    
+
     @staticmethod
     def detypeable(val):
         return not (callable(val) or isinstance(val, MutableMapping))
-        
+
     def detype(self):
         if self._detyped is not None:
             return self._detyped
@@ -641,7 +641,7 @@ class Env(MutableMapping):
                 else:
                     dval = ensurer.detype(val)
                     os.environ[key] = dval
-            
+
     def __delitem__(self, key):
         val = self._d.pop(key)
         if self.detypeable(val):
@@ -649,7 +649,7 @@ class Env(MutableMapping):
             if self.get('UPDATE_OS_ENVIRON'):
                 if key in os.environ:
                     del os.environ[key]
-        
+
     def get(self, key, default=None):
         """The environment will look up default values from its own defaults if a
         default is not given here.
@@ -1004,13 +1004,15 @@ def _current_job():
 
 
 def env_name(pre_chars='(', post_chars=') '):
-    """Extract the current environment name from $VIRTUAL_ENV."""
-    env_path = __xonsh_env__.get('VIRTUAL_ENV', '')
-
+    """Extract the current environment name from $VIRTUAL_ENV or
+    $CONDA_DEFAULT_ENV if that is set
+    """
+    env_path = builtins.__xonsh_env__.get('VIRTUAL_ENV', '')
+    if len(env_path) == 0 and 'Anaconda' in sys.version:
+        pre_chars, post_chars = '[', '] '
+        env_path = builtins.__xonsh_env__.get('CONDA_DEFAULT_ENV', '')
     env_name = os.path.basename(env_path)
-
     return pre_chars + env_name + post_chars if env_name else ''
-
 
 if ON_WINDOWS:
     USER = 'USERNAME'
@@ -1032,6 +1034,9 @@ FORMATTER_DICT = dict(
     current_job=_current_job,
     env_name=env_name,
     )
+
+
+
 DEFAULT_VALUES['FORMATTER_DICT'] = dict(FORMATTER_DICT)
 
 _FORMATTER = string.Formatter()

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -135,7 +135,7 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
                        aliascmd=None, extra_args=(), currenv=None,
                        safe=True, prevcmd='', postcmd='', funcscmd=None,
                        sourcer=None, use_tmpfile=False, tmpfile_ext=None,
-                       runcmd= None):
+                       runcmd=None):
     """Extracts data from a foreign (non-xonsh) shells. Currently this gets
     the environment, aliases, and functions but may be extended in the future.
 
@@ -238,6 +238,7 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
 
 ENV_RE = re.compile('__XONSH_ENV_BEG__\n(.*)__XONSH_ENV_END__', flags=re.DOTALL)
 
+
 def parse_env(s):
     """Parses the environment portion of string into a dict."""
     m = ENV_RE.search(s)
@@ -252,13 +253,14 @@ def parse_env(s):
 ALIAS_RE = re.compile('__XONSH_ALIAS_BEG__\n(.*)__XONSH_ALIAS_END__',
                       flags=re.DOTALL)
 
+
 def parse_aliases(s):
     """Parses the aliases portion of string into a dict."""
     m = ALIAS_RE.search(s)
     if m is None:
         return {}
     g1 = m.group(1)
-    items = [line.split('=', 1) for line in g1.splitlines() if \
+    items = [line.split('=', 1) for line in g1.splitlines() if
              line.startswith('alias ') and '=' in line]
     aliases = {}
     for key, value in items:
@@ -280,6 +282,7 @@ def parse_aliases(s):
 
 FUNCS_RE = re.compile('__XONSH_FUNCS_BEG__\n(.+)\n__XONSH_FUNCS_END__',
                       flags=re.DOTALL)
+
 
 def parse_funcs(s, shell, sourcer=None):
     """Parses the funcs portion of a string into a dict of callable foreign

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -85,6 +85,7 @@ DEFAULT_ENVCMDS = {
     'zsh': 'env',
     '/bin/zsh': 'env',
     '/usr/bin/zsh': 'env',
+    'cmd': 'set',
 }
 DEFAULT_ALIASCMDS = {
     'bash': 'alias',
@@ -92,6 +93,7 @@ DEFAULT_ALIASCMDS = {
     'zsh': 'alias -L',
     '/bin/zsh': 'alias -L',
     '/usr/bin/zsh': 'alias -L',
+    'cmd': 'echo.',
 }
 DEFAULT_FUNCSCMDS = {
     'bash': DEFAULT_BASH_FUNCSCMD,
@@ -99,6 +101,7 @@ DEFAULT_FUNCSCMDS = {
     'zsh': DEFAULT_ZSH_FUNCSCMD,
     '/bin/zsh': DEFAULT_ZSH_FUNCSCMD,
     '/usr/bin/zsh': DEFAULT_ZSH_FUNCSCMD,
+    'cmd': 'echo.',
 }
 DEFAULT_SOURCERS = {
     'bash': 'source',
@@ -106,6 +109,7 @@ DEFAULT_SOURCERS = {
     'zsh': 'source',
     '/bin/zsh': 'source',
     '/usr/bin/zsh': 'source',
+    'cmd': 'call',
 }
 
 @lru_cache()
@@ -173,6 +177,11 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
     funcscmd = DEFAULT_FUNCSCMDS.get(shell, 'echo {}') if funcscmd is None else funcscmd
     command = COMMAND.format(envcmd=envcmd, aliascmd=aliascmd, prevcmd=prevcmd,
                              postcmd=postcmd, funcscmd=funcscmd).strip()
+    if shell == 'cmd':
+        cmd.remove('-c')
+        cmd.append('/C')
+        command = command.replace('\n','&&')
+
     cmd.append(command)
     if currenv is None and hasattr(builtins, '__xonsh_env__'):
         currenv = builtins.__xonsh_env__.detype()
@@ -236,7 +245,7 @@ def parse_aliases(s):
     return aliases
 
 
-FUNCS_RE = re.compile('__XONSH_FUNCS_BEG__\n(.*)__XONSH_FUNCS_END__',
+FUNCS_RE = re.compile('__XONSH_FUNCS_BEG__\n(.+)\n__XONSH_FUNCS_END__',
                       flags=re.DOTALL)
 
 def parse_funcs(s, shell, sourcer=None):

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -94,7 +94,7 @@ DEFAULT_ALIASCMDS = {
     'zsh': 'alias -L',
     '/bin/zsh': 'alias -L',
     '/usr/bin/zsh': 'alias -L',
-    'cmd': 'echo.',
+    'cmd': '',
 }
 DEFAULT_FUNCSCMDS = {
     'bash': DEFAULT_BASH_FUNCSCMD,
@@ -102,7 +102,7 @@ DEFAULT_FUNCSCMDS = {
     'zsh': DEFAULT_ZSH_FUNCSCMD,
     '/bin/zsh': DEFAULT_ZSH_FUNCSCMD,
     '/usr/bin/zsh': DEFAULT_ZSH_FUNCSCMD,
-    'cmd': 'echo.',
+    'cmd': '',
 }
 DEFAULT_SOURCERS = {
     'bash': 'source',
@@ -208,7 +208,6 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
     if not use_tmpfile:
         cmd.append(command)
     else:
-        import pdb; pdb.set_trace()
         tmpfile = NamedTemporaryFile(suffix=tmpfile_ext, delete=False)
         tmpfile.write(command.encode('utf8'))
         tmpfile.close()

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -8,6 +8,7 @@ import builtins
 import subprocess
 from warnings import warn
 from functools import lru_cache
+from tempfile import NamedTemporaryFile
 from collections import MutableMapping, Mapping, Sequence
 
 from xonsh.tools import to_bool, ensure_string
@@ -44,7 +45,7 @@ shopt -s extdebug
 namelocfilestr=$(declare -F $funcnames)
 shopt -u extdebug
 
-# print just names and files as JSON object 
+# print just names and files as JSON object
 read -r -a namelocfile <<< $namelocfilestr
 sep=" "
 namefile="{"
@@ -70,7 +71,7 @@ for name in ${(ok)functions}; do
   loc=${(z)loc}
   file=${loc[7,-1]}
   namefile="${namefile}\\"${name}\\":\\"${(Q)file:A}\\","
-done 
+done
 if [[ "{" == "${namefile}" ]]; then
   namefile="${namefile}}"
 else
@@ -111,12 +112,30 @@ DEFAULT_SOURCERS = {
     '/usr/bin/zsh': 'source',
     'cmd': 'call',
 }
+DEFAULT_TMPFILE_EXT = {
+    'bash': '.sh',
+    '/bin/bash': '.sh',
+    'zsh': '.zsh',
+    '/bin/zsh': '.zsh',
+    '/usr/bin/zsh': '.zsh',
+    'cmd': '.bat',
+}
+DEFAULT_RUNCMD = {
+    'bash': '-c',
+    '/bin/bash': '-c',
+    'zsh': '-c',
+    '/bin/zsh': '-c',
+    '/usr/bin/zsh': '-c',
+    'cmd': '/C',
+}
+
 
 @lru_cache()
 def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
                        aliascmd=None, extra_args=(), currenv=None,
                        safe=True, prevcmd='', postcmd='', funcscmd=None,
-                       sourcer=None):
+                       sourcer=None, use_tmpfile=False, tmpfile_ext=None,
+                       runcmd= None):
     """Extracts data from a foreign (non-xonsh) shells. Currently this gets
     the environment, aliases, and functions but may be extended in the future.
 
@@ -156,6 +175,11 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
         How to source a foreign shell file for purposes of calling functions
         in that shell. If this is None, a default value will attempt to be
         looked up based on the shell name.
+    use_tmpfile : bool, optional
+        This specifies if the commands are written to a tmp file or just
+        parsed directly to the shell
+    tmpfile_ext : str or None, optional
+        If tmpfile is True this sets specifies the extension used.
 
     Returns
     -------
@@ -171,18 +195,25 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
         cmd.append('-i')
     if login:
         cmd.append('-l')
-    cmd.append('-c')
     envcmd = DEFAULT_ENVCMDS.get(shell, 'env') if envcmd is None else envcmd
     aliascmd = DEFAULT_ALIASCMDS.get(shell, 'alias') if aliascmd is None else aliascmd
     funcscmd = DEFAULT_FUNCSCMDS.get(shell, 'echo {}') if funcscmd is None else funcscmd
+    tmpfile_ext = DEFAULT_TMPFILE_EXT.get(shell, 'sh') if tmpfile_ext is None else tmpfile_ext
+    runcmd = DEFAULT_RUNCMD.get(shell, '-c') if runcmd is None else runcmd
     command = COMMAND.format(envcmd=envcmd, aliascmd=aliascmd, prevcmd=prevcmd,
                              postcmd=postcmd, funcscmd=funcscmd).strip()
-    if shell == 'cmd':
-        cmd.remove('-c')
-        cmd.append('/C')
-        command = command.replace('\n','&&')
 
-    cmd.append(command)
+    cmd.append(runcmd)
+
+    if not use_tmpfile:
+        cmd.append(command)
+    else:
+        import pdb; pdb.set_trace()
+        tmpfile = NamedTemporaryFile(suffix=tmpfile_ext, delete=False)
+        tmpfile.write(command.encode('utf8'))
+        tmpfile.close()
+        cmd.append(tmpfile.name)
+
     if currenv is None and hasattr(builtins, '__xonsh_env__'):
         currenv = builtins.__xonsh_env__.detype()
     elif currenv is not None:
@@ -196,6 +227,9 @@ def foreign_shell_data(shell, interactive=True, login=False, envcmd=None,
         if not safe:
             raise
         return {}, {}
+    finally:
+        if use_tmpfile:
+            os.remove(tmpfile.name)
     env = parse_env(s)
     aliases = parse_aliases(s)
     funcs = parse_funcs(s, shell=shell, sourcer=sourcer)


### PR DESCRIPTION
This is best effort to fit cmd.exe support into the framework of foreign_shells. There are a number of places where it doesn't align with the POSIX shells. 

The first commit adds the ability to source *.bat files on Windows. 
The second commit uses `source_cmd()` to add an alias for the activate/deactivate scripts that are used to switch Conda environments on windows. 

The current implementation contains a few hacks in the attempt to change the existing structure of foreign_shells.py as little as possible. It only supports sourcing batch scripts, not reading functions or aliases. I have no idea if the latter is even possible.

 I don't think it is ready for merging, but it may help @scopatz figure out how `foreign_shells should be changed to accommodate cmd.exe...

