### PR TITLE
Fix launcher for Windows install dirs with a space

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,7 @@ Current Developments
 * Fixed PermissionError when running commands in directories without read permissions
 * Prevent Windows fixups from overriding environment vars in static config
 * Fixed Optional Github project status to reflect added/removed files via git_dirty_working_directory()
+* Fixed xonsh.exe launcher on Windows, when Python install directory has a space in it
 
 **Security:** None
 


### PR DESCRIPTION
Feeling productive and useful today. Have another fix, this time for #879.

I've tested this on Windows, both as 'setup.py install', and via a wheel (which should be equivalent to pip).

I haven't tested for regressions on Linux, because I won't be near a Linux machine until Monday. There should be absolutely no reason why this does break something on Linux, but better safe than sorry.
