### PR TITLE
Update which to be a pure python implementation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,12 +28,14 @@ Current Developments
   running the Anaconda python distribution on Windows.
 * Added a menu entry to launch xonsh when installing xonsh from a conda package
 * Added a new ``which`` alias that supports both regular ``which`` and also searches
-  through xonsh aliases
+  through xonsh aliases. A pure python implementation of ``which`` is used. Thanks
+  to Trent Mick. https://github.com/trentm/which/
 * Added support for prompt toolkit v1.0.0.
 * Added ``$XONSH_CACHE_SCRIPTS`` and ``$XONSH_CACHE_EVERYTHING`` environment
   variables to control caching of scripts and interactive commands.  These can
   also be controlled by command line options ``--no-script-cache`` and
   ``--cache-everything`` when starting xonsh.
+  
 
 **Changed:**
 

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ def main():
         url='https://github.com/scopatz/xonsh',
         platforms='Cross Platform',
         classifiers=['Programming Language :: Python :: 3'],
-        packages=['xonsh', 'xonsh.ptk', 'xonsh.parsers', 'xontrib'],
+        packages=['xonsh', 'xonsh.ptk', 'xonsh.parsers', 'xonsh.xoreutils', 'xontrib'],
         package_dir={'xonsh': 'xonsh', 'xontrib': 'xontrib'},
         package_data={'xonsh': ['*.json'], 'xontrib': ['*.xsh']},
         cmdclass=cmdclass

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -3,12 +3,15 @@
 from __future__ import unicode_literals, print_function
 
 import os
+import tempfile
+
 import nose
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_equal
 
 import xonsh.built_ins as built_ins
 from xonsh.aliases import Aliases
+from xonsh.aliases import _which
 from xonsh.environ import Env
 from xonsh.tools import ON_WINDOWS
 
@@ -53,6 +56,85 @@ def test_eval_recursive_callable_partial():
     with mock_xonsh_env(built_ins.ENV):
         assert_equal(ALIASES.get('indirect_cd')(['arg2', 'arg3']),
                      ['..', 'arg2', 'arg3'])
+
+
+class TestWhich:
+    # Tests for the _whichgen function which is the only thing we 
+    # use from the _which.py module.
+    def setup(self):
+        # Setup two folders with some test files.
+        self.testdirs = [tempfile.TemporaryDirectory(),
+                         tempfile.TemporaryDirectory()]
+        if ON_WINDOWS:
+            self.testapps = ['whichtestapp1.exe',
+                             'whichtestapp2.wta']
+        else:
+            self.testapps = ['whichtestapp1']
+        for app in self.testapps:
+            for d in self.testdirs:
+                path = os.path.join(d.name, app)
+                open(path, 'wb').write(b'')
+                os.chmod(path, 0o755)
+
+    def teardown(self):
+        for d in self.testdirs:
+            d.cleanup()
+
+    def test_whichgen(self):
+        testdir = self.testdirs[0].name
+        arg = 'whichtestapp1'
+        matches = list(_which.whichgen(arg, path=[testdir]))
+        assert len(matches) == 1
+        assert self._file_match(matches[0], os.path.join(testdir, arg))
+
+    def test_whichgen_failure(self):
+        testdir = self.testdirs[0].name
+        arg = 'not_a_file'
+        matches = list(_which.whichgen(arg, path=[testdir]))
+        assert len(matches) == 0
+
+    def test_whichgen_verbose(self):
+        testdir = self.testdirs[0].name
+        arg = 'whichtestapp1'
+        matches = list(_which.whichgen(arg, path=[testdir], verbose=True))
+        assert len(matches) == 1
+        match, from_where = matches[0]
+        assert self._file_match(match, os.path.join(testdir, arg))
+        assert from_where == 'from given path element 0'
+
+    def test_whichgen_multiple(self):
+        testdir0 = self.testdirs[0].name
+        testdir1 = self.testdirs[1].name
+        arg = 'whichtestapp1'
+        matches = list(_which.whichgen(arg, path=[testdir0, testdir1]))
+        assert len(matches) == 2
+        assert self._file_match(matches[0], os.path.join(testdir0, arg))
+        assert self._file_match(matches[1], os.path.join(testdir1, arg))
+
+    if ON_WINDOWS:
+        def test_whichgen_ext_failure(self):
+            testdir = self.testdirs[0].name
+            arg = 'whichtestapp2'
+            matches = list(_which.whichgen(arg, path=[testdir]))
+            assert len(matches) == 0
+
+        def test_whichgen_ext_success(self):
+                testdir = self.testdirs[0].name
+                arg = 'whichtestapp2'
+                matches = list(_which.whichgen(arg, path=[testdir], exts = ['.wta']))
+                assert len(matches) == 1
+                assert self._file_match(matches[0], os.path.join(testdir, arg))
+
+    def _file_match(self, path1, path2):
+        if ON_WINDOWS:
+            path1 = os.path.normpath(os.path.normcase(path1))
+            path2 = os.path.normpath(os.path.normcase(path2))
+            path1 = os.path.splitext(path1)[0]
+            path2 = os.path.splitext(path2)[0]
+            return path1 == path2
+        else:
+            return os.path.samefile(path1, path2)
+
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -375,7 +375,7 @@ def which(args, stdin, stdout, stderr):
         parser.print_usage(file=stderr)
         return -1
     pargs = parser.parse_args(args)
