### PR TITLE
Allow Ctrl-C to Exit Reverse-Incremental Search in Readline Shell

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,8 @@ Current Developments
   variables to control caching of scripts and interactive commands.  These can
   also be controlled by command line options ``--no-script-cache`` and
   ``--cache-everything`` when starting xonsh.
-  
+* Added a workaround to allow ctrl-c to interrupt reverse incremental search in
+  the readline shell
 
 **Changed:**
 

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -19,14 +19,15 @@ if HAVE_PYGMENTS:
     import pygments
     from pygments.formatters.terminal256 import Terminal256Formatter
 
-RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = None
+RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = RL_STATE = None
 RL_CAN_RESIZE = False
 RL_DONE = None
-
+_RL_STATE_DONE = 0x1000000
+_RL_STATE_ISEARCH = 0x0000080
 
 def setup_readline():
     """Sets up the readline module and completion suppression, if available."""
-    global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE
+    global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE, RL_STATE
     if RL_COMPLETION_SUPPRESS_APPEND is not None:
         return
     try:
@@ -44,6 +45,7 @@ def setup_readline():
         except ValueError:
             # not all versions of readline have this symbol, ie Macs sometimes
             RL_COMPLETION_SUPPRESS_APPEND = None
+        RL_STATE = ctypes.c_int.in_dll(lib, 'rl_readline_state')
         RL_CAN_RESIZE = hasattr(lib, 'rl_reset_screen_size')
     env = builtins.__xonsh_env__
     # reads in history
@@ -69,6 +71,20 @@ def teardown_readline():
         import readline
     except (ImportError, TypeError):
         return
+
+
+def fix_readline_state_after_ctrl_c():
+    """
+    Fix to allow Ctrl-C to exit reverse-i-search.
+
+    Based on code from:
+        http://bugs.python.org/file39467/raw_input__workaround_demo.py
+    """
+    if RL_STATE.value & _RL_STATE_ISEARCH:
+        RL_STATE.value &= ~_RL_STATE_ISEARCH
+
+    if not RL_STATE.value & _RL_STATE_DONE:
+        RL_STATE.value |= _RL_STATE_DONE
 
 
 def rl_completion_suppress_append(val=1):
@@ -263,6 +279,7 @@ class ReadlineShell(BaseShell, Cmd):
                 self._cmdloop(intro=intro)
             except KeyboardInterrupt:
                 print()  # Gives a newline
+                fix_readline_state_after_ctrl_c()
                 self.reset_buffer()
                 intro = None
 

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -19,6 +19,7 @@ if HAVE_PYGMENTS:
     import pygments
     from pygments.formatters.terminal256 import Terminal256Formatter
 
+readline = None
 RL_COMPLETION_SUPPRESS_APPEND = RL_LIB = RL_STATE = None
 RL_CAN_RESIZE = False
 RL_DONE = None
@@ -27,7 +28,7 @@ _RL_STATE_ISEARCH = 0x0000080
 
 def setup_readline():
     """Sets up the readline module and completion suppression, if available."""
-    global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE, RL_STATE
+    global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE, RL_STATE, readline
     if RL_COMPLETION_SUPPRESS_APPEND is not None:
         return
     try:
@@ -83,6 +84,12 @@ def fix_readline_state_after_ctrl_c():
     Based on code from:
         http://bugs.python.org/file39467/raw_input__workaround_demo.py
     """
+    if ON_WINDOWS:
+        # hack to make pyreadline mimic the desired behavior
+        try:
+            readline.rl.mode.process_keyevent_queue.pop()
+        except:
+            pass
     if RL_STATE is None:
         return
     if RL_STATE.value & _RL_STATE_ISEARCH:

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -87,7 +87,9 @@ def fix_readline_state_after_ctrl_c():
     if ON_WINDOWS:
         # hack to make pyreadline mimic the desired behavior
         try:
-            readline.rl.mode.process_keyevent_queue.pop()
+            _q = readline.rl.mode.process_keyevent_queue
+            if len(_q) > 1:
+                _q.pop()
         except:
             pass
     if RL_STATE is None:

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -45,7 +45,10 @@ def setup_readline():
         except ValueError:
             # not all versions of readline have this symbol, ie Macs sometimes
             RL_COMPLETION_SUPPRESS_APPEND = None
-        RL_STATE = ctypes.c_int.in_dll(lib, 'rl_readline_state')
+        try:
+            RL_STATE = ctypes.c_int.in_dll(lib, 'rl_readline_state')
+        except:
+            pass
         RL_CAN_RESIZE = hasattr(lib, 'rl_reset_screen_size')
     env = builtins.__xonsh_env__
     # reads in history
@@ -80,9 +83,10 @@ def fix_readline_state_after_ctrl_c():
     Based on code from:
         http://bugs.python.org/file39467/raw_input__workaround_demo.py
     """
+    if RL_STATE is None:
+        return
     if RL_STATE.value & _RL_STATE_ISEARCH:
         RL_STATE.value &= ~_RL_STATE_ISEARCH
-
     if not RL_STATE.value & _RL_STATE_DONE:
         RL_STATE.value |= _RL_STATE_DONE
 


### PR DESCRIPTION
This little patch should allow Ctrl-C to exit reverse-i-search mode in the readline shell (see #78).

Should work on Windows and *nix, I believe.