### PR TITLE
Job Control Fixes (Built on #867)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,11 @@ Current Developments
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
+
+* Numerous improvements to job control via a nearly-complete rewrite
+* Fixed a parsing bug whereby a trailing ``&`` on a line was being ignored
+  (processes were unable to be started in the background)
 
 **Security:** None
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -720,7 +720,6 @@ def load_builtins(execer=None, config=None, login=False, ctx=None):
     builtins.__xonsh_execer__ = execer
     builtins.__xonsh_commands_cache__ = CommandsCache()
     builtins.__xonsh_all_jobs__ = {}
-    builtins.__xonsh_active_job__ = None
     builtins.__xonsh_ensure_list_of_strs__ = ensure_list_of_strs
     # public built-ins
     builtins.evalx = None if execer is None else execer.eval
@@ -784,7 +783,6 @@ def unload_builtins():
              'compilex',
              'default_aliases',
              '__xonsh_all_jobs__',
-             '__xonsh_active_job__',
              '__xonsh_ensure_list_of_strs__',
              '__xonsh_history__',
              ]

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -556,8 +556,7 @@ def run_subproc(cmds, captured=False):
             'cmds': cmds,
             'pids': [i.pid for i in procs],
             'obj': prev_proc,
-            'bg': background,
-            'signal': None
+            'bg': background
         })
     if (ENV.get('XONSH_INTERACTIVE') and
             not ENV.get('XONSH_STORE_STDOUT') and

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -556,7 +556,8 @@ def run_subproc(cmds, captured=False):
             'cmds': cmds,
             'pids': [i.pid for i in procs],
             'obj': prev_proc,
-            'bg': background
+            'bg': background,
+            'signal': None
         })
     if (ENV.get('XONSH_INTERACTIVE') and
             not ENV.get('XONSH_STORE_STDOUT') and

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -17,6 +17,7 @@ import sys
 from warnings import warn
 
 from xonsh import __version__ as XONSH_VERSION
+from xonsh.jobs import get_next_task
 from xonsh.codecache import run_script_with_cache
 from xonsh.dirstack import _get_cwd
 from xonsh.foreign_shells import DEFAULT_SHELLS, load_foreign_envs
@@ -1012,9 +1013,8 @@ def _collapsed_pwd():
 
 
 def _current_job():
-    j = builtins.__xonsh_active_job__
+    j = get_next_task()
     if j is not None:
-        j = builtins.__xonsh_all_jobs__[j]
         if not j['bg']:
             cmd = j['cmds'][-1]
             s = cmd[0]

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -20,14 +20,11 @@ if ON_WINDOWS:
     def _continue(job):
         job['status'] = 'running'
 
-
     def _kill(obj):
         return obj.kill()
 
-
     def ignore_sigtstp():
         pass
-
 
     def _set_pgrp(info):
         pass
@@ -57,19 +54,16 @@ if ON_WINDOWS:
 
 else:
     def _continue(job):
-        _sendSignal(job, signal.SIGCONT)
-
+        _send_signal(job, signal.SIGCONT)
 
     def _kill(job):
-        _sendSignal(job, signal.SIGKILL)
+        _send_signal(job, signal.SIGKILL)
 
-    def _sendSignal(job, signal):
+    def _send_signal(job, signal):
         os.killpg(job['pgrp'], signal)
-
 
     def ignore_sigtstp():
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
-
 
     def _set_pgrp(info):
         try:
@@ -77,21 +71,19 @@ else:
         except ProcessLookupError:
             pass
 
-
     _shell_pgrp = os.getpgrp()
 
     _block_when_giving = (signal.SIGTTOU, signal.SIGTTIN, signal.SIGTSTP)
-
 
     def _give_terminal_to(pgid):
         # over-simplified version of:
         #    give_terminal_to from bash 4.3 source, jobs.c, line 4030
         # this will give the terminal to the process group pgid
         if _shell_tty is not None and os.isatty(_shell_tty):
-            oldmask = signal.pthread_sigmask(signal.SIG_BLOCK, _block_when_giving)
+            oldmask = signal.pthread_sigmask(signal.SIG_BLOCK,
+                                             _block_when_giving)
             os.tcsetpgrp(_shell_tty, pgid)
             signal.pthread_sigmask(signal.SIG_SETMASK, oldmask)
-
 
     # check for shell tty
     try:
@@ -110,12 +102,11 @@ else:
             if not task['bg'] and task['status'] == RUNNING:
                 selected_task = tid
                 break
-        if selected_task == None:
+        if selected_task is None:
             return
         tasks.remove(selected_task)
         tasks.appendleft(selected_task)
         return get_task(selected_task)
-
 
     def wait_for_active_job():
         """
@@ -242,7 +233,7 @@ def fg(args, stdin=None):
         return '', 'Cannot bring nonexistent job to foreground.\n'
 
     if len(args) == 0:
-        act = tasks[0] # take the last manipulated task by default
+        act = tasks[0]  # take the last manipulated task by default
     elif len(args) == 1:
         try:
             act = int(args[0])
@@ -271,7 +262,7 @@ def bg(args, stdin=None):
     single number is given as an argument, resume that job in the background.
     """
     res = fg(args, stdin)
-    if res == None:
+    if res is None:
         curTask = get_task(tasks[0])
         curTask['bg'] = True
         _continue(curTask)

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -29,7 +29,6 @@ if ON_WINDOWS:
     def _set_pgrp(info):
         pass
 
-
     def wait_for_active_job(signal_to_send=None):
         """
         Wait for the active job to finish, to be killed by SIGINT, or to be
@@ -43,10 +42,7 @@ if ON_WINDOWS:
         if active_task is None:
             return
 
-        pgrp = active_task['pgrp']
         obj = active_task['obj']
-        # give the terminal over to the fg process
-        _give_terminal_to(pgrp)
 
         _continue(active_task)
 
@@ -107,7 +103,6 @@ else:
         Wait for the active job to finish, to be killed by SIGINT, or to be
         suspended by ctrl-z.
         """
-
         _clear_dead_jobs()
 
         active_task = get_next_task()
@@ -137,6 +132,7 @@ else:
             obj.signal = None
 
         return wait_for_active_job()
+
 
 def get_next_task():
     """ Get the next active task and put it on top of the queue"""
@@ -179,7 +175,7 @@ def print_one_job(num):
     cmd = ' '.join(cmd)
     pid = job['pids'][-1]
     bg = ' &' if job['bg'] else ''
-    print('{}[{}] {}: {}{} ({})'.format(act, num, status, cmd, bg, pid))
+    print('[{}] {}: {}{} ({})'.format(num, status, cmd, bg, pid))
 
 
 def get_next_job_number():

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -134,6 +134,8 @@ else:
         # give the terminal over to the fg process
         _give_terminal_to(pgrp)
 
+        _continue(active_task)
+
         _, wcode = os.waitpid(obj.pid, os.WUNTRACED)
         if os.WIFSTOPPED(wcode):
             print()  # get a newline because ^Z will have been printed
@@ -255,7 +257,6 @@ def fg(args, stdin=None):
     job = get_task(act)
     job['bg'] = False
     job['status'] = RUNNING
-    _continue(job)
     print_one_job(act)
 
 
@@ -268,6 +269,8 @@ def bg(args, stdin=None):
     """
     res = fg(args, stdin)
     if res == None:
-        get_task(tasks[0])['bg'] = True
+        curTask = get_task(tasks[0])
+        curTask['bg'] = True
+        _continue(curTask)
     else:
         return res

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -5,7 +5,7 @@ import sys
 import time
 import signal
 import builtins
-from subprocess import TimeoutExpired
+from subprocess import TimeoutExpired, check_output
 from io import BytesIO
 from collections import deque
 
@@ -21,7 +21,7 @@ if ON_WINDOWS:
         job['status'] = RUNNING
 
     def _kill(obj):
-        return obj.kill()
+        check_output(['taskkill', '/F', '/T', '/PID', str(obj.pid)])
 
     def ignore_sigtstp():
         pass
@@ -52,7 +52,7 @@ if ON_WINDOWS:
             except TimeoutExpired:
                 pass
             except KeyboardInterrupt:
-                obj.kill()
+                _kill(obj)
 
         return wait_for_active_job()
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -57,11 +57,14 @@ if ON_WINDOWS:
 
 else:
     def _continue(job):
-        os.kill(job['obj'].pid, signal.SIGCONT)
+        _sendSignal(job, signal.SIGCONT)
 
 
-    def _kill(obj):
-        os.kill(obj.pid, signal.SIGKILL)
+    def _kill(job):
+        _sendSignal(job, signal.SIGKILL)
+
+    def _sendSignal(job, signal):
+        os.killpg(job['pgrp'], signal)
 
 
     def ignore_sigtstp():
@@ -211,7 +214,7 @@ def kill_all_jobs():
     """
     _clear_dead_jobs()
     for job in builtins.__xonsh_all_jobs__.values():
-        _kill(job['obj'])
+        _kill(job)
 
 
 def jobs(args, stdin=None):

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -11,14 +11,11 @@ from collections import deque
 
 from xonsh.tools import ON_WINDOWS
 
-RUNNING = 1
-STOPPED = 0
-
 tasks = deque()
 
 if ON_WINDOWS:
     def _continue(job):
-        job['status'] = RUNNING
+        job['status'] = "running"
 
     def _kill(obj):
         check_output(['taskkill', '/F', '/T', '/PID', str(obj.pid)])
@@ -122,7 +119,7 @@ else:
         _, wcode = os.waitpid(obj.pid, os.WUNTRACED)
         if os.WIFSTOPPED(wcode):
             print()  # get a newline because ^Z will have been printed
-            active_task['status'] = STOPPED
+            active_task['status'] = "stopped"
         elif os.WIFSIGNALED(wcode):
             print()  # get a newline because ^C will have been printed
             obj.signal = (os.WTERMSIG(wcode), os.WCOREDUMP(wcode))
@@ -139,10 +136,10 @@ def get_next_task():
     selected_task = None
     for tid in tasks:
         task = get_task(tid)
-        if not task['bg'] and task['status'] == RUNNING:
+        if not task['bg'] and task['status'] == "running":
             selected_task = tid
             break
-    if selected_task == None:
+    if selected_task is None:
         return
     tasks.remove(selected_task)
     tasks.appendleft(selected_task)
@@ -170,7 +167,7 @@ def print_one_job(num):
         job = builtins.__xonsh_all_jobs__[num]
     except KeyError:
         return
-    status = "running" if job['status'] == RUNNING else "stopped"
+    status = job['status']
     cmd = [' '.join(i) if isinstance(i, list) else i for i in job['cmds']]
     cmd = ' '.join(cmd)
     pid = job['pids'][-1]
@@ -194,7 +191,7 @@ def add_job(info):
     """
     num = get_next_job_number()
     info['started'] = time.time()
-    info['status'] = RUNNING
+    info['status'] = "running"
     _set_pgrp(info)
     tasks.appendleft(num)
     builtins.__xonsh_all_jobs__[num] = info
@@ -253,7 +250,7 @@ def fg(args, stdin=None):
 
     job = get_task(act)
     job['bg'] = False
-    job['status'] = RUNNING
+    job['status'] = "running"
     print_one_job(act)
 
 

--- a/xonsh/jobs.py
+++ b/xonsh/jobs.py
@@ -120,7 +120,6 @@ else:
         if signal_to_send is not None:
             if signal_to_send == signal.SIGCONT:
                 job['status'] = 'running'
-
             os.kill(obj.pid, signal_to_send)
             job['signal'] = None
 
@@ -132,6 +131,8 @@ else:
         if os.WIFSTOPPED(wcode):
             job['bg'] = True
             job['status'] = 'stopped'
+            # The task was stopped therefore we don't have any active task
+            builtins.__xonsh_active_job__ = None
             print()  # get a newline because ^Z will have been printed
             print_one_job(act)
         elif os.WIFSIGNALED(wcode):
@@ -158,16 +159,17 @@ def _clear_dead_jobs():
         del builtins.__xonsh_all_jobs__[i]
         if builtins.__xonsh_active_job__ == i:
             builtins.__xonsh_active_job__ = None
-    if builtins.__xonsh_active_job__ is None:
-        _reactivate_job()
 
 
 def _reactivate_job():
     if len(builtins.__xonsh_all_jobs__) == 0:
         return
-    builtins.__xonsh_active_job__ = max(builtins.__xonsh_all_jobs__.items(),
-                                        key=lambda x: x[1]['started'])[0]
 
+    all_jobs = builtins.__xonsh_all_jobs__.items()
+    reactivable_jobs = [job for job in all_jobs if job[1]['status'] == 'stopped']
+
+    builtins.__xonsh_active_job__ = max(reactivable_jobs,
+                                        key=lambda x: x[1]['started'])[0]
 
 
 def print_one_job(num):
@@ -244,6 +246,7 @@ def fg(args, stdin=None):
     _clear_dead_jobs()
     if len(args) == 0:
         # start active job in foreground
+        _reactivate_job()
         act = builtins.__xonsh_active_job__
         if act is None:
             return '', 'Cannot bring nonexistent job to foreground.\n'

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -166,8 +166,7 @@ def handle_ampersands(state, token):
         yield _new_token('AND', 'and', token.start)
     else:
         state['last'] = token
-        if state['pymode'][-1][0]:
-            yield _new_token('AMPERSAND', token.string, token.start)
+        yield _new_token('AMPERSAND', token.string, token.start)
         if n is not None:
             yield from handle_token(state, n)
 

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -159,16 +159,49 @@ handle_number = _make_special_handler('NUMBER')
 
 def handle_ampersands(state, token):
     """Function for generating PLY tokens for single and double ampersands."""
+    state['last'] = token
     n = next(state['stream'], None)
     if n is not None and n.type == tokenize.OP and \
             n.string == '&' and n.start == token.end:
         state['last'] = n
         yield _new_token('AND', 'and', token.start)
-    else:
-        state['last'] = token
-        yield _new_token('AMPERSAND', token.string, token.start)
+    elif state['pymode'][-1][0]:
+        yield _new_token("AMPERSAND", token.string, token.start)
         if n is not None:
             yield from handle_token(state, n)
+    else:
+        # subprocess mode
+        string = token.string
+        if (n is not None and
+                n.string in {'<', '>', '>>'} and
+                n.start == token.end):
+            e = n.end
+            string += n.string
+            n2 = next(state['stream'], None)
+            if n2 is not None and n2.string == '&' and n2.start == n.end:
+                state['last'] = n2
+                string += n2.string
+                e = n2.end
+                n2 = next(state['stream'], None)
+            if n2 is not None:
+                if (n2.start == e and
+                        (n2.type == tokenize.NUMBER or
+                            (n2.type == tokenize.NAME and
+                             n2.string in _REDIRECT_NAMES))):
+                    string += n2.string
+                    state['last'] = n2
+                    yield _new_token('IOREDIRECT', string, token.start)
+                else:
+                    state['last'] = n
+                    yield _new_token('IOREDIRECT', string, token.start)
+                    yield from handle_token(state, n2)
+            else:
+                state['last'] = n
+                yield _new_token('IOREDIRECT', string, token.start)
+        else:
+            yield _new_token("AMPERSAND", token.string, token.start)
+            if n is not None:
+                yield from handle_token(state, n)
 
 
 def handle_pipes(state, token):


### PR DESCRIPTION
This builds on @GuillaumeLeclerc's great work in #867 refactoring xonsh's job control.  I think all of those changes are ready to be merged in.

Beyond the changes made there, this patch:

* fixes a few PEP8 issues
* brings back the "current job" text in the title bar
* makes windows job control kind of work again (as well as it ever did)
* should fix the issue with launching commands in the background (by bringing back code that looks like it got lost as part of #672)

@scopatz, et al, do you mind taking a look?