-    exts = pargs.exts if ON_WINDOWS else []
+    exts = pargs.exts if ON_WINDOWS else None
     failures = []
     for arg in pargs.args:
         nmatches = 0

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -377,7 +377,7 @@ def which(args, stdin=None, stdout=None, stderr=None):
     pargs = parser.parse_args(args)
     
     if ON_WINDOWS:
-        if len(pargs.exts) > 0:
+        if pargs.exts:
             exts = pargs.exts
         else:
             exts = builtins.__xonsh_env__.get('PATHEXT', ['.COM', '.EXE', '.BAT'])
@@ -416,8 +416,10 @@ def which(args, stdin=None, stdout=None, stderr=None):
     if len(failures) == 0:
         return 0
     else:
-        print('{} not in $PATH or xonsh.builtins.aliases\n'.format(
-              ', '.join(failures), file=stderr))
+        print('{} not in $PATH'.format(', '.join(failures)), file=stderr, end='')
+        if not pargs.skip:
+            print(' or xonsh.builtins.aliases', file=stderr, end='')
+        print('', end='\n')
         return len(failures)
 
 

--- a/xonsh/xoreutils/_which.py
+++ b/xonsh/xoreutils/_which.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python
+# Copyright (c) 2002-2007 ActiveState Software Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# Author:
+#   Trent Mick (TrentM@ActiveState.com)
+# Home:
+#   http://trentm.com/projects/which/
+
+r"""Find the full path to commands.
+
+which(command, path=None, verbose=0, exts=None)
+    Return the full path to the first match of the given command on the
+    path.
+
+whichall(command, path=None, verbose=0, exts=None)
+    Return a list of full paths to all matches of the given command on
+    the path.
+
+whichgen(command, path=None, verbose=0, exts=None)
+    Return a generator which will yield full paths to all matches of the
+    given command on the path.
+    
+By default the PATH environment variable is searched (as well as, on
+Windows, the AppPaths key in the registry), but a specific 'path' list
+to search may be specified as well.  On Windows, the PATHEXT environment
+variable is applied as appropriate.
+
+If "verbose" is true then a tuple of the form
+    (<fullpath>, <matched-where-description>)
+is returned for each match. The latter element is a textual description
+of where the match was found. For example:
+    from PATH element 0
+    from HKLM\SOFTWARE\...\perl.exe
+"""
+
+_cmdlnUsage = """
+    Show the full path of commands.
+
+    Usage:
+        which [<options>...] [<command-name>...]
+
+    Options:
+        -h, --help      Print this help and exit.
+        -V, --version   Print the version info and exit.
+
+        -a, --all       Print *all* matching paths.
+        -v, --verbose   Print out how matches were located and
+                        show near misses on stderr.
+        -q, --quiet     Just print out matches. I.e., do not print out
+                        near misses.
+
+        -p <altpath>, --path=<altpath>
+                        An alternative path (list of directories) may
+                        be specified for searching.
+        -e <exts>, --exts=<exts>
+                        Specify a list of extensions to consider instead
+                        of the usual list (';'-separate list, Windows
+                        only).
+
+    Show the full path to the program that would be run for each given
+    command name, if any. Which, like GNU's which, returns the number of
+    failed arguments, or -1 when no <command-name> was given.
+
+    Near misses include duplicates, non-regular files and (on Un*x)
+    files without executable access.
+"""
+
+__revision__ = "$Id: which.py 1448 2007-02-28 19:13:06Z trentm $"
+__version_info__ = (1, 1, 3)
+__version__ = '.'.join(map(str, __version_info__))
+__all__ = ["which", "whichall", "whichgen", "WhichError"]
+
+import os
+import sys
+import getopt
+import stat
+
+
+#---- exceptions
+
+class WhichError(Exception):
+    pass
+
+
+
+#---- internal support stuff
+
+def _getRegisteredExecutable(exeName):
+    """Windows allow application paths to be registered in the registry."""
+    registered = None
+    if sys.platform.startswith('win'):
+        if os.path.splitext(exeName)[1].lower() != '.exe':
+            exeName += '.exe'
+        try: 
+            import winreg as _winreg
+        except ImportError:
+            import _winreg
+        try:
+            key = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\" +\
+                  exeName
+            value = _winreg.QueryValue(_winreg.HKEY_LOCAL_MACHINE, key)
+            registered = (value, "from HKLM\\"+key)
+        except _winreg.error:
+            pass
+        if registered and not os.path.exists(registered[0]):
+            registered = None
+    return registered
+
+def _samefile(fname1, fname2):
+    if sys.platform.startswith('win'):
+        return ( os.path.normpath(os.path.normcase(fname1)) ==\
+            os.path.normpath(os.path.normcase(fname2)) )
+    else:
+        return os.path.samefile(fname1, fname2)
+
+def _cull(potential, matches, verbose=0):
+    """Cull inappropriate matches. Possible reasons:
+        - a duplicate of a previous match
+        - not a disk file
+        - not executable (non-Windows)
+    If 'potential' is approved it is returned and added to 'matches'.
+    Otherwise, None is returned.
+    """
+    for match in matches:  # don't yield duplicates
+        if _samefile(potential[0], match[0]):
+            if verbose:
+                sys.stderr.write("duplicate: %s (%s)\n" % potential)
+            return None
+    else:
+        if not stat.S_ISREG(os.stat(potential[0]).st_mode):
+            if verbose:
+                sys.stderr.write("not a regular file: %s (%s)\n" % potential)
+        elif sys.platform != "win32" \
+             and not os.access(potential[0], os.X_OK):
+            if verbose:
+                sys.stderr.write("no executable access: %s (%s)\n"\
+                                 % potential)
+        else:
+            matches.append(potential)
+            return potential
+
+        
+#---- module API
+
+def whichgen(command, path=None, verbose=0, exts=None):
+    """Return a generator of full paths to the given command.
+    
+    "command" is a the name of the executable to search for.
+    "path" is an optional alternate path list to search. The default it
+        to use the PATH environment variable.
+    "verbose", if true, will cause a 2-tuple to be returned for each
+        match. The second element is a textual description of where the
+        match was found.
+    "exts" optionally allows one to specify a list of extensions to use
+        instead of the standard list for this system. This can
+        effectively be used as an optimization to, for example, avoid
+        stat's of "foo.vbs" when searching for "foo" and you know it is
+        not a VisualBasic script but ".vbs" is on PATHEXT. This option
+        is only supported on Windows.
+
+    This method returns a generator which yields either full paths to
+    the given command or, if verbose, tuples of the form (<path to
+    command>, <where path found>).
+    """
+    matches = []
+    if path is None:
+        usingGivenPath = 0
+        path = os.environ.get("PATH", "").split(os.pathsep)
+        if sys.platform.startswith("win"):
+            path.insert(0, os.curdir)  # implied by Windows shell
+    else:
+        usingGivenPath = 1
+
+    # Windows has the concept of a list of extensions (PATHEXT env var).
+    if sys.platform.startswith("win"):
+        if exts is None:
+            exts = os.environ.get("PATHEXT", "").split(os.pathsep)
+            # If '.exe' is not in exts then obviously this is Win9x and
+            # or a bogus PATHEXT, then use a reasonable default.
+            for ext in exts:
+                if ext.lower() == ".exe":
+                    break
+            else:
+                exts = ['.COM', '.EXE', '.BAT']
+        elif not isinstance(exts, list):
+            raise TypeError("'exts' argument must be a list or None")
+    else:
+        if exts is not None:
+            raise WhichError("'exts' argument is not supported on "\
+                             "platform '%s'" % sys.platform)
+        exts = []
+
+    # File name cannot have path separators because PATH lookup does not
+    # work that way.
+    if os.sep in command or os.altsep and os.altsep in command:
+        if os.path.exists(command):
+            match = _cull((command, "explicit path given"), matches, verbose)
+            if verbose:
+                yield match
+            else:
+                yield match[0]
+    else:
+        for i in range(len(path)):
+            dirName = path[i]
+            # On windows the dirName *could* be quoted, drop the quotes
+            if sys.platform.startswith("win") and len(dirName) >= 2\
+               and dirName[0] == '"' and dirName[-1] == '"':
+                dirName = dirName[1:-1]
+            for ext in ['']+exts:
+                absName = os.path.abspath(
+                    os.path.normpath(os.path.join(dirName, command+ext)))
+                if os.path.isfile(absName):
+                    if usingGivenPath:
+                        fromWhere = "from given path element %d" % i
+                    elif not sys.platform.startswith("win"):
+                        fromWhere = "from PATH element %d" % i
+                    elif i == 0:
+                        fromWhere = "from current directory"
+                    else:
+                        fromWhere = "from PATH element %d" % (i-1)
+                    match = _cull((absName, fromWhere), matches, verbose)
+                    if match:
+                        if verbose:
+                            yield match
+                        else:
+                            yield match[0]
+        match = _getRegisteredExecutable(command)
+        if match is not None:
+            match = _cull(match, matches, verbose)
+            if match:
+                if verbose:
+                    yield match
+                else:
+                    yield match[0]
+
+
+def which(command, path=None, verbose=0, exts=None):
+    """Return the full path to the first match of the given command on
+    the path.
+    
+    "command" is a the name of the executable to search for.
+    "path" is an optional alternate path list to search. The default it
+        to use the PATH environment variable.
+    "verbose", if true, will cause a 2-tuple to be returned. The second
+        element is a textual description of where the match was found.
+    "exts" optionally allows one to specify a list of extensions to use
+        instead of the standard list for this system. This can
+        effectively be used as an optimization to, for example, avoid
+        stat's of "foo.vbs" when searching for "foo" and you know it is
+        not a VisualBasic script but ".vbs" is on PATHEXT. This option
+        is only supported on Windows.
+
+    If no match is found for the command, a WhichError is raised.
+    """
+    try:
+        match = whichgen(command, path, verbose, exts).next()
+    except StopIteration:
+        raise WhichError("Could not find '%s' on the path." % command)
+    return match
+
+
+def whichall(command, path=None, verbose=0, exts=None):
+    """Return a list of full paths to all matches of the given command
+    on the path.  
+
+    "command" is a the name of the executable to search for.
+    "path" is an optional alternate path list to search. The default it
+        to use the PATH environment variable.
+    "verbose", if true, will cause a 2-tuple to be returned for each
+        match. The second element is a textual description of where the
+        match was found.
+    "exts" optionally allows one to specify a list of extensions to use
+        instead of the standard list for this system. This can
+        effectively be used as an optimization to, for example, avoid
+        stat's of "foo.vbs" when searching for "foo" and you know it is
+        not a VisualBasic script but ".vbs" is on PATHEXT. This option
+        is only supported on Windows.
+    """
+    return list( whichgen(command, path, verbose, exts) )
+
+
+
+#---- mainline
+
+def main(argv):
+    all = 0
+    verbose = 0
+    altpath = None
+    exts = None
+    try:
+        optlist, args = getopt.getopt(argv[1:], 'haVvqp:e:',
+            ['help', 'all', 'version', 'verbose', 'quiet', 'path=', 'exts='])
+    except getopt.GetoptErrsor as msg:
+        sys.stderr.write("which: error: %s. Your invocation was: %s\n"\
+                         % (msg, argv))
+        sys.stderr.write("Try 'which --help'.\n")
+        return 1
+    for opt, optarg in optlist:
+        if opt in ('-h', '--help'):
+            print(_cmdlnUsage)
+            return 0
+        elif opt in ('-V', '--version'):
+            print( "which %s" % __version__)
+            return 0
+        elif opt in ('-a', '--all'):
+            all = 1
+        elif opt in ('-v', '--verbose'):
+            verbose = 1
+        elif opt in ('-q', '--quiet'):
+            verbose = 0
+        elif opt in ('-p', '--path'):
+            if optarg:
+                altpath = optarg.split(os.pathsep)
+            else:
+                altpath = []
+        elif opt in ('-e', '--exts'):
+            if optarg:
+                exts = optarg.split(os.pathsep)
+            else:
+                exts = []
+
+    if len(args) == 0:
+        return -1
+
+    failures = 0
+    for arg in args:
+        #print "debug: search for %r" % arg
+        nmatches = 0
+        for match in whichgen(arg, path=altpath, verbose=verbose, exts=exts):
+            if verbose:
+                print( "%s (%s)" % match)
+            else:
+                print(match)
+            nmatches += 1
+            if not all:
+                break
+        if not nmatches:
+            failures += 1
+    return failures
+
+
+if __name__ == "__main__":
+    sys.exit( main(sys.argv) )
+
+


### PR DESCRIPTION
@gforsyth I added the pure python 'which' which you suggested :)
I include the `which.py` from https://github.com/trentm/which but updated for Python 3. The interface is is still in `aliases.py`, but I imagine that @adqm could move the whole thing to `xoreutils` when that is ready.

This new which have some differences:
- It can handle multiple inputs. 
- it understands PATHEXT and "App Paths" registration on Windows (i.e. it
    will find everything that `start` does from the command shell); 
- it can print all matches on the PATH; 
- it can note "near misses" on the PATH (e.g. files that match but may not,
    say, have execute permissions)
