### PR TITLE
Allow python -m xonsh

### DIFF
--- a/xonsh/__main__.py
+++ b/xonsh/__main__.py
@@ -1,0 +1,2 @@
+from xonsh.main import main
+main()


### PR DESCRIPTION
It seems more pythonistic than `python -m xonsh.main`

--- 

Thoughts?
