### PR TITLE
Aligns the colors with prompt_toolkit specification of colors.

### DIFF
--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Hooks for pygments syntax highlighting."""
+import os
 import re
 import string
 import builtins
@@ -539,10 +540,10 @@ if hasattr(pygments.style, 'ansicolors'):
         Color.WHITE: '#ansiwhite',
         Color.YELLOW: '#ansiyellow',
     }
-elif ON_WINDOWS:
+elif ON_WINDOWS and 'CONEMUANSI' not in os.environ:
     # These colors must match the color specification
     # in prompt_toolkit, so the colors are converted 
-    # correctly
+    # correctly when using cmd.exe
     DEFAULT_STYLE = {
         Color.BLACK: '#000000',
         Color.BLUE: '#0000AA',

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -539,6 +539,29 @@ if hasattr(pygments.style, 'ansicolors'):
         Color.WHITE: '#ansiwhite',
         Color.YELLOW: '#ansiyellow',
     }
+elif ON_WINDOWS:
+    # These colors must match the color specification
+    # in prompt_toolkit, so the colors are converted 
+    # correctly
+    DEFAULT_STYLE = {
+        Color.BLACK: '#000000',
+        Color.BLUE: '#0000AA',
+        Color.CYAN: '#00AAAA',
+        Color.GREEN: '#00AA00',
+        Color.INTENSE_BLACK: '#444444',
+        Color.INTENSE_BLUE: '#4444FF',
+        Color.INTENSE_CYAN: '#44FFFF',
+        Color.INTENSE_GREEN: '#44FF44',
+        Color.INTENSE_PURPLE: '#FF44FF',
+        Color.INTENSE_RED: '#FF4444',
+        Color.INTENSE_WHITE: '#888888',
+        Color.INTENSE_YELLOW: '#FFFF44',
+        Color.NO_COLOR: 'noinherit',
+        Color.PURPLE: '#AA00AA',
+        Color.RED: '#AA0000',
+        Color.WHITE: '#FFFFFF',
+        Color.YELLOW: '#AAAA00',
+        }
 else:
     DEFAULT_STYLE = {
         Color.BLACK: '#000000',


### PR DESCRIPTION
This aligns the colors with the specification used by prompt_toolkit. 
https://github.com/jonathanslenders/python-prompt-toolkit/blob/master/prompt_toolkit/terminal/win32_output.py#L442

Without this, some colors were simply mapped incorrectly, at least for me on windows. For example 'INTENSE_GREEN' is not just normal green. 
 
This will not be a problem as soon as pygments 2.2 is released because prompt_toolkit will then used the `#ansicolors` specification instead.