### PR TITLE
Prevented hg branch call for default branch

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -887,7 +887,7 @@ def get_hg_branch(cwd=None, root=None):
             with open(branch_path, 'r') as branch_file:
                 branch = branch_file.read()
         else:
-            branch = call_hg_command(['branch'], cwd)
+            branch = 'default'
 
         if os.path.exists(bookmark_path):
             with open(bookmark_path, 'r') as bookmark_file:


### PR DESCRIPTION
When ```.hg/branch``` doesn't exist, ```hg branch``` is used to determine the branch.

If the file does not exist it will be the ```default``` branch.