### PR TITLE
Fixed dirstack._try_cdpath to work with CDPATH values prefixed with ~/

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,7 @@ Current Developments
 * Prevent Windows fixups from overriding environment vars in static config
 * Fixed Optional Github project status to reflect added/removed files via git_dirty_working_directory()
 * Fixed xonsh.exe launcher on Windows, when Python install directory has a space in it
+* Fixed `$CDPATH` to support `~` and environments variables in its items
 
 **Security:** None
 

--- a/tests/test_dirstack.py
+++ b/tests/test_dirstack.py
@@ -57,6 +57,20 @@ def test_cdpath_collision():
             dirstack.cd(["tests"])
             assert_equal(os.getcwd(), os.path.join(HERE, "tests"))
 
+def test_cdpath_expansion():
+    with xonsh_env(Env(HERE=HERE, CDPATH=("~", "$HERE"))):
+        test_dirs = (
+            os.path.join(HERE, "xonsh-test-cdpath-here"),
+            os.path.expanduser("~/xonsh-test-cdpath-home")
+        )
+        try:
+            for _ in test_dirs:
+                if not os.path.exists(_):
+                    os.mkdir(_)
+                assert os.path.exists(dirstack._try_cdpath(_)), "dirstack._try_cdpath: could not resolve {0}".format(_)
+        except Exception as e:
+            tuple(os.rmdir(_) for _ in test_dirs if os.path.exists(_))
+            raise e
 
 if __name__ == '__main__':
     nose.runmodule()

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -41,7 +41,7 @@ def _try_cdpath(apath):
     env = builtins.__xonsh_env__
     cdpaths = env.get('CDPATH')
     for cdp in cdpaths:
-        for cdpath_prefixed_path in iglob(os.path.join(cdp, apath)):
+        for cdpath_prefixed_path in iglob(os.path.expanduser(os.path.join(cdp, apath))):
             return cdpath_prefixed_path
     return apath
 

--- a/xonsh/dirstack.py
+++ b/xonsh/dirstack.py
@@ -41,7 +41,7 @@ def _try_cdpath(apath):
     env = builtins.__xonsh_env__
     cdpaths = env.get('CDPATH')
     for cdp in cdpaths:
-        for cdpath_prefixed_path in iglob(os.path.expanduser(os.path.join(cdp, apath))):
+        for cdpath_prefixed_path in iglob(builtins.__xonsh_expand_path__(os.path.join(cdp, apath))):
             return cdpath_prefixed_path
     return apath
 


### PR DESCRIPTION
The following script

```
mkdir ~/TEST
cd ~/TEST
mkdir A
ln -s A LINK
cd ~
$CDPATH=("~/TEST")
cd LINK
```

yields

```cd: no such file or directory: LINK```