### PR TITLE
str().split() | grep exit now throws a SyntaxError

### DIFF
--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -83,10 +83,6 @@ def test_bad_indent():
             'x = 1\n')
     assert_raises(SyntaxError, check_parse, code)
 
-def test_bad_rhs_subproc():
-    code = 'str().split() | grep exit\n'
-    assert_raises(SyntaxError, check_parse, code)
-
 def test_good_rhs_subproc():
     # nonsense but parsebale
     code = 'str().split() | ![grep exit]\n'

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -83,6 +83,20 @@ def test_bad_indent():
             'x = 1\n')
     assert_raises(SyntaxError, check_parse, code)
 
+def test_bad_rhs_subproc():
+    code = 'str().split() | grep exit\n'
+    assert_raises(SyntaxError, check_parse, code)
+
+def test_good_rhs_subproc():
+    # nonsense but parsebale
+    code = 'str().split() | ![grep exit]\n'
+    check_parse(code)
+
+def test_bad_rhs_subproc():
+    # nonsense but unparsebale
+    code = 'str().split() | grep exit\n'
+    assert_raises(SyntaxError, check_parse, code)
+
 def test_indent_with_empty_line():
     code = ('if True:\n'
             '\n'

--- a/xonsh/execer.py
+++ b/xonsh/execer.py
@@ -204,7 +204,8 @@ class Execer(object):
                     else:
                         # or for some other syntax error
                         raise original_error
-                elif sbpline.lstrip().startswith('![!['):
+                elif sbpline[last_error_col:].startswith('![![') or \
+                     sbpline.lstrip().startswith('![!['):
                     # if we have already wrapped this in subproc tokens
                     # and it still doesn't work, adding more won't help
                     # anything


### PR DESCRIPTION
This was a subtle bug caused by the new and/or stuff.  Should close #927 