### PR TITLE
Expand tildas when using $CDPATH

### DIFF
--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -41,7 +41,7 @@ def _try_cdpath(apath):
     env = builtins.__xonsh_env__
     cdpaths = env.get('CDPATH')
     for cdp in cdpaths:
-        for cdpath_prefixed_path in iglob(os.path.join(cdp, apath)):
+        for cdpath_prefixed_path in iglob(os.path.expanduser(os.path.join(cdp, apath))):
             return cdpath_prefixed_path
     return apath
 


### PR DESCRIPTION
When $CDPATH contains user directory shortcuts '~', xonsh should expand those so that it can find and return the appropriate directory path.