### PR TITLE
#763 fixed ';' input on tools.subproc_toks()

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,9 +7,9 @@ import nose
 from nose.tools import assert_equal, assert_true, assert_false
 
 from xonsh.lexer import Lexer
-from xonsh.tools import (subproc_toks, subexpr_from_unbalanced, is_int, 
-    always_true, always_false, ensure_string, is_env_path, str_to_env_path, 
-    env_path_to_str, escape_windows_cmd_string, is_bool, to_bool, bool_to_str, 
+from xonsh.tools import (subproc_toks, subexpr_from_unbalanced, is_int,
+    always_true, always_false, ensure_string, is_env_path, str_to_env_path,
+    env_path_to_str, escape_windows_cmd_string, is_bool, to_bool, bool_to_str,
     ensure_int_or_slice, is_float, is_string, check_for_partial_string,
     argvquote)
 
@@ -156,6 +156,11 @@ def test_subproc_hello_mom_second():
 def test_subproc_toks_comment():
     exp = None
     obs = subproc_toks('# I am a comment', lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_semicolon_only():
+    exp = None
+    obs = subproc_toks(';', lexer=LEXER, returnline=True)
     assert_equal(exp, obs)
 
 def test_subexpr_from_unbalanced_parens():

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -140,10 +140,10 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
                 tok.lexpos = len(line)
             break
     else:
+        if len(toks) > 0 and toks[-1].type == 'SEMI':
+            toks.pop()
         if len(toks) == 0:
             return  # handle comment lines
-        if toks[-1].type == 'SEMI':
-            toks.pop()
         tok = toks[-1]
         pos = tok.lexpos
         if isinstance(tok.value, string_types):


### PR DESCRIPTION
Partially solved. Still throwing error in another part of the code.