### PR TITLE
Proposal: Syntax Changes (from #921)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Current Developments
 
 * When a subprocess exits with a signal (e.g. SIGSEGV), a message is printed,
   similar to Bash.
+* ``@$(cmd)`` has been added as a subprocess-mode operator, which replaces in
+  the subprocess command itself with the result of running ``cmd``.
 
 **Changed:** None
 

--- a/docs/bash_to_xsh.rst
+++ b/docs/bash_to_xsh.rst
@@ -19,11 +19,10 @@ will help you put a finger on how to do the equivelent task in xonsh.
       - Look up an environment variable via another variable name. In xonsh,
         this may be any valid expression.
     * - ``$(cmd args)`` or ```cmd args```
-      - ``$(cmd args)``
-      - Use the ``$()`` operator to capture subprocesses as strings. Bash's
-        version of (now-deprecated) backticks is not supported. Note that
-        Bash will automatically tokenize the string, while xonsh just returns
-        a str of stdout.
+      - ``@$(cmd args)``
+      - Command substitution (allow the output of a command to replace the
+        command itself).  Tokenizes and executes the output of a subprocess
+        command as another subprocess.
     * - ``set -e``
       - ``$RAISE_SUBPROC_ERROR = True``
       - Cause a failure after a non-zero return code. Xonsh will raise a

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -459,6 +459,10 @@ feed them to a subprocess as needed.  For example:
     for i in range(20):
         $[touch @('file%02d' % i)]
 
+.. note:: A common use of the ``@()`` operator is allowing the output of a
+          command to replace the command itself (command substitution):
+          ``@([i.strip() for i in $(cmd).split()])``.  Xonsh offers a
+          short-hand syntax for this operation: ``@$(cmd)``.
 
 Nesting Subprocesses
 =====================================

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -134,11 +134,23 @@ def test_multiline():
            ('NAME', 'y', 0),]
     yield check_tokens, inp, exp
 
+def test_atdollar_expression():
+    inp = '@$(which python)'
+    exp = [('ATDOLLAR_LPAREN', '@$(', 0),
+           ('NAME', 'which', 3),
+           ('WS', ' ', 8),
+           ('NAME', 'python', 9),
+           ('RPAREN', ')', 15)]
+    yield check_tokens, inp, exp
+
 def test_and():
     yield check_token, 'and', ['AND', 'and', 0]
 
 def test_ampersand():
     yield check_token, '&', ['AMPERSAND', '&', 0]
+
+def test_atdollar():
+    yield check_token, '@$', ['ATDOLLAR', '@$', 0]
 
 def test_doubleamp():
     yield check_token, '&&', ['AND', 'and', 0]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1622,6 +1622,12 @@ def test_backtick():
 def test_ls_regex_octothorpe():
     yield check_xonsh_ast, {}, '$(ls `#[Ff]+i*LE` -l)', False
 
+def test_injection():
+    yield check_xonsh_ast, {}, '$[@$(which python)]', False
+
+def test_rhs_nested_injection():
+    yield check_xonsh_ast, {}, '$[ls @$(dirname @$(which python))]', False
+
 def test_backtick_octothorpe():
     yield check_xonsh_ast, {}, 'print(`#.*`)', False
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -649,6 +649,12 @@ def subproc_captured_stdout(*cmds):
     return run_subproc(cmds, captured='stdout')
 
 
