### PR TITLE
Fix Anaconda check. 

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -13,7 +13,8 @@ from xonsh.dirstack import cd, pushd, popd, dirs, _get_cwd
 from xonsh.jobs import jobs, fg, bg, kill_all_jobs
 from xonsh.proc import foreground
 from xonsh.timings import timeit_alias
-from xonsh.tools import ON_MAC, ON_WINDOWS, XonshError, to_bool, string_types
+from xonsh.tools import (ON_MAC, ON_WINDOWS, ON_ANACONDA,
+    XonshError, to_bool, string_types)
 from xonsh.history import main as history_alias
 from xonsh.replay import main as replay_main
 from xonsh.xontribs import main as xontribs_main
@@ -447,7 +448,7 @@ def make_default_aliases():
         default_aliases['call'] = ['source-cmd']
         default_aliases['source-bat'] = ['source-cmd']
         # Add aliases specific to the Anaconda python distribution.
-        if 'Anaconda' in sys.version:
+        if ON_ANACONDA:
             def source_cmd_keep_prompt(args, stdin=None):
                 p = builtins.__xonsh_env__.get('PROMPT')
                 source_cmd(args, stdin=stdin)

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -19,7 +19,7 @@ from collections import MutableMapping, MutableSequence, MutableSet, namedtuple
 
 from xonsh import __version__ as XONSH_VERSION
 from xonsh.tools import (
-    ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, IS_ROOT,
+    ON_WINDOWS, ON_MAC, ON_LINUX, ON_ARCH, IS_ROOT, ON_ANACONDA,
     always_true, always_false, ensure_string, is_env_path, str_to_env_path,
     env_path_to_str, is_bool, to_bool, bool_to_str, is_history_tuple, to_history_tuple,
     history_tuple_to_str, is_float, string_types, is_string, DEFAULT_ENCODING,
@@ -1016,7 +1016,7 @@ def env_name(pre_chars='(', post_chars=') '):
     $CONDA_DEFAULT_ENV if that is set
     """
     env_path = builtins.__xonsh_env__.get('VIRTUAL_ENV', '')
-    if len(env_path) == 0 and 'Anaconda' in sys.version:
+    if len(env_path) == 0 and ON_ANACONDA:
         pre_chars, post_chars = '[', '] '
         env_path = builtins.__xonsh_env__.get('CONDA_DEFAULT_ENV', '')
     env_name = os.path.basename(env_path)

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -58,6 +58,7 @@ except ImportError:
 
 DEFAULT_ENCODING = sys.getdefaultencoding()
 
+ON_ANACONDA = any(s in sys.version for s in ['Anaconda','Continuum'])
 ON_WINDOWS = (platform.system() == 'Windows')
 ON_MAC = (platform.system() == 'Darwin')
 ON_LINUX = (platform.system() == 'Linux')


### PR DESCRIPTION
This is a no brainer....
It fixes the check  if we are runnning in an Anaconda distribution. 

It seems that 'Anaconda' is not always part of the sys.version string. Sometimes it writes 'Continuum Analytics' instead. 

'3.5.1 |Anaconda custom (64-bit)| (default, Feb 16 2016, 09:49:46) [MSC v.1900 64 bit (AMD64)]'
'3.5.1 |Continuum Analytics, Inc.| (default, Feb 16 2016, 09:49:46) [MSC v.1900 64 bit (AMD64)]'

Also the check has been moved to xonsh.tools as ON_ANACONDA