### PR TITLE
A few readline updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,7 @@ Current Developments
   at execution time rather than passing through a literal string.
 * Fixed environment variables from os.environ not beeing loaded when a running
   a script
+* The readline shell will now load the inputrc files.
 * Fixed bug that prevented `source-alias` from working.
 * Now able to ``^C`` the xonfig wizard on start up.
 * Fixed deadlock on Windows when runing subprocess that generates enough output

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -394,10 +394,17 @@ DEFAULT_DOCS = {
     'TERM': VarDocs(
         'TERM is sometimes set by the terminal emulator. This is used (when '
         "valid) to determine whether or not to set the title. Users shouldn't "
-        "need to set this themselves. Note that this variable cannot be set from "
-        "within xonsh itself; you need to see this from the program that launches "
-        "xonsh. On posix systems, this can be performed by using env, e.g. "
-        "'/usr/bin/env TERM=xterm-color xonsh' or similar.", configurable=False),
+        "need to set this themselves. Note that this variable should be set as "
+        "early as possible in order to ensure it is effective. Here are a few "
+        "options:\n\n"
+        "* Set this from the program that launches xonsh. On posix systems, \n"
+        "  this can be performed by using env, e.g. \n"
+        "  '/usr/bin/env TERM=xterm-color xonsh' or similar.\n"
+        "* From the xonsh command line, namely 'xonsh -DTERM=xterm-color'.\n"
+        "* In the config file with '{\"env\": {\"TERM\": \"xterm-color\"}}'.\n"
+        "* Lastly, in xonshrc with '$TERM'\n\n"
+        "Ideally, your terminal emulator will set this correctly but that does "
+        "not always happen.", configurable=False),
     'TITLE': VarDocs(
         'The title text for the window in which xonsh is running. Formatted '
         "in the same manner as $PROMPT, see 'Customizing the Prompt' "

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -394,7 +394,10 @@ DEFAULT_DOCS = {
     'TERM': VarDocs(
         'TERM is sometimes set by the terminal emulator. This is used (when '
         "valid) to determine whether or not to set the title. Users shouldn't "
-        "need to set this themselves.", configurable=False),
+        "need to set this themselves. Note that this variable cannot be set from "
+        "within xonsh itself; you need to see this from the program that launches "
+        "xonsh. On posix systems, this can be performed by using env, e.g. "
+        "'/usr/bin/env TERM=xterm-color xonsh' or similar.", configurable=False),
     'TITLE': VarDocs(
         'The title text for the window in which xonsh is running. Formatted '
         "in the same manner as $PROMPT, see 'Customizing the Prompt' "

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -149,11 +149,11 @@ class ReadlineShell(BaseShell, Cmd):
     """The readline based xonsh shell."""
 
     def __init__(self, completekey='tab', stdin=None, stdout=None, **kwargs):
-        setup_readline()
         super().__init__(completekey=completekey,
                          stdin=stdin,
                          stdout=stdout,
                          **kwargs)
+        setup_readline()
         self._current_indent = ''
         self._current_prompt = ''
         self.cmdqueue = deque()


### PR DESCRIPTION
This PR adds a few readline related fixes.

1. The readline shell will now load user config files, which was requested by @asmeurer way back in #290
2. Adds some more docs on the $TERM variable.
3. Adds the ability to dump out the current readline configuration. These are mostky meant as a developer/debuging tools. Users shouldn't have to use them ever, but I was getting annoyed at having to reimplement them every time I did readline stuff :)