+def subproc_captured_inject(*cmds):
+    """Runs a subprocess, capturing the output. Returns a list of
+    whitespace-separated strings in the stdout that was produced."""
+    return [i.strip() for i in run_subproc(cmds, captured='stdout').split()]
+
+
 def subproc_captured_object(*cmds):
     """
     Runs a subprocess, capturing the output. Returns an instance of
@@ -707,6 +713,7 @@ def load_builtins(execer=None, config=None, login=False, ctx=None):
         builtins.__xonsh_pyquit__ = builtins.quit
         del builtins.quit
     builtins.__xonsh_subproc_captured_stdout__ = subproc_captured_stdout
+    builtins.__xonsh_subproc_captured_inject__ = subproc_captured_inject
     builtins.__xonsh_subproc_captured_object__ = subproc_captured_object
     builtins.__xonsh_subproc_captured_hiddenobject__ = subproc_captured_hiddenobject
     builtins.__xonsh_subproc_uncaptured__ = subproc_uncaptured
@@ -766,6 +773,7 @@ def unload_builtins():
              '__xonsh_pyexit__',
              '__xonsh_pyquit__',
              '__xonsh_subproc_captured_stdout__',
+             '__xonsh_subproc_captured_inject__',
              '__xonsh_subproc_captured_object__',
              '__xonsh_subproc_captured_hiddenobject__',
              '__xonsh_subproc_uncaptured__',

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -218,6 +218,28 @@ def handle_dollar(state, token):
         yield _new_token("ERRORTOKEN", m, token.start)
 
 
+def handle_atdollar(state, token):
+    """
+    Function for generating PLY tokens associated with ``@$``.
+    """
+    n = next(state['stream'], None)
+
+    if n is None:
+        state['last'] = token
+        m = "missing token after @$"
+        yield _new_token("ERRORTOKEN", m, token.start)
+    elif n.type == tokenize.OP and n.string == '(' and \
+            n.start == token.end:
+        state['pymode'].append((False, '@$(', ')', token.start))
+        state['last'] = n
+        yield _new_token('ATDOLLAR_LPAREN', '@$(', token.start)
+    else:
+        state['last'] = token
+        yield _new_token('ATDOLLAR', '@$', token.start)
+        yield from handle_token(state, n)
+
+
+
 def handle_at(state, token):
     """
     Function for generating PLY tokens associated with ``@``.
@@ -401,6 +423,7 @@ special_handlers = {
     (tokenize.OP, '}'): handle_rbrace,
     (tokenize.OP, '['): handle_lbracket,
     (tokenize.OP, ']'): handle_rbracket,
+    (tokenize.OP, '@$'): handle_atdollar,
     (tokenize.ERRORTOKEN, '$'): handle_dollar,
     (tokenize.ERRORTOKEN, '?'): handle_question,
     (tokenize.ERRORTOKEN, '!'): handle_bang,
@@ -556,4 +579,6 @@ class Lexer(object):
         'DOLLAR_LPAREN',         # $(
         'DOLLAR_LBRACE',         # ${
         'DOLLAR_LBRACKET',       # $[
+        'ATDOLLAR',              # @$
+        'ATDOLLAR_LPAREN',       # @$(
     ) + tuple(i.upper() for i in kwlist)

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -156,6 +156,7 @@ def _make_special_handler(token_type, extra_check=lambda x: True):
 handle_number = _make_special_handler('NUMBER')
 """Function for handling number tokens"""
 
+
 def handle_ampersands(state, token):
     """Function for generating PLY tokens for single and double ampersands."""
     n = next(state['stream'], None)
@@ -239,7 +240,6 @@ def handle_atdollar(state, token):
         yield from handle_token(state, n)
 
 
-
 def handle_at(state, token):
     """
     Function for generating PLY tokens associated with ``@``.
@@ -283,13 +283,13 @@ def handle_bang(state, token):
     Function for generating PLY tokens starting with !
     """
     n = next(state['stream'], None)
-    if (n is not None and n.type == tokenize.OP
-            and n.string == '(' and n.start == token.end):
+    if (n is not None and n.type == tokenize.OP and
+            n.string == '(' and n.start == token.end):
         state['pymode'].append((False, '!(', ')', token.start))
         state['last'] = n
         yield _new_token('BANG_LPAREN', '!(', token.start)
-    elif (n is not None and n.type == tokenize.OP
-            and n.string == '[' and n.start == token.end):
+    elif (n is not None and n.type == tokenize.OP and
+            n.string == '[' and n.start == token.end):
         state['pymode'].append((False, '![', ']', token.start))
         state['last'] = n
         yield _new_token('BANG_LBRACKET', '![', token.start)

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2174,7 +2174,7 @@ class BaseParser(object):
         p1 = p[1]
         p0 = xonsh_call('__xonsh_subproc_captured_stdout__', args=p[2],
                         lineno=p1.lineno, col=p1.lexpos)
-        p0._cliarg_action = 'splitlines'
+        p0._cliarg_action = 'append'
         p[0] = p0
 
     def p_subproc_atom_pyenv_lookup(self, p):
@@ -2194,6 +2194,13 @@ class BaseParser(object):
     def p_subproc_atom_pyeval(self, p):
         """subproc_atom : AT_LPAREN test RPAREN"""
         p0 = xonsh_call('__xonsh_ensure_list_of_strs__', [p[2]],
+                        lineno=self.lineno, col=self.col)
+        p0._cliarg_action = 'extend'
+        p[0] = p0
+
+    def p_subproc_atom_subproc_inject(self, p):
+        """subproc_atom : ATDOLLAR_LPAREN subproc RPAREN"""
+        p0 = xonsh_call('__xonsh_subproc_captured_inject__', p[2],
                         lineno=self.lineno, col=self.col)
         p0._cliarg_action = 'extend'
         p[0] = p0
@@ -2265,6 +2272,7 @@ class BaseParser(object):
                             | PLUS
                             | COLON
                             | AT
+                            | ATDOLLAR
                             | EQUALS
                             | TIMES
                             | POW
@@ -2277,6 +2285,8 @@ class BaseParser(object):
                             | FALSE
                             | NUMBER
                             | STRING
+                            | QUESTION
+                            | COMMA
         """
         # Many tokens cannot be part of this list, such as $, ', ", ()
         # Use a string atom instead.

--- a/xonsh/pyghooks.py
+++ b/xonsh/pyghooks.py
@@ -33,6 +33,7 @@ ROOT_TOKENS = [(r'\?', Keyword),
                (r'\$\{', Keyword, ('pymode', )),
                (r'[\!\$]\(', Keyword, ('subproc', )),
                (r'[\!\$]\[', Keyword, ('subproc', )),
+               (r'@\$\(', Keyword, ('subproc', )),
                (r'@\(', Keyword, ('pymode', )),
                inherit, ]
 

--- a/xonsh/tokenize/tokenize_34.py
+++ b/xonsh/tokenize/tokenize_34.py
@@ -4,7 +4,8 @@ This file is a modified version of tokenize.py form the Python 3.4 standard
 library (licensed under the Python Software Foundation License, version 2),
 which provides tokenization help for Python programs.
 
-It is modified to properly tokenize xonsh's backtick operator.
+It is modified to properly tokenize xonsh's backtick operator and to support
+the @$ operator.
 
 Original file credits:
    __author__ = 'Ka-Ping Yee <ping@lfw.org>'
@@ -27,7 +28,7 @@ blank_re = re.compile(br'^[ \t\f]*(?:[#\r\n]|$)', re.ASCII)
 import token
 __all__ = token.__all__ + ["COMMENT", "tokenize", "detect_encoding",
                            "NL", "untokenize", "ENCODING", "TokenInfo",
-                           "REGEXPATH", "TokenError"]
+                           "REGEXPATH", "ATDOLLAR", "TokenError"]
 del token
 
 COMMENT = N_TOKENS
@@ -39,6 +40,9 @@ tok_name[ENCODING] = 'ENCODING'
 N_TOKENS += 3
 REGEXPATH = N_TOKENS
 tok_name[REGEXPATH] = 'REGEXPATH'
+N_TOKENS += 1
+ATDOLLAR = N_TOKENS
+tok_name[ATDOLLAR] = 'ATDOLLAR'
 N_TOKENS += 1
 EXACT_TOKEN_TYPES = {
     '(':   LPAR,
@@ -83,7 +87,8 @@ EXACT_TOKEN_TYPES = {
     '**=': DOUBLESTAREQUAL,
     '//':  DOUBLESLASH,
     '//=': DOUBLESLASHEQUAL,
-    '@':   AT
+    '@':   AT,
+    '@$':  ATDOLLAR,
 }
 
 class TokenInfo(collections.namedtuple('TokenInfo', 'type string start end line')):
@@ -146,7 +151,7 @@ RegexPath = r"`[^\n`\\]*(?:\\.[^\n`\\]*)*`"
 Operator = group(r"\*\*=?", r">>=?", r"<<=?", r"!=",
                  r"//=?", r"->",
                  r"[+\-*/%&|^=<>]=?",
-                 r"~")
+                 r"~", r"@\$")
 
 Bracket = '[][(){}]'
 Special = group(r'\r?\n', r'\.\.\.', r'[:;.,@]')

--- a/xonsh/tokenize/tokenize_35.py
+++ b/xonsh/tokenize/tokenize_35.py
@@ -4,7 +4,8 @@ This file is a modified version of tokenize.py form the Python 3.5 standard
 library (licensed under the Python Software Foundation License, version 2),
 which provides tokenization help for Python programs.
 
-It is modified to properly tokenize xonsh's backtick operator.
+It is modified to properly tokenize xonsh's backtick operator and to support
+the @$ operator.
 
 Original file credits:
    __author__ = 'Ka-Ping Yee <ping@lfw.org>'
@@ -28,7 +29,7 @@ blank_re = re.compile(br'^[ \t\f]*(?:[#\r\n]|$)', re.ASCII)
 import token
 __all__ = token.__all__ + ["COMMENT", "tokenize", "detect_encoding",
                            "NL", "untokenize", "ENCODING", "TokenInfo",
-                           "REGEXPATH", "TokenError"]
+                           "REGEXPATH", "ATDOLLAR", "TokenError"]
 del token
 
 COMMENT = N_TOKENS
@@ -40,6 +41,9 @@ tok_name[ENCODING] = 'ENCODING'
 N_TOKENS += 3
 REGEXPATH = N_TOKENS
 tok_name[REGEXPATH] = 'REGEXPATH'
+N_TOKENS += 1
+ATDOLLAR = N_TOKENS
+tok_name[ATDOLLAR] = 'ATDOLLAR'
 N_TOKENS += 1
 EXACT_TOKEN_TYPES = {
     '(':   LPAR,
@@ -86,6 +90,7 @@ EXACT_TOKEN_TYPES = {
     '//=': DOUBLESLASHEQUAL,
     '@':   AT,
     '@=':  ATEQUAL,
+    '@$':  ATDOLLAR,
 }
 
 class TokenInfo(collections.namedtuple('TokenInfo', 'type string start end line')):
@@ -148,7 +153,7 @@ RegexPath = r"`[^\n`\\]*(?:\\.[^\n`\\]*)*`"
 Operator = group(r"\*\*=?", r">>=?", r"<<=?", r"!=",
                  r"//=?", r"->",
                  r"[+\-*/%&@|^=<>]=?",
-                 r"~")
+                 r"~", r"@\$")
 
 Bracket = '[][(){}]'
 Special = group(r'\r?\n', r'\.\.\.', r'[:;.,@]')

--- a/xonsh/tokenize/tokenize_35.py
+++ b/xonsh/tokenize/tokenize_35.py
@@ -151,9 +151,9 @@ RegexPath = r"`[^\n`\\]*(?:\\.[^\n`\\]*)*`"
 # longest operators first (e.g., if = came before ==, == would get
 # recognized as two instances of =).
 Operator = group(r"\*\*=?", r">>=?", r"<<=?", r"!=",
-                 r"//=?", r"->",
+                 r"//=?", r"->", r"@\$",
                  r"[+\-*/%&@|^=<>]=?",
-                 r"~", r"@\$")
+                 r"~")
 
 Bracket = '[][(){}]'
 Special = group(r'\r?\n', r'\.\.\.', r'[:;.,@]')

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -56,7 +56,7 @@ DefaultNotGiven = DefaultNotGivenType()
 
 BEG_TOK_SKIPS = frozenset(['WS', 'INDENT', 'NOT', 'LPAREN'])
 END_TOK_TYPES = frozenset(['SEMI', 'AND', 'OR', 'RPAREN'])
-LPARENS = frozenset(['LPAREN', 'AT_LPAREN', 'BANG_LPAREN', 'DOLLAR_LPAREN'])
+LPARENS = frozenset(['LPAREN', 'AT_LPAREN', 'BANG_LPAREN', 'DOLLAR_LPAREN', 'ATDOLLAR_LPAREN'])
 
 def _is_not_lparen_and_rparen(lparens, rtok):
     """Tests if an RPAREN token is matched with something other than a plain old


### PR DESCRIPTION
Per the discussion in  #921, this changeset introduces a couple of changes to the syntax of the xonsh language, relating to the handling of subprocess args:

* `$(cmd)` ~~is unchanged~~ now _always_ gives the whole string as a single element, even in subproc mode
* `?(cmd)` does the super-captured subproc (with return code, etc)
* `!(cmd)` does, effectively: `@([i.strip() for i in $(cmd).split()])`

Quoting a relevant piece of that discussion:

> That said, no matter what, it still feels a little painful to me to have to call two functions to inject output back into the command line: @($(which python)), not to mention the need for strip. I'm not sure what that syntax would be, but it would be nice if this could be done in a single operation.

>Really, I would vote for !(...) having this property, and ?(...) being introduced to replace the super-captured subproc calls we have now. To me, ! says "do this" in a way that feels like it matches @($(...)); and ? says, "tell me some information about this."


Of course, this is a big and backward-incompatible change, so this is open for discussion.

I updated the docs and existing tests, but I have not yet added documentation or tests for the new syntax.  The changes that are actually meaningful are in `execer.py`, `lexer.py`, `parsers/base.py`, `built_ins.py`, and `tools.py`.