### PR TITLE
add support for prompt_toolkit-1.0.0 and preserve support for previous versions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Current Developments
 * Added a menu entry to launch xonsh when installing xonsh from a conda package
 * Added a new ``which`` alias that supports both regular ``which`` and also searches
   through xonsh aliases
+* Add support for prompt_toolkit_1.0.0
 
 
 **Changed:**

--- a/xonsh/ptk/shortcuts.py
+++ b/xonsh/ptk/shortcuts.py
@@ -6,6 +6,8 @@ from prompt_toolkit.shortcuts import (create_prompt_application,
 
 from xonsh.shell import prompt_toolkit_version_info
 
+import builtins
+
 class Prompter(object):
 
     def __init__(self, cli=None, *args, **kwargs):
@@ -69,6 +71,15 @@ class Prompter(object):
             if self.major_minor <= (0, 57):
                 kwargs.pop('get_rprompt_tokens', None)
                 kwargs.pop('get_continuation_tokens', None)
+            #VI_Mode handling changed in prompt_toolkit v1.0
+            if self.major_minor >= (1, 0):
+                from prompt_toolkit.enums import EditingMode
+                if builtins.__xonsh_env__.get('VI_MODE'):
+                    editing_mode = EditingMode.VI
+                else:
+                    editing_mode = EditingMode.EMACS
+
+                kwargs['editing_mode'] = editing_mode
             cli = CommandLineInterface(
                 application=create_prompt_application(message, **kwargs),
                 eventloop=eventloop,

--- a/xonsh/ptk/shortcuts.py
+++ b/xonsh/ptk/shortcuts.py
@@ -71,7 +71,7 @@ class Prompter(object):
             if self.major_minor <= (0, 57):
                 kwargs.pop('get_rprompt_tokens', None)
                 kwargs.pop('get_continuation_tokens', None)
-            #VI_Mode handling changed in prompt_toolkit v1.0
+            # VI_Mode handling changed in prompt_toolkit v1.0
             if self.major_minor >= (1, 0):
                 from prompt_toolkit.enums import EditingMode
                 if builtins.__xonsh_env__.get('VI_MODE'):


### PR DESCRIPTION
hat tip and congratulations to @jonathanslenders in #819 

This makes exactly the same changes but doesn't break `xonsh` for people using `prompt_toolkit` versions `0.57` or `0.58`.  

Is it time that we start thinking about a deprecation schedule for those?