### PR TITLE
Fix deadlock on windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,8 @@ Current Developments
 * Fixed environment variables from os.environ not beeing loaded when a running 
   a script
 * Fixed bug that prevented `source-alias` from working. 
+* Fixed deadlock on Windows when runing subprocess that generates enough output
+  to fill the OS pipe buffer 
 
 **Security:** None
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -6,6 +6,7 @@ import time
 import signal
 import builtins
 from subprocess import TimeoutExpired
+from io import BytesIO
 
 from xonsh.tools import ON_WINDOWS
 
@@ -41,13 +42,16 @@ if ON_WINDOWS:
             return
         while obj.returncode is None:
             try:
-                obj.wait(0.01)
+                outs, errs = obj.communicate(timeout=0.01)
             except TimeoutExpired:
                 pass
             except KeyboardInterrupt:
                 obj.kill()
+                outs, errs = obj.communicate()
         if obj.poll() is not None:
             builtins.__xonsh_active_job__ = None
+            obj.stdout = BytesIO(outs)
+            obj.stderr = BytesIO(errs)
 
 else:
     def _continue(obj):


### PR DESCRIPTION
@BYK and @scopatz  This is a fix for deadlock on windows when running subproc that generates enough data to fill the os pipe. 

This may be a hacky way to solve it, but it is a minimal change and it seems to work. 