### PR TITLE
Fix for balancing parens in subproc wrapping.

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -137,7 +137,7 @@ def test_subproc_toks_ls_l_semi_ls_second():
     obs = subproc_toks(s, lexer=LEXER, mincol=7, returnline=True)
     assert_equal(exp, obs)
 
-def test_subproc_hello_mom_first():
+def test_subproc_toks_hello_mom_first():
     fst = "echo 'hello'"
     sec = "echo 'mom'"
     s = '{0}; {1}'.format(fst, sec)
@@ -145,7 +145,7 @@ def test_subproc_hello_mom_first():
     obs = subproc_toks(s, lexer=LEXER, maxcol=len(fst)+1, returnline=True)
     assert_equal(exp, obs)
 
-def test_subproc_hello_mom_second():
+def test_subproc_toks_hello_mom_second():
     fst = "echo 'hello'"
     sec = "echo 'mom'"
     s = '{0}; {1}'.format(fst, sec)
@@ -191,6 +191,32 @@ def test_subproc_toks_paren_and_paren():
 def test_subproc_toks_semicolon_only():
     exp = None
     obs = subproc_toks(';', lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_pyeval():
+    s = 'echo @(1+1)'
+    exp = '![{0}]'.format(s)
+    obs = subproc_toks(s, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_twopyeval():
+    s = 'echo @(1+1) @(40 + 2)'
+    exp = '![{0}]'.format(s)
+    obs = subproc_toks(s, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_pyeval_parens():
+    s = 'echo @(1+1)'
+    inp = '({0})'.format(s)
+    exp = '(![{0}])'.format(s)
+    obs = subproc_toks(inp, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_twopyeval_parens():
+    s = 'echo @(1+1) @(40+2)'
+    inp = '({0})'.format(s)
+    exp = '(![{0}])'.format(s)
+    obs = subproc_toks(inp, lexer=LEXER, returnline=True)
     assert_equal(exp, obs)
 
 def test_subexpr_from_unbalanced_parens():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -219,6 +219,32 @@ def test_subproc_toks_twopyeval_parens():
     obs = subproc_toks(inp, lexer=LEXER, returnline=True)
     assert_equal(exp, obs)
 
+def test_subproc_toks_pyeval_nested():
+    s = 'echo @(min(1, 42))'
+    exp = '![{0}]'.format(s)
+    obs = subproc_toks(s, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_pyeval_nested_parens():
+    s = 'echo @(min(1, 42))'
+    inp = '({0})'.format(s)
+    exp = '(![{0}])'.format(s)
+    obs = subproc_toks(inp, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_capstdout():
+    s = 'echo $(echo bat)'
+    exp = '![{0}]'.format(s)
+    obs = subproc_toks(s, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+def test_subproc_toks_capproc():
+    s = 'echo !(echo bat)'
+    exp = '![{0}]'.format(s)
+    obs = subproc_toks(s, lexer=LEXER, returnline=True)
+    assert_equal(exp, obs)
+
+
 def test_subexpr_from_unbalanced_parens():
     cases = [
         ('f(x.', 'x.'),

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -97,6 +97,14 @@ DefaultNotGiven = DefaultNotGivenType()
 
 BEG_TOK_SKIPS = frozenset(['WS', 'INDENT', 'NOT', 'LPAREN'])
 END_TOK_TYPES = frozenset(['SEMI', 'AND', 'OR', 'RPAREN'])
+LPARENS = frozenset(['LPAREN', 'AT_LPAREN', 'BANG_LPAREN', 'DOLLAR_LPAREN'])
+
+def _is_not_lparen_and_rparen(lparens, rtok):
+    """Tests if an RPAREN token is matched with something other than a plain old
+    LPAREN type.
+    """
+    return rtok.type == 'RPAREN' and len(lparens) > 0 and lparens[-1] != 'LPAREN'
+
 
 def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
     """Excapsulates tokens in a source code line in a uncaptured
@@ -110,15 +118,22 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
     lexer.reset()
     lexer.input(line)
     toks = []
+    lparens = []
     end_offset = 0
     for tok in lexer:
         pos = tok.lexpos
+        print(tok.type)
         if tok.type not in END_TOK_TYPES and pos >= maxcol:
             break
+        if tok.type in LPARENS:
+            lparens.append(tok.type)
+            print("adding", lparens)
         if len(toks) == 0 and tok.type in BEG_TOK_SKIPS:
             continue  # handle indentation
         elif len(toks) > 0 and toks[-1].type in END_TOK_TYPES:
-            if pos < maxcol and tok.type not in ('NEWLINE', 'DEDENT', 'WS'):
+            if _is_not_lparen_and_rparen(lparens, toks[-1]):
+                lparens.pop()  # don't continue or break
+            elif pos < maxcol and tok.type not in ('NEWLINE', 'DEDENT', 'WS'):
                 toks.clear()
                 if tok.type in BEG_TOK_SKIPS:
                     continue
@@ -145,7 +160,10 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
             break
     else:
         if len(toks) > 0 and toks[-1].type in END_TOK_TYPES:
-            toks.pop()
+            if _is_not_lparen_and_rparen(lparens, toks[-1]):
+                pass
+            else:
+                toks.pop()
         if len(toks) == 0:
             return  # handle comment lines
         tok = toks[-1]

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -103,7 +103,8 @@ def _is_not_lparen_and_rparen(lparens, rtok):
     """Tests if an RPAREN token is matched with something other than a plain old
     LPAREN type.
     """
-    return rtok.type == 'RPAREN' and len(lparens) > 0 and lparens[-1] != 'LPAREN'
+    # note that any([]) is False, so this covers len(lparens) == 0
+    return rtok.type == 'RPAREN' and any(x != 'LPAREN' for x in lparens)
 
 
 def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
@@ -122,12 +123,10 @@ def subproc_toks(line, mincol=-1, maxcol=None, lexer=None, returnline=False):
     end_offset = 0
     for tok in lexer:
         pos = tok.lexpos
-        print(tok.type)
         if tok.type not in END_TOK_TYPES and pos >= maxcol:
             break
         if tok.type in LPARENS:
             lparens.append(tok.type)
-            print("adding", lparens)
         if len(toks) == 0 and tok.type in BEG_TOK_SKIPS:
             continue  # handle indentation
         elif len(toks) > 0 and toks[-1].type in END_TOK_TYPES:


### PR DESCRIPTION
I tested every case I could think of, except for possible weird scenarios with single expression spread over multiple lines.  If this breaks in that case, it is probably just safer to have folks use `![...]` anyway.  This should fix #828