### PR TITLE
set error on exit for foriegn shells

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,16 +16,16 @@ Current Developments
 * Added an option to update ``os.environ`` every time the xonsh environment changes.
   This is disabled by default but can be enabled by setting ``$UPDATE_OS_ENVIRON`` to
   True.
-* Added Windows 'cmd.exe' as a foreign shell. This gives xonsh the ability to source 
-  Windows Batch files (.bat and .cmd). Calling ``source-cmd script.bat`` or the 
-  alias ``source-bat script.bat`` will call the bat file and changes to the 
+* Added Windows 'cmd.exe' as a foreign shell. This gives xonsh the ability to source
+  Windows Batch files (.bat and .cmd). Calling ``source-cmd script.bat`` or the
+  alias ``source-bat script.bat`` will call the bat file and changes to the
   environment variables will be reflected in xonsh.
-* Added an alias for the conda environment activate/deactivate batch scripts when 
+* Added an alias for the conda environment activate/deactivate batch scripts when
   running the Anaconda python distribution on Windows.
 * Added a menu entry to launch xonsh when installing xonsh from a conda package
 * Added a new ``which`` alias that supports both regular ``which`` and also searches
   through xonsh aliases
-* Add support for prompt_toolkit_1.0.0
+* Added support for prompt toolkit v1.0.0.
 
 
 **Changed:**
@@ -40,7 +40,9 @@ Current Developments
   environments
 * Regexpath matching with backticks, now returns an empty list in python mode.
 * Pygments added as a dependency for the conda package
-
+* Foreign shells now allow for setting exit-on-error commands before and after
+  all other commands via the ``seterrprevcmd`` and ``seterrpostcmd`` arguments.
+  Sensinble defaults are provided for existing shells.
 
 
 **Deprecated:** None
@@ -54,11 +56,13 @@ Current Developments
   the line.
 * Aliases will now evaluate enviornment variables and other expansions
   at execution time rather than passing through a literal string.
-* Fixed environment variables from os.environ not beeing loaded when a running 
+* Fixed environment variables from os.environ not beeing loaded when a running
   a script
-* Fixed bug that prevented `source-alias` from working. 
+* Fixed bug that prevented `source-alias` from working.
 * Fixed deadlock on Windows when runing subprocess that generates enough output
-  to fill the OS pipe buffer 
+  to fill the OS pipe buffer.
+* Sourcing foreign shells will now return a non-zero exit code if the
+  source operation failed for some reason.
 
 **Security:** None
 

--- a/docs/xonshconfig.rst
+++ b/docs/xonshconfig.rst
@@ -66,9 +66,14 @@ dictionaries have the following structure:
 :runcmd : *str or None, optional* - Command line switches to use when
     running the script, such as ``-c`` for Bash and ``/C`` for cmd.exe.
     ``default=null``
-:seterrcmd : *str or None, optional* - Command that enables exit-on-error
-    for the shell. For example, this is "set -e" in Bash. To disable
-    exit-on-error behavior, simply pass in an empty string. ``default=null``
+:seterrprevcmd : *str or None, optional* - Command that enables exit-on-error
+    for the shell before all other commands. For example, this is "set -e" in Bash.
+    To disable this exit-on-error behavior, simply pass in an empty string.
+    ``default=null``
+:seterrpostcmd : *str or None, optional* - Command that enables exit-on-error
+    for the shell after all other commands. For example, this is "set -e" in Bash.
+    To disable this exit-on-error behavior, simply pass in an empty string.
+    ``default=null``
 
 
 Some examples can be seen below:

--- a/docs/xonshconfig.rst
+++ b/docs/xonshconfig.rst
@@ -3,17 +3,17 @@ Static Configuration File
 In addition to the run control file, xonsh allows you to have a static config file.
 This JSON-formatted file lives at ``$XONSH_CONFIG_DIR/config.json``, which is
 normally ``~/.config/xonsh/config.json``. The purpose of this file is to allow
-users to set runtime parameters *before* anything else happens. This includes 
+users to set runtime parameters *before* anything else happens. This includes
 loading data from various foreign shells or setting critical environment
 variables.
 
-This is a dictionary or JSON object at its top-level.  It has the following 
+This is a dictionary or JSON object at its top-level.  It has the following
 top-level keys.  All top-level keys are optional.
 
 ``env``
 --------
-This is a simple string-keyed dictionary that lets you set environment 
-variables. For example, 
+This is a simple string-keyed dictionary that lets you set environment
+variables. For example,
 
 .. code:: json
 
@@ -28,9 +28,9 @@ variables. For example,
 --------------------
 This is a list (JSON Array) of dicts (JSON objects) that represent the
 foreign shells to inspect for extra start up information, such as environment
-variables, aliases, and foreign shell functions. The suite of data gathered 
+variables, aliases, and foreign shell functions. The suite of data gathered
 may be expanded in the future.  Each shell dictionary unpacked and passed into
-the ``xonsh.foreign_shells.foreign_shell_data()`` function. Thus, these 
+the ``xonsh.foreign_shells.foreign_shell_data()`` function. Thus, these
 dictionaries have the following structure:
 
 :shell: *str, required* - The name or path of the shell, such as "bash" or "/bin/sh".
@@ -42,27 +42,34 @@ dictionaries have the following structure:
     ``default="env"``
 :aliascmd: *str, optional* - The command to generate alais output with.
     ``default="alias"``
-:extra_args: *list of str, optional* - Addtional command line options to pass 
+:extra_args: *list of str, optional* - Addtional command line options to pass
     into the shell. ``default=[]``
 :currenv: *dict or null, optional* - Manual override for the current environment.
     ``default=null``
