### PR TITLE
Add option to prevent config wizard starting every time xonsh is run

### DIFF
--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -214,7 +214,7 @@ class StateFile(Input):
 
     attrs = ('default_file', 'check')
 
-    def __init__(self, default_file=None, check=True):
+    def __init__(self, default_file=None, check=True, ask=True):
         """
         Parameters
         ----------
@@ -224,10 +224,14 @@ class StateFile(Input):
             Whether to print the current state and ask if it should be
             saved/loaded prior to asking for the file name and saving the
             file, default=True.
+        ask : bool, optional
+            Whether to ask for the filename (if ``False``, always use the
+            default filename)
         """
         self._df = None
         super().__init__(prompt='filename: ', converter=None,
                          confirm=False, path=None)
+        self.ask_filename = ask
         self.default_file = default_file
         self.check = check
 
@@ -604,7 +608,9 @@ class PromptVisitor(StateVisitor):
             do_save = self.visit(asker)
             if not do_save:
                 return Unstorable
-        fname = self.visit_input(node)
+        fname = None
+        if node.ask_filename:
+            fname = self.visit_input(node)
         if fname is None or len(fname) == 0:
             fname = node.default_file
         if os.path.isfile(fname):

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -224,7 +224,7 @@ class StateFile(Input):
             Whether to print the current state and ask if it should be
             saved/loaded prior to asking for the file name and saving the
             file, default=True.
-        ask : bool, optional
+        ask_filename : bool, optional
             Whether to ask for the filename (if ``False``, always use the
             default filename)
         """

--- a/xonsh/wizard.py
+++ b/xonsh/wizard.py
@@ -212,9 +212,9 @@ class StateFile(Input):
     given file name. This node type is likely not useful on its own.
     """
 
-    attrs = ('default_file', 'check')
+    attrs = ('default_file', 'check', 'ask_filename')
 
-    def __init__(self, default_file=None, check=True, ask=True):
+    def __init__(self, default_file=None, check=True, ask_filename=True):
         """
         Parameters
         ----------
@@ -231,7 +231,7 @@ class StateFile(Input):
         self._df = None
         super().__init__(prompt='filename: ', converter=None,
                          confirm=False, path=None)
-        self.ask_filename = ask
+        self.ask_filename = ask_filename
         self.default_file = default_file
         self.check = check
 
@@ -388,8 +388,8 @@ class PrettyFormatter(Visitor):
         return s
 
     def visit_statefile(self, node):
-        s = '{0}(default_file={1!r}, check={2})'
-        s = s.format(node.__class__.__name__, node.default_file, node.check)
+        s = '{0}(default_file={1!r}, check={2}, ask_filename={3})'
+        s = s.format(node.__class__.__name__, node.default_file, node.check, node.ask_filename)
         return s
 
     def visit_while(self, node):

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -281,7 +281,7 @@ def make_wizard(default_file=None, confirm=False):
              "\n\n1, 2, or 3 [default: 2]? ")
         passer = Pass()
         saver = Save(check=False, ask=False, default_file=default_file)
-        wiz = Question(q, {1: wiz, 2: Pass(), 3: saver},
+        wiz = Question(q, {1: wiz, 2: passer, 3: saver},
                        converter=lambda x: int(x.strip()) if x !='' else 2)
     return wiz
 

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -1,4 +1,5 @@
 """The xonsh configuration (xonfig) utility."""
+import os
 import ast
 import json
 import shutil
@@ -20,7 +21,8 @@ from xonsh.environ import is_template_string
 from xonsh.shell import (is_readline_available, is_prompt_toolkit_available,
     prompt_toolkit_version)
 from xonsh.wizard import (Wizard, Pass, Message, Save, Load, YesNo, Input,
-    PromptVisitor, While, StoreNonEmpty, create_truefalse_cond, YN, Unstorable)
+    PromptVisitor, While, StoreNonEmpty, create_truefalse_cond, YN, Unstorable,
+    Question)
 from xonsh.xontribs import xontrib_metadata, find_xontrib
 
 
@@ -274,8 +276,13 @@ def make_wizard(default_file=None, confirm=False):
             Message(message=WIZARD_TAIL),
             ])
     if confirm:
-        q = 'Would you like to run the xonsh configuration wizard now, ' + YN
-        wiz = YesNo(question=q, yes=wiz, no=Pass())
+        q = ("Would you like to run the xonsh configuration wizard now?\n\n"
+             "1. Yes\n2. No, but ask me later.\n3. No, and don't ask me again."
+             "\n\n1, 2, or 3 [default: 2]? ")
+        passer = Pass()
+        saver = Save(check=False, ask=False, default_file=default_file)
+        wiz = Question(q, {1: wiz, 2: Pass(), 3: saver},
+                       converter=lambda x: int(x.strip()) if x !='' else 2)
     return wiz
 
 

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -280,9 +280,9 @@ def make_wizard(default_file=None, confirm=False):
              "1. Yes\n2. No, but ask me later.\n3. No, and don't ask me again."
              "\n\n1, 2, or 3 [default: 2]? ")
         passer = Pass()
-        saver = Save(check=False, ask=False, default_file=default_file)
+        saver = Save(check=False, ask_filename=False, default_file=default_file)
         wiz = Question(q, {1: wiz, 2: passer, 3: saver},
-                       converter=lambda x: int(x.strip()) if x !='' else 2)
+                       converter=lambda x: int(x) if x != '' else 2)
     return wiz
 
 


### PR DESCRIPTION
This patch changes the question that is asked when a user starts xonsh with no configuration files to allow a third option (specifically, the option not to run the wizard now _or ever_).

When I was doing some testing after removing my `.xonshrc` file, I found it a little annoying that I was asked whether I wanted to run the wizard every time I opened a new terminal.  I'm not sure if I'm alone in this (if so, or if there is a better way to implement this, we can close this PR).

I suppose it is a little bit dangerous as written, as it will blow away an existing config file if one exists _and_ for some reason the wizard is run with `confirm=True` _and_ the user chooses option 3.  But I imagine it would be hard to do that acidentally, and xonsh backs up the old file anyway, so I don't think that's a concern.