### PR TITLE
Fix many logic issues with xontribs

### DIFF
--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -662,7 +662,7 @@ def ensure_list_of_strs(x):
     return rtn
 
 
-def load_builtins(execer=None, config=None, login=False):
+def load_builtins(execer=None, config=None, login=False, ctx=None):
     """Loads the xonsh builtins into the Python builtins. Sets the
     BUILTINS_LOADED variable to True.
     """
@@ -670,7 +670,7 @@ def load_builtins(execer=None, config=None, login=False):
     # private built-ins
     builtins.__xonsh_config__ = {}
     builtins.__xonsh_env__ = ENV = Env(default_env(config=config, login=login))
-    builtins.__xonsh_ctx__ = {}
+    builtins.__xonsh_ctx__ = {} if ctx is None else ctx
     builtins.__xonsh_help__ = helper
     builtins.__xonsh_superhelp__ = superhelper
     builtins.__xonsh_regexpath__ = regexpath

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -18,7 +18,7 @@ class Execer(object):
     """Executes xonsh code in a context."""
 
     def __init__(self, filename='<xonsh-code>', debug_level=0, parser_args=None,
-                 unload=True, config=None, login=True):
+                 unload=True, config=None, login=True, xonsh_ctx=None):
         """Parameters
         ----------
         filename : str, optional
@@ -31,6 +31,8 @@ class Execer(object):
             Whether or not to unload xonsh builtins upon deletion.
         config : str, optional
             Path to configuration file.
+        xonsh_ctx : dict or None, optional
+            Xonsh xontext to load as builtins.__xonsh_ctx__
         """
         parser_args = parser_args or {}
         self.parser = Parser(**parser_args)
@@ -38,7 +40,7 @@ class Execer(object):
         self.debug_level = debug_level
         self.unload = unload
         self.ctxtransformer = ast.CtxAwareTransformer(self.parser)
-        load_builtins(execer=self, config=config, login=login)
+        load_builtins(execer=self, config=config, login=login, ctx=xonsh_ctx)
 
     def __del__(self):
         if self.unload:

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -206,8 +206,8 @@ def premain(argv=None):
         args.mode = XonshMode.interactive
         shell_kwargs['completer'] = True
         shell_kwargs['login'] = True
-    shell = builtins.__xonsh_shell__ = Shell(**shell_kwargs)
     from xonsh import imphooks
+    shell = builtins.__xonsh_shell__ = Shell(**shell_kwargs)
     env = builtins.__xonsh_env__
     env['XONSH_LOGIN'] = shell_kwargs['login']
     if args.defines is not None:

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -118,20 +118,17 @@ class Shell(object):
         return getattr(self.shell, attr)
 
     def _init_environ(self, ctx, config, rc, scriptcache, cacheall):
-        self.execer = Execer(config=config, login=self.login)
+        self.ctx = {} if ctx is None else ctx
+        self.execer = Execer(config=config, login=self.login, xonsh_ctx=self.ctx)
         self.execer.scriptcache = scriptcache
         self.execer.cacheall = cacheall
-        if ctx is None:
-            self.ctx = {}
-            if self.stype != 'none' or self.login:
-                names = builtins.__xonsh_config__.get('xontribs', ())
-                for name in names:
-                    xontribs.update_context(name, ctx=self.ctx)
-                # load run contol files
-                env = builtins.__xonsh_env__
-                rc = env.get('XONSHRC') if rc is None else rc
-                self.ctx.update(xonshrc_context(rcfiles=rc, execer=self.execer))
-        else:
-            self.ctx = ctx
-        builtins.__xonsh_ctx__ = self.ctx
+        if ctx is None and (self.stype != 'none' or self.login):
+            # load xontribs from config file
+            names = builtins.__xonsh_config__.get('xontribs', ())
+            for name in names:
+                xontribs.update_context(name, ctx=self.ctx)
+            # load run contol files
+            env = builtins.__xonsh_env__
+            rc = env.get('XONSHRC') if rc is None else rc
+            self.ctx.update(xonshrc_context(rcfiles=rc, execer=self.execer))
         self.ctx['__name__'] = '__main__'

--- a/xonsh/xontribs.py
+++ b/xonsh/xontribs.py
@@ -4,7 +4,7 @@ import sys
 import json
 import builtins
 import functools
-from warnings import warn
+from warnings import warn, catch_warnings, simplefilter
 from argparse import ArgumentParser
 from importlib import import_module
 from importlib.util import find_spec
@@ -27,7 +27,9 @@ def xontrib_context(name):
     """Return a context dictionary for a xontrib of a given name."""
     spec = find_xontrib(name)
     if spec is None:
-        warn('could not find xontrib module {0!r}'.format(name), ImportWarning)
+        with catch_warnings():
+            simplefilter('default', ImportWarning)
+            warn('could not find xontrib module {0!r}'.format(name), ImportWarning)
         return {}
     m = import_module(spec.name)
     ctx = {k: getattr(m, k) for k in dir(m) if not k.startswith('_')}


### PR DESCRIPTION
Thanks to @Siecje, I found many logic issues with the xontribs module:

1. Inability to import *.xsh files before the Shell was initialized (ie in the config or rc files)
2. Import warnings were silently suppressed by default
3. xontrib context would be overwritten as `__xonsh_ctx__` by the time the actual prompt was reached.

This should clear all of these up.