### PR TITLE
Fix 'git status' option for include_untracked=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,6 +76,7 @@ Current Developments
   source operation failed for some reason.
 * Fixed PermissionError when running commands in directories without read permissions
 * Prevent Windows fixups from overriding environment vars in static config
+* Fixed Optional Github project status to reflect added/removed files via git_dirty_working_directory()
 
 **Security:** None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -935,7 +935,7 @@ def git_dirty_working_directory(cwd=None, include_untracked=False):
     try:
         cmd = ['git', 'status', '--porcelain']
         if include_untracked:
-            cmd.append('--untracked-files=yes')
+            cmd.append('--untracked-files=normal')
         else:
             cmd.append('--untracked-files=no')
         s = subprocess.check_output(cmd,


### PR DESCRIPTION
the '--untracked-files=yes' option for 'git status' returns an error, which causes this function to return False even when there are untracked files present. I referred to this post for the correct argument of 'normal' instead of 'yes' ('no' still seems to work):
https://stackoverflow.com/questions/31708427/cant-see-untracked-files