### PR TITLE
Which updates

### DIFF
--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -85,7 +85,7 @@ class TestWhich:
         arg = 'whichtestapp1'
         matches = list(_which.whichgen(arg, path=[testdir]))
         assert len(matches) == 1
-        assert self._file_match(matches[0], os.path.join(testdir, arg))
+        assert self._file_match(matches[0][0], os.path.join(testdir, arg))
 
     def test_whichgen_failure(self):
         testdir = self.testdirs[0].name
@@ -108,8 +108,8 @@ class TestWhich:
         arg = 'whichtestapp1'
         matches = list(_which.whichgen(arg, path=[testdir0, testdir1]))
         assert len(matches) == 2
-        assert self._file_match(matches[0], os.path.join(testdir0, arg))
-        assert self._file_match(matches[1], os.path.join(testdir1, arg))
+        assert self._file_match(matches[0][0], os.path.join(testdir0, arg))
+        assert self._file_match(matches[1][0], os.path.join(testdir1, arg))
 
     if ON_WINDOWS:
         def test_whichgen_ext_failure(self):
@@ -123,7 +123,7 @@ class TestWhich:
                 arg = 'whichtestapp2'
                 matches = list(_which.whichgen(arg, path=[testdir], exts = ['.wta']))
                 assert len(matches) == 1
-                assert self._file_match(matches[0], os.path.join(testdir, arg))
+                assert self._file_match(matches[0][0], os.path.join(testdir, arg))
 
     def _file_match(self, path1, path2):
         if ON_WINDOWS:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -357,11 +357,15 @@ def which(args, stdin=None, stdout=None, stderr=None):
                         help='Show all matches in $PATH and xonsh.aliases')
     parser.add_argument('-s', '--skip-alias', action='store_true',
                         help='Do not search in xonsh.aliases', dest='skip')
-    parser.add_argument('-V', '--version', action='version',
-                        version='{}'.format(_which.__version__))
-    parser.add_argument('-v', '--verbose', action='store_true', dest='verbose')
+    parser.add_argument('-V', '-v', '--version', action='version',
+                        version='{}'.format(_which.__version__),
+                        help='Display the version of the python which module '
+                        'used by xonsh')
+    parser.add_argument('--verbose', action='store_true', dest='verbose',
+                        help='Show extra information on for example near misses')
     parser.add_argument('-p', '--plain', action='store_true', dest='plain',
-                        help='Do not display alias expansions')
+                        help='Do not display alias expansions or location of '
+                             'where binaries are found.')
     parser.add_argument('--very-small-rocks', action=AWitchAWitch)
     if ON_WINDOWS:
         parser.add_argument('-e', '--exts', nargs='*', type=str,
@@ -377,7 +381,7 @@ def which(args, stdin=None, stdout=None, stderr=None):
         parser.print_usage(file=stderr)
         return -1
     pargs = parser.parse_args(args)
-    
+
     if ON_WINDOWS:
         if pargs.exts:
             exts = pargs.exts
@@ -398,9 +402,9 @@ def which(args, stdin=None, stdout=None, stderr=None):
             nmatches += 1
             if not pargs.all:
                 continue
-        for match in _which.whichgen(arg, path=builtins.__xonsh_env__['PATH'],
-                                     exts=exts, verbose=pargs.verbose):
-            abs_name, from_where = match if pargs.verbose else (match, '')
+        macthes = _which.whichgen(arg, exts=exts, verbose=pargs.verbose,
+                                  path=builtins.__xonsh_env__['PATH'])
+        for abs_name, from_where in macthes:
             if ON_WINDOWS:
                 # Use list dir to get correct case for the filename
                 # i.e. windows is case insesitive but case preserving
@@ -409,8 +413,8 @@ def which(args, stdin=None, stdout=None, stderr=None):
                 abs_name = os.path.join(p, f)
                 if builtins.__xonsh_env__.get('FORCE_POSIX_PATHS', False):
                     abs_name.replace(os.sep, os.altsep)
-            if pargs.verbose:
-                print('{} ({})'.format(abs_name, from_where), file=stdout)
+            if not pargs.plain:
+                print('{} -> ({})'.format(abs_name, from_where), file=stdout)
             else:
                 print(abs_name, file=stdout)
             nmatches += 1

--- a/xonsh/xoreutils/_which.py
+++ b/xonsh/xoreutils/_which.py
@@ -84,8 +84,7 @@ _cmdlnUsage = """
     files without executable access.
 """
 
-__revision__ = "$Id: which.py 1448 2007-02-28 19:13:06Z trentm $"
-__version_info__ = (1, 1, 3)
+__version_info__ = (1, 2, 0)
 __version__ = '.'.join(map(str, __version_info__))
 __all__ = ["which", "whichall", "whichgen", "WhichError"]
 


### PR DESCRIPTION
This updates the `which` alias so both '-v/-V/--version' triggers the version output. Similar to gnu-which. 

It also makes it the default to show where binaries are found, similar to how we by default show where aliases come from: 
``` bash
snail@sea ~ $ which ipconfig
C:\Windows\system32\ipconfig.exe -> (from given path element 6)
snail@sea ~ $ which ls
ls -> ['ls', '--show-control-chars', '--color', '-X']
```
 The `-p/--pain` can still be used to hide this. 

```bash
snail@sea ~ $ which ipconfig -p
C:\Windows\system32\ipconfig.exe
snail@sea ~ $ which ls -p
ls
```

The `-a/--all` option is unchanged. 
```bash
snail@sea ~ $ which ls -a
ls -> ['ls', '--show-control-chars', '--color', '-X']
C:\Program Files\Git\usr\bin\ls.exe -> (from given path element 17)
```

The `--verbose` has a much more limited functionality now. It will report on duplicates and near misses (files that are not executable on posix). 

The PR also updates `whichgen()` from the `_which.py` module to always return tuples of (<path to command>, <where path found>). This is just an internal thing, that made it possible to change the functionality of the `--verbose` 