### PR TITLE
don't crash on empty .xonshrc file

### DIFF
--- a/xonsh/codecache.py
+++ b/xonsh/codecache.py
@@ -48,6 +48,8 @@ def run_compiled_code(code, glb, loc, mode):
     """
     Helper to run code in a given mode and context
     """
+    if code is None:
+        return
     if mode in {'exec', 'single'}:
         func = exec
     else:


### PR DESCRIPTION
I think this might have been a merge failure on my part (with #757), but an old issue has crept back in, whereby if a user has an empty `.xonshrc` file (rather than no `.xonshrc` at all), xonsh will crash immediately on startup.  This small patch should avoid that issue.