### PR TITLE
Documenting issue of functions appended to Ubuntu's default .bashrc failing

### DIFF
--- a/docs/linux.rst
+++ b/docs/linux.rst
@@ -86,3 +86,30 @@ lines to your ``~/.bashrc file``:
 
     unset module
     unset scl
+
+
+
+Default Ubuntu .bashrc breaks Foreign Shell Functions
+=====================================================
+
+Xonsh supports importing functions from foreign shells using the
+`ForeignShellFunctionAlias` class, which calls functions as if they were
+aliases. This is implemented by executing a command that sources the file
+containing the function definition and then immediately calls the function with
+any necessary arguments.
+
+The default user `~/.bashrc` file in Ubuntu 15.10 has the following snippet at
+the top, which causes the script to exit immediately if not run interactively.
+
+.. code-block:: bash
+                
+    # If not running interactively, don't do anything
+    case $- in
+        *i*) ;;
+          *) return;;
+    esac
+
+This means that any function you have added to the file after this point will be
+registered as a xonsh alias but will fail on execution. Previous versions of
+Ubuntu have a different test for interactivity at the top of the file that
+yields the same problem.


### PR DESCRIPTION
Updated the docs to include a description of why functions defined at the end of Ubuntu's default ~/.bashrc will fail upon execution in xonsh. 

I did not suggest any workarounds as I don't really know the consequences of removing the exit-on-non-interactive-shell behaviour. I figure uses should be able to work out they can either remove the check or add needed functions before this check.  