### PR TITLE
Which updates

### DIFF
--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -362,12 +362,13 @@ def which(args, stdin=None, stdout=None, stderr=None):
                         help='Display the version of the python which module '
                         'used by xonsh')
     parser.add_argument('-v', '--verbose', action='store_true', dest='verbose',
-                        help='Show extra information on for example near misses')
+                        help='Print out how matches were located and show '
+                        'near misses on stderr')
     parser.add_argument('-p', '--plain', action='store_true', dest='plain',
                         help='Do not display alias expansions or location of '
-                             'where binaries are found. This the default '
-                             'but can be used to override the --verbose '
-                             'the verbose option')
+                             'where binaries are found. This is the '
+                             'default behavior, but the option can be used to '
+                             'override the --verbose option')
     parser.add_argument('--very-small-rocks', action=AWitchAWitch)
     if ON_WINDOWS:
         parser.add_argument('-e', '--exts', nargs='*', type=str,
@@ -406,7 +407,7 @@ def which(args, stdin=None, stdout=None, stderr=None):
                 else:
                     print(arg, file=stdout)
             else:
-                print('{} -> {}'.format(arg, builtins.aliases[arg]), file=stdout)
+                print("aliases['{}'] = {}".format(arg, builtins.aliases[arg]), file=stdout)
             nmatches += 1
             if not pargs.all:
                 continue
@@ -424,7 +425,9 @@ def which(args, stdin=None, stdout=None, stderr=None):
             if pargs.plain or not pargs.verbose:
                 print(abs_name, file=stdout)
             else:
-                print('{} -> ({})'.format(abs_name, from_where), file=stdout)
+                if 'given path element' in from_where:
+                    from_where = from_where.replace('given path', '$PATH')
+                print('{} ({})'.format(abs_name, from_where), file=stdout)
             nmatches += 1
             if not pargs.all:
                 break

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -357,15 +357,17 @@ def which(args, stdin=None, stdout=None, stderr=None):
                         help='Show all matches in $PATH and xonsh.aliases')
     parser.add_argument('-s', '--skip-alias', action='store_true',
                         help='Do not search in xonsh.aliases', dest='skip')
-    parser.add_argument('-V', '-v', '--version', action='version',
+    parser.add_argument('-V', '--version', action='version',
                         version='{}'.format(_which.__version__),
                         help='Display the version of the python which module '
                         'used by xonsh')
-    parser.add_argument('--verbose', action='store_true', dest='verbose',
+    parser.add_argument('-v', '--verbose', action='store_true', dest='verbose',
                         help='Show extra information on for example near misses')
     parser.add_argument('-p', '--plain', action='store_true', dest='plain',
                         help='Do not display alias expansions or location of '
-                             'where binaries are found.')
+                             'where binaries are found. This the default '
+                             'but can be used to override the --verbose '
+                             'the verbose option')
     parser.add_argument('--very-small-rocks', action=AWitchAWitch)
     if ON_WINDOWS:
         parser.add_argument('-e', '--exts', nargs='*', type=str,
@@ -381,7 +383,10 @@ def which(args, stdin=None, stdout=None, stderr=None):
         parser.print_usage(file=stderr)
         return -1
     pargs = parser.parse_args(args)
-
+    
+    if pargs.all:
+        pargs.verbose = True
+        
     if ON_WINDOWS:
         if pargs.exts:
             exts = pargs.exts
@@ -395,8 +400,11 @@ def which(args, stdin=None, stdout=None, stderr=None):
         nmatches = 0
         # skip alias check if user asks to skip
         if (arg in builtins.aliases and not pargs.skip):
-            if pargs.plain:
-                print(arg, file=stdout)
+            if pargs.plain or not pargs.verbose:
+                if isinstance(builtins.aliases[arg], list):
+                    print(' '.join(builtins.aliases[arg]), file=stdout)
+                else:
+                    print(arg, file=stdout)
             else:
                 print('{} -> {}'.format(arg, builtins.aliases[arg]), file=stdout)
             nmatches += 1
@@ -413,10 +421,10 @@ def which(args, stdin=None, stdout=None, stderr=None):
                 abs_name = os.path.join(p, f)
                 if builtins.__xonsh_env__.get('FORCE_POSIX_PATHS', False):
                     abs_name.replace(os.sep, os.altsep)
-            if not pargs.plain:
-                print('{} -> ({})'.format(abs_name, from_where), file=stdout)
-            else:
+            if pargs.plain or not pargs.verbose:
                 print(abs_name, file=stdout)
+            else:
+                print('{} -> ({})'.format(abs_name, from_where), file=stdout)
             nmatches += 1
             if not pargs.all:
                 break


### PR DESCRIPTION
Further updates to make '-p/--plain' the default output of which. See the discussion with @adqm #934 

This is how the update works now:

```
$ which ls
ls --show-control-chars --color -X

$ which 2to3
C:\Users\mel\Anaconda3\envs\xonshdev\Scripts\2to3.exe 

$ which jobs
jobs
```

```
$ which ls -v
aliases['ls'] = ['ls', '--show-control-chars', '--color', '-X']

$ which 2to3 -v
C:\Users\mel\Anaconda3\envs\xonshdev\Scripts\2to3.exe (from $PATH element 2)

$ which jobs -v
aliases['jobs'] = <function jobs at 0x0000026E4AB54400>
```
I have no idea why it writes the memory location of the functions. If I manually do `aliases['jobs']` I get `<function xonsh.jobs.jobs>`

If the `-p/-plain` is added with the `-v/--verbose`, then plain takes priority. This is to ensure that people can override verbose if they have an alias like this (`which -> ['which', '--verbose']`)
```
$ which ls -v -p
ls --show-control-chars --color -X
```

The `-a/--all` option would automatically be verbose:
``` 
$ which ls -a
aliases['ls'] = ['ls', '--show-control-chars', '--color', '-X']
C:\Program Files\Git\usr\bin\ls.exe (from $PATH element 17)
```
But again can be overridden with `-p/--plain`:
``` 
$ which ls -a -p
ls --show-control-chars --color -X
C:\Program Files\Git\usr\bin\ls.exe
```