-:safe: *bool, optional* - Flag for whether or not to safely handle exceptions 
+:safe: *bool, optional* - Flag for whether or not to safely handle exceptions
     and other errors. ``default=true``
-:prevcmd: *str, optional* - An additional command or script to run before 
-    anything else, useful for sourcing and other commands that may require 
+:prevcmd: *str, optional* - An additional command or script to run before
+    anything else, useful for sourcing and other commands that may require
     environment recovery. ``default=''``
 :postcmd: *str, optional* - A command to run after everything else, useful for
     cleaning up any damage that the ``prevcmd`` may have caused. ``default=''``
-:funcscmd: *str or None, optional* - This is a command or script that can be 
+:funcscmd: *str or None, optional* - This is a command or script that can be
     used to determine the names and locations of any functions that are native
-    to the foreign shell. This command should print *only* a whitespace 
+    to the foreign shell. This command should print *only* a whitespace
     separated sequence of pairs function name & filenames where the functions
     are defined. If this is None (null), then a default script will attempted
-    to be looked up based on the shell name. Callable wrappers for these 
+    to be looked up based on the shell name. Callable wrappers for these
     functions will be returned in the aliases dictionary. ``default=null``
-:sourcer: *str or None, optional* - How to source a foreign shell file for 
-    purposes of calling functions in that shell. If this is None, a default 
+:sourcer: *str or None, optional* - How to source a foreign shell file for
+    purposes of calling functions in that shell. If this is None, a default
     value will attempt to be looked up based on the shell name. ``default=null``
+:runcmd : *str or None, optional* - Command line switches to use when
+    running the script, such as ``-c`` for Bash and ``/C`` for cmd.exe.
+    ``default=null``
+:seterrcmd : *str or None, optional* - Command that enables exit-on-error
+    for the shell. For example, this is "set -e" in Bash. To disable
+    exit-on-error behavior, simply pass in an empty string. ``default=null``
+
 
 Some examples can be seen below:
 
@@ -77,8 +84,8 @@ Some examples can be seen below:
 
     # load bash as a login shell with custom rcfile
     {"foreign_shells": [
-        {"shell": "bash", 
-         "login": true, 
+        {"shell": "bash",
+         "login": true,
          "extra_args": ["--rcfile", "/path/to/rcfile"]
          }
      ]

--- a/docs/xonshconfig.rst
+++ b/docs/xonshconfig.rst
@@ -71,9 +71,9 @@ dictionaries have the following structure:
     To disable this exit-on-error behavior, simply pass in an empty string.
     ``default=null``
 :seterrpostcmd : *str or None, optional* - Command that enables exit-on-error
-    for the shell after all other commands. For example, this is "set -e" in Bash.
-    To disable this exit-on-error behavior, simply pass in an empty string.
-    ``default=null``
+    for the shell after all other commands. For example, this is
+    "if errorlevel 1 exit 1" in cmd.exe. To disable this exit-on-error behavior,
+    simply pass in an empty string. ``default=null``
 
 
 Some examples can be seen below:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -192,6 +192,12 @@ def _ensure_source_foreign_parser():
                         help='whether the commands for source shell should be '
                              'written to a temporary file.',
                         dest='use_tmpfile')
+    parser.add_argument('--seterrprevcmd', default=None, dest='seterrprevcmd',
+                        help='command(s) to set exit-on-error before any'
+                             'other commands.')
+    parser.add_argument('--seterrpostcmd', default=None, dest='seterrpostcmd',
+                        help='command(s) to set exit-on-error after all'
+                             'other commands.')
     _SOURCE_FOREIGN_PARSER = parser
     return parser
 
@@ -217,7 +223,9 @@ def source_foreign(args, stdin=None):
                                           postcmd=ns.postcmd,
                                           funcscmd=ns.funcscmd,
                                           sourcer=ns.sourcer,
-                                          use_tmpfile=ns.use_tmpfile)
+                                          use_tmpfile=ns.use_tmpfile,
+                                          seterrprevcmd=ns.seterrprevcmd,
+                                          seterrpostcmd=ns.seterrpostcmd)
     if fsenv is None:
         return (None, 'xonsh: error: Source failed: '
                       '{}\n'.format(ns.prevcmd), 1)
@@ -267,7 +275,7 @@ def source_cmd(args, stdin=None):
     args.append('--interactive=0')
     args.append('--sourcer=call')
     args.append('--envcmd=set')
-    args.append('--postcmd=if errorlevel 1 exit 1')
+    args.append('--seterrpostcmd=if errorlevel 1 exit 1')
     args.append('--use-tmpfile=1')
     return source_foreign(args, stdin=stdin)
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -269,7 +269,6 @@ def source_cmd(args, stdin=None):
     prevcmd = 'call '
     prevcmd += ' '.join([argvquote(arg, force=True) for arg in args])
     prevcmd = escape_windows_cmd_string(prevcmd)
-    prevcmd += '\n@echo off'
     args.append('--prevcmd={}'.format(prevcmd))
     args.insert(0, 'cmd')
     args.append('--interactive=0')

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -126,7 +126,7 @@ DEFAULT_RUNCMD = {
 DEFAULT_SETERRPREVCMD = {
     'bash': 'set -e',
     'zsh': 'set -e',
-    'cmd': '',
+    'cmd': '@echo off',
 }
 DEFAULT_SETERRPOSTCMD = {
     'bash': '',


### PR DESCRIPTION
This should address #817.  Not sure what the value of this should be for `cmd.exe`.  @melund or @BYK do you have any idea?