### PR TITLE
An commit `which` fixes #833

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -328,6 +328,10 @@ def bang_bang(args, stdin=None):
 
 def which_version():
     """Returns output from system `which -v`"""
+    if sys.platform == 'darwin':
+        if ('gnu' not in subprocess.run(['which'], stderr=subprocess.PIPE).stderr.decode('utf-8')):
+            return '<no version number available on OS X>'
+
     _ver = subprocess.run(['which','-v'], stdout=subprocess.PIPE)
     return(_ver.stdout.decode('utf-8'))
 


### PR DESCRIPTION
CROWD:  A `which`!  A `which`!  A `which`!  We've got a `which`!  A `which`!
GFORSYTH:  We have found a `which`, might we burn it?
CROWD:  Burn it!  Burn!
SCOPATZ:  How do you know it is a `which`?
CARREAU:  It looks like one.
SCOPATZ:  Bring it forward.
WITCH:  I'm not a `gnu-which`.  I'm not a `gnu-which`.
SCOPATZ:  But you have a `-v` flag.
WITCH:  They monkey patched me.
CROWD:  No, we didn't... no.
WITCH:  And this isn't my source code, it's a false one.
SCOPATZ:  Well?
GFORSYTH:  Well, we did do the `-v` flag.
SCOPATZ:  The source code?
GFORSYTH:  And the function signature -- but it is a `which`!
CROWD:  Burn it!  `which`!  `which`!  Burn it!
SCOPATZ:  Did you dress it up like this?
CROWD:  No, no... no ... yes.  Yes, yes, a bit, a bit.

---- 
Note, above text is the commit text, not only the issue one. 