### PR TITLE
Updated changlog "Fixed" section

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,6 +76,7 @@ Current Developments
   source operation failed for some reason.
 * Fixed PermissionError when running commands in directories without read permissions
 * Prevent Windows fixups from overriding environment vars in static config
+* Fixed Optional Github project status to reflect added/removed files via git_dirty_working_directory()
 
 **Security:** None
 


### PR DESCRIPTION
added change for git_dirty_working_directory() being fixed to "Fixed" section