### PR TITLE
Added `source-bat` as an alias for `source-cmd`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,8 +17,9 @@ Current Developments
   This is disabled by default but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to
   True.
 * Added Windows 'cmd.exe' as a foreign shell. This gives xonsh the ability to source 
-  Windows Batch files (.bat and .cmd). Calling ``source-cmd script.bat`` will call 
-  the bat file and changes to the environment variables will be reflected in xonsh.
+  Windows Batch files (.bat and .cmd). Calling ``source-cmd script.bat`` or the 
+  alias ``source-bat script.bat`` will call the bat file and changes to the 
+  environment variables will be reflected in xonsh.
 * Added an alias for the conda environment activate/deactivate batch scripts when 
   running the Anaconda python distribution on Windows.
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -389,6 +389,7 @@ def make_default_aliases():
         for alias in windows_cmd_aliases:
             default_aliases[alias] = ['cmd', '/c', alias]
         default_aliases['call'] = ['source-cmd']
+        default_aliases['source-bat'] = ['source-cmd']
         # Add aliases specific to the Anaconda python distribution.
         if 'Anaconda' in sys.version:
             def source_cmd_keep_prompt(args, stdin=None):


### PR DESCRIPTION
Maybe not the most important PR. We already had `call` as an alias. Anyway, since @scopatz suggested in #800 I had to implement it. 