### PR TITLE
Fix For Deadlock On Captured stdout/stderr

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -428,7 +428,9 @@ def run_subproc(cmds, captured=False):
                 raise XonshError('Multiple redirects for stdout')
             stdout = streams['stdout'][-1]
             procinfo['stdout_redirect'] = streams['stdout'][:-1]
-        elif _capture_streams or ix != last_cmd:
+        elif ix != last_cmd:
+            stdout = PIPE
+        elif _capture_streams:
             _nstdout = stdout = tempfile.NamedTemporaryFile(delete=False)
             _stdout_name = stdout.name
         elif builtins.__xonsh_stdout_uncaptured__ is not None:
@@ -439,7 +441,7 @@ def run_subproc(cmds, captured=False):
         if 'stderr' in streams:
             stderr = streams['stderr'][-1]
             procinfo['stderr_redirect'] = streams['stderr'][:-1]
-        elif captured == 'object':
+        elif captured == 'object' and ix != last_cmd:
             _nstderr = stderr = tempfile.NamedTemporaryFile(delete=False)
             _stderr_name = stderr.name
         elif builtins.__xonsh_stderr_uncaptured__ is not None:

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -429,7 +429,7 @@ def run_subproc(cmds, captured=False):
             stdout = streams['stdout'][-1]
             procinfo['stdout_redirect'] = streams['stdout'][:-1]
         elif _capture_streams or ix != last_cmd:
-            stdout = tempfile.NamedTemporaryFile(delete=False)
+            _nstdout = stdout = tempfile.NamedTemporaryFile(delete=False)
             _stdout_name = stdout.name
         elif builtins.__xonsh_stdout_uncaptured__ is not None:
             stdout = builtins.__xonsh_stdout_uncaptured__
@@ -440,7 +440,7 @@ def run_subproc(cmds, captured=False):
             stderr = streams['stderr'][-1]
             procinfo['stderr_redirect'] = streams['stderr'][:-1]
         elif captured == 'object':
-            stderr = tempfile.NamedTemporaryFile(delete=False)
+            _nstderr = stderr = tempfile.NamedTemporaryFile(delete=False)
             _stderr_name = stderr.name
         elif builtins.__xonsh_stderr_uncaptured__ is not None:
             stderr = builtins.__xonsh_stderr_uncaptured__
@@ -557,9 +557,12 @@ def run_subproc(cmds, captured=False):
     output = b''
     if write_target is None:
         if _stdout_name is not None:
-            stdout = open(_stdout_name, 'rb')
-            output = stdout.read()
-            stdout.close()
+            with open(_stdout_name, 'rb') as stdoutfile:
+                output = stdoutfile.read()
+            try:
+                _nstdout.close()
+            except:
+                pass
             os.unlink(_stdout_name)
         elif prev_proc.stdout not in (None, sys.stdout):
             output = prev_proc.stdout.read()
@@ -575,9 +578,12 @@ def run_subproc(cmds, captured=False):
             named = _stderr_name is not None
             unnamed = prev_proc.stderr not in {None, sys.stderr}
             if named:
-                stderr = open(_stderr_name, 'rb')
-                errout = stderr.read()
-                stderr.close()
+                with open(_stderr_name, 'rb') as stderrfile:
+                    errout = stderrfile.read()
+                try:
+                    _nstderr.close()
+                except:
+                    pass
                 os.unlink(_stderr_name)
             elif unnamed:
                 errout = prev_proc.stderr.read()

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -429,9 +429,8 @@ def run_subproc(cmds, captured=False):
             stdout = streams['stdout'][-1]
             procinfo['stdout_redirect'] = streams['stdout'][:-1]
         elif _capture_streams or ix != last_cmd:
-            _stdout = tempfile.NamedTemporaryFile(delete=False)
-            _stdout_name = _stdout.name
-            stdout = open(_stdout_name, 'w')
+            stdout = tempfile.NamedTemporaryFile(delete=False)
+            _stdout_name = stdout.name
         elif builtins.__xonsh_stdout_uncaptured__ is not None:
             stdout = builtins.__xonsh_stdout_uncaptured__
         else:
@@ -441,9 +440,8 @@ def run_subproc(cmds, captured=False):
             stderr = streams['stderr'][-1]
             procinfo['stderr_redirect'] = streams['stderr'][:-1]
         elif captured == 'object':
-            _stderr = tempfile.NamedTemporaryFile(delete=False)
-            _stderr_name = _stderr.name
-            stderr = open(_stderr_name, 'w')
+            stderr = tempfile.NamedTemporaryFile(delete=False)
+            _stderr_name = stderr.name
         elif builtins.__xonsh_stderr_uncaptured__ is not None:
             stderr = builtins.__xonsh_stderr_uncaptured__
         uninew = (ix == last_cmd) and (not _capture_streams)

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -558,7 +558,6 @@ def run_subproc(cmds, captured=False):
     if write_target is None:
         if _stdout_name is not None:
             stdout = open(_stdout_name, 'rb')
-            stdout.seek(0)
             output = stdout.read()
             stdout.close()
             os.unlink(_stdout_name)
@@ -577,7 +576,6 @@ def run_subproc(cmds, captured=False):
             unnamed = prev_proc.stderr not in {None, sys.stderr}
             if named:
                 stderr = open(_stderr_name, 'rb')
-                stderr.seek(0)
                 errout = stderr.read()
                 stderr.close()
                 os.unlink(_stderr_name)

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -441,7 +441,7 @@ def run_subproc(cmds, captured=False):
         if 'stderr' in streams:
             stderr = streams['stderr'][-1]
             procinfo['stderr_redirect'] = streams['stderr'][:-1]
-        elif captured == 'object' and ix != last_cmd:
+        elif captured == 'object' and ix == last_cmd:
             _nstderr = stderr = tempfile.NamedTemporaryFile(delete=False)
             _stderr_name = stderr.name
         elif builtins.__xonsh_stderr_uncaptured__ is not None:

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -42,16 +42,13 @@ if ON_WINDOWS:
             return
         while obj.returncode is None:
             try:
-                outs, errs = obj.communicate(timeout=0.01)
+                obj.wait(0.01)
             except TimeoutExpired:
                 pass
             except KeyboardInterrupt:
                 obj.kill()
-                outs, errs = obj.communicate()
         if obj.poll() is not None:
             builtins.__xonsh_active_job__ = None
-            obj.stdout = BytesIO(outs)
-            obj.stderr = BytesIO(errs)
 
 else:
     def _continue(obj):


### PR DESCRIPTION
It turns out the issue described in #798 is not specific to Windows.  If the PIPE used by a captured subproc gets filled, everything blocks.

This implements a general fix, using a `NamedTemporaryFile` instead of a `PIPE` as the process's `stdout`.  It is likely to be slow as it uses a file on disk, but nothing else I tried got around this quite so nicely, and the speed wasn't a noticeable issue for me.

I ran it through some quick tests that had been locking things up both on GNU/Linux and on Windows, and it seems to pass those cases now.