### PR TITLE
add warning if user has pt-specific options using rlshell

### DIFF
--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -23,6 +23,8 @@ RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
 RL_CAN_RESIZE = False
 RL_DONE = None
 
+PT_ONLY_OPTIONS = ['VI_MODE', 'MOUSE_SUPPORT', 'RIGHT_PROMPT']
+
 
 def setup_readline():
     """Sets up the readline module and completion suppression, if available."""
@@ -61,6 +63,14 @@ def setup_readline():
         readline.parse_and_bind("bind ^I rl_complete")
     else:
         readline.parse_and_bind("tab: complete")
+
+    invalid_option = False
+    for option in PT_ONLY_OPTIONS:
+        if env.get(option):
+            invalid_option = True
+            print('{} is set to {} but has no effect in the readline shell.'.format(option, env.get(option)))
+    if invalid_option:
+        print('To make use of these options, install `prompt_toolkit`.  See https://xon.sh for more information.')
 
 
 def teardown_readline():

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -13,6 +13,7 @@ from xonsh.base_shell import BaseShell
 from xonsh.ansi_colors import partial_color_format, color_style_names, color_style
 from xonsh.environ import partial_format_prompt, multiline_prompt
 from xonsh.tools import ON_WINDOWS, print_exception, HAVE_PYGMENTS
+from xonsh.shell import is_prompt_toolkit_available
 
 if HAVE_PYGMENTS:
     from xonsh import pyghooks
@@ -64,12 +65,17 @@ def setup_readline():
     else:
         readline.parse_and_bind("tab: complete")
 
-    invalid_option = False
+    invalid_option = []
     for option in PT_ONLY_OPTIONS:
         if env.get(option):
-            invalid_option = True
-            print('{} is set to {} but has no effect in the readline shell.'.format(option, env.get(option)))
+            invalid_option.append(option)
     if invalid_option:
+        print('The following options are unavailable in the readline shell: {}'
+              .format(', '.join(invalid_option)))
+    if is_prompt_toolkit_available():
+        print('To enable the prompt_toolkit shell, '
+                'put `$SHELL_TYPE=\'prompt_toolkit\'` in your `xonshrc`')
+    else:
         print('To make use of these options, install `prompt_toolkit`.  See https://xon.sh for more information.')
 
 


### PR DESCRIPTION
If user has set any `prompt_toolkit` specific options (of those that are
False or empty strings by default) set in their `xonshrc`, a warning
will be printed if they open a `readline` shell.

Right now this triggers if any of the following are changed from their
defaults:
* `VI_MODE`
* `MOUSE_SUPPORT`
* `RIGHT_PROMPT`

Caveat: This might be _really_ annoying if you switch back and forth between the two.

```console
(xonshtest)gil@theo~/git/myxonsh master$ xonsh --shell-type readline
VI_MODE is set to True but has no effect in the readline shell.
MOUSE_SUPPORT is set to True but has no effect in the readline shell.
RIGHT_PROMPT is set to hi! but has no effect in the readline shell.
To make use of these options, install `prompt_toolkit`.  See https://xon.sh for more information.
```