### PR TITLE
Alias for `which` to support alias lookups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Current Developments
 * Added an alias for the conda environment activate/deactivate batch scripts when 
   running the Anaconda python distribution on Windows.
 * Added a menu entry to launch xonsh when installing xonsh from a conda package
+* Added a new ``which`` alias that supports both regular ``which`` and also searches
+  through xonsh aliases
 
 
 **Changed:**

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -453,7 +453,6 @@ def make_default_aliases():
                                            'activate.bat']
             default_aliases['deactivate'] = ['source-cmd-keep-promt',
                                              'deactivate.bat']
-        default_aliases['which'] = ['where']
         if not locate_binary('sudo'):
             import xonsh.winutils as winutils
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -329,7 +329,7 @@ def which(args, stdin=None):
     """
     desc = "Parses arguments to which wrapper"
     parser = ArgumentParser('which', description=desc)
-    parser.add_argument('arg', type=str, default='-h',
+    parser.add_argument('arg', type=str,
                         help='The executable or alias to search for')
     parser.add_argument('-a', action='store_true', dest='all',
                         help='Show all matches in $PATH and xonsh.aliases')


### PR DESCRIPTION
Caveats:  
1. I think Windows will just ignore this entirely
2. Some, but not all, `which` flags are supported

As requested by @scopatz in #809 

```console
(xonshtest)gil@theo~/git/myxonsh alias_which$ which ls
ls -> ['ls', '--color=auto', '-v']
(xonshtest)gil@theo~/git/myxonsh alias_which$ which -a ls
ls -> ['ls', '--color=auto', '-v']
/usr/bin/ls
(xonshtest)gil@theo~/git/myxonsh alias_which$ which timeit
timeit -> <function timeit_alias at 0x7f6558ec3d08>
(xonshtest)gil@theo~/git/myxonsh alias_which$ which -a timeit
timeit -> <function timeit_alias at 0x7f6558ec3d08>
(xonshtest)gil@theo~/git/myxonsh alias_which$ which DERP
xonsh.tools.XonshError: DERP not in /home/gil/anaconda/bin:/usr/bin:/usr/local/bin:/usr/bin/vendor_perl/:/usr/bin/core_perl/:/opt/cuda/bin or xonsh.builtins.aliases
(xonshtest)gil@theo~/git/myxonsh alias_which$ which -v ls
GNU which v2.21, Copyright (C) 1999 - 2015 Carlo Wood.
GNU which comes with ABSOLUTELY NO WARRANTY;
This program is free software; your freedom to use, change
and distribute this program is protected by the GPL.
(xonshtest)gil@theo~/git/myxonsh alias_which$ which --skip-alias ls
/usr/bin/ls
```