### PR TITLE
Adding xontrib-prompt-ret-code extension

### DIFF
--- a/xonsh/xontribs.json
+++ b/xonsh/xontribs.json
@@ -4,7 +4,13 @@
   "url": "http://xon.sh",
   "description": ["Matplotlib hooks for xonsh, including the new 'mpl' alias ",
                   "that displays the current figure on the screen."]
+  },
+ {"name": "prompt_ret_code",
+  "package": "xontrib-prompt-ret-code",
+  "url": "https://github.com/Siecje/xontrib-prompt-ret-code",
+  "description": ["Adds return code info to the prompt"]
   }
+
  ],
  "packages": {
   "xonsh": {
@@ -15,6 +21,12 @@
     "pip": "pip install xonsh",
     "aura": "sudo aura -A xonsh",
     "yaourt": "yaourt -Sa xonsh"}
+   },
+  "xontrib-prompt-ret-code": {
+   "license": "MIT",
+   "url": "https://github.com/Siecje/xontrib-prompt-ret-code",
+   "install": {
+    "pip": "pip install xontrib-prompt-ret-code"
    }
  }
 }


### PR DESCRIPTION
What is the difference between ```name``` and ```package```?

Currently package is the Python package name to install with pip.
The name is the name of the new module that will be added to ```xontrib```.

Ref: https://github.com/scopatz/xonsh/pull/816