### PR TITLE
lower-case xonsh history string specs before parsing

### DIFF
--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -742,7 +742,7 @@ def to_history_tuple(x):
     if not isinstance(x, (Sequence, float, int)):
         raise ValueError('history size must be given as a sequence or number')
     if isinstance(x, str):
-        m = RE_HISTORY_TUPLE.match(x.strip())
+        m = RE_HISTORY_TUPLE.match(x.strip().lower())
         return to_history_tuple((m.group(1), m.group(3)))
     elif isinstance(x, (float, int)):
         return to_history_tuple((x, 'commands'))


### PR DESCRIPTION
This makes it possible to have:

```
$XONSH_HISTORY_SIZE = '1 GB'
```

Right now this will error out because the history tuple parsing only knows about lower-case units names. This behavior is supposed to work, I think, since upper-case `GB` is documented here: http://xon.sh/envvars.html#xonsh-history-size