### PR TITLE
fix broken imports in certain tests

### DIFF
--- a/tests/test_environ.py
+++ b/tests/test_environ.py
@@ -11,7 +11,7 @@ from nose.tools import (assert_equal, assert_true, assert_not_in,
 
 from xonsh.environ import Env, format_prompt, load_static_config
 
-from tests.tools import mock_xonsh_env
+from tools import mock_xonsh_env
 
 def test_env_normal():
     env = Env(VAR='wakka')

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -16,7 +16,7 @@ from xonsh.lazyjson import LazyJSON
 from xonsh.history import History
 from xonsh import history
 
-from tests.tools import mock_xonsh_env
+from tools import mock_xonsh_env
 
 HIST_TEST_KWARGS = dict(sessionid='SESSIONID', gc=False)
 

--- a/tests/test_imphooks.py
+++ b/tests/test_imphooks.py
@@ -10,7 +10,7 @@ from xonsh import built_ins
 from xonsh.execer import Execer
 from xonsh.built_ins import load_builtins, unload_builtins
 
-from tests.tools import mock_xonsh_env
+from tools import mock_xonsh_env
 LOADED_HERE = False
 
 def setup():

--- a/tests/test_man.py
+++ b/tests/test_man.py
@@ -8,7 +8,7 @@ from nose.plugins.skip import SkipTest
 from xonsh.tools import ON_WINDOWS
 from xonsh.completer import ManCompleter
 
-from tests.tools import mock_xonsh_env
+from tools import mock_xonsh_env
 
 _OLD_MANPATH = None
 


### PR DESCRIPTION
these were introduced in a few places but there is no __init__.py file
in the tests directory so the import breaks (at least on my machine)