### PR TITLE
adds scandir to platform

### DIFF
--- a/docs/api/platform.rst
+++ b/docs/api/platform.rst
@@ -12,10 +12,20 @@ Functions
 
 .. py:module:: xonsh.platform
 
+.. py:function:: scandir
+
+   This is either `os.scandir` on Python 3.5+ or a function providing a
+   compatibility layer for it.
+   It is recommended for iterations over directory entries at a significantly
+   higher speed than `os.listdir` on Python 3.5+. It also caches properties
+   that are commonly used for filtering.
+
+   :param str path: The path to scan for entries.
+   :return: A generator yielding `DirEntry` instances.
+
 
 Constants
 ---------
-
 
 .. autodata:: BASH_COMPLETIONS_DEFAULT
     :annotation:
@@ -55,4 +65,3 @@ Constants
 
 .. autodata:: PYTHON_VERSION_INFO
     :annotation:
-

--- a/docs/api/platform.rst
+++ b/docs/api/platform.rst
@@ -3,9 +3,56 @@
 Platform-specific constants and implementations (``xonsh.platform``)
 ====================================================================
 
+Functions
+---------
 
 .. automodule:: xonsh.platform
-    :members:
-    :undoc-members:
-    :inherited-members:
+    :members: has_prompt_toolkit, is_readline_available, ptk_version,
+              ptk_version_info
+
+.. py:module:: xonsh.platform
+
+
+Constants
+---------
+
+
+.. autodata:: BASH_COMPLETIONS_DEFAULT
+    :annotation:
+
+.. autodata:: BEST_SHELL_TYPE
+    :annotation:
+
+.. autodata:: DEFAULT_ENCODING
+    :annotation:
+
+.. autodata:: HAS_PYGMENTS
+    :annotation:
+
+.. autodata:: LINUX_DISTRO
+    :annotation:
+
+.. autodata:: ON_ANACONDA
+    :annotation:
+
+.. autodata:: ON_DARWIN
+    :annotation:
+
+.. autodata:: ON_LINUX
+    :annotation:
+
+.. autodata:: ON_POSIX
+    :annotation:
+
+.. autodata:: ON_WINDOWS
+    :annotation:
+
+.. autodata:: PLATFORM_INFO
+    :annotation:
+
+.. autodata:: PYGMENTS_VERSION
+    :annotation:
+
+.. autodata:: PYTHON_VERSION_INFO
+    :annotation:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,7 +98,7 @@ pygments_style = 'sphinx'
 #pygments_style = 'pastie'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+modindex_common_prefix = ['xonsh.']
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -1,3 +1,4 @@
+============
 Dependencies
 ============
 Xonsh currently has the following external dependencies,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -218,24 +218,9 @@ table lists features and capabilities that various tools may or may not share.
       - ✓
 
 
-============
-Dependencies
-============
-Xonsh currently has the following external dependencies,
 
-*Run Time:*
+.. include:: dependencies.rst
 
-    #. Python v3.4+
-    #. PLY (optional, included with xonsh)
-    #. prompt-toolkit (optional)
-    #. Jupyter (optional)
-    #. setproctitle (optional)
-
-*Documentation:*
-
-    #. `Sphinx <http://sphinx-doc.org/>`_ (which uses  `reStructuredText <http://sphinx-doc.org/rest.html>`_)
-    #. Numpydoc
-    #. Cloud Sphinx Theme
 
 ============
 Contributing

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -12,7 +12,7 @@ from xonsh.environ import locate_binary
 from xonsh.foreign_shells import foreign_shell_data
 from xonsh.jobs import jobs, fg, bg, kill_all_jobs
 from xonsh.history import main as history_alias
-from xonsh.platform import ON_ANACONDA, ON_DARWIN, ON_WINDOWS
+from xonsh.platform import ON_ANACONDA, ON_DARWIN, ON_WINDOWS, scandir
 from xonsh.proc import foreground
 from xonsh.replay import main as replay_main
 from xonsh.timings import timeit_alias
@@ -412,9 +412,9 @@ def which(args, stdin=None, stdout=None, stderr=None):
         for abs_name, from_where in matches:
             if ON_WINDOWS:
                 # Use list dir to get correct case for the filename
-                # i.e. windows is case insesitive but case preserving
+                # i.e. windows is case insensitive but case preserving
                 p, f = os.path.split(abs_name)
-                f = next(s for s in os.listdir(p) if s.lower() == f.lower())
+                f = next(s.name for s in scandir(p) if s.name.lower() == f.lower())
                 abs_name = os.path.join(p, f)
                 if builtins.__xonsh_env__.get('FORCE_POSIX_PATHS', False):
                     abs_name.replace(os.sep, os.altsep)

--- a/xonsh/imphooks.py
+++ b/xonsh/imphooks.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 from xonsh.execer import Execer
+from xonsh.platform import scandir
 
 
 class XonshImportHook(MetaPathFinder, SourceLoader):
@@ -49,7 +50,7 @@ class XonshImportHook(MetaPathFinder, SourceLoader):
                 continue
             if not os.path.isdir(p):
                 continue
-            if fname not in os.listdir(p):
+            if fname not in (x.name for x in scandir(p)):
                 continue
             spec = ModuleSpec(fullname, self)
             self._filenames[fullname] = os.path.join(p, fname)

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -23,10 +23,14 @@ except:
 #
 
 ON_DARWIN = platform.system() == 'Darwin'
+""" ``True`` if executed on a Darwin platform, else ``False``. """
 ON_LINUX = platform.system() == 'Linux'
+""" ``True`` if executed on a Linux platform, else ``False``. """
 ON_WINDOWS = platform.system() == 'Windows'
+""" ``True`` if executed on a Windows platform, else ``False``. """
 
 ON_POSIX = (os.name == 'posix')
+""" ``True`` if executed on a POSIX-compliant platform, else ``False``. """
 
 
 
@@ -35,12 +39,20 @@ ON_POSIX = (os.name == 'posix')
 #
 
 PYTHON_VERSION_INFO = sys.version_info[:3]
+""" Version of Python interpreter as three-value tuple. """
 ON_ANACONDA = any(s in sys.version for s in {'Anaconda', 'Continuum'})
+""" ``True`` if executed in an Anaconda instance, else ``False``. """
+
+
+HAS_PYGMENTS = False
+""" ``True`` if `pygments` is available, else ``False``. """
+PYGMENTS_VERSION = None
+""" `pygments.__version__` version if available, else ``Ǹone``. """
 
 try:
     import pygments
 except ImportError:
-    HAS_PYGMENTS, PYGMENTS_VERSION = False, None
+    pass
 except:
     raise
 else:
@@ -49,6 +61,7 @@ else:
 
 @lru_cache(1)
 def has_prompt_toolkit():
+    """ Tests if the `prompt_toolkit` is available. """
     try:
         import prompt_toolkit
     except ImportError:
@@ -61,6 +74,7 @@ def has_prompt_toolkit():
 
 @lru_cache(1)
 def ptk_version():
+    """ Returns `prompt_toolkit.__version__` if available, else ``None``. """
     if has_prompt_toolkit():
         import prompt_toolkit
         return getattr(prompt_toolkit, '__version__', '<0.57')
@@ -70,11 +84,15 @@ def ptk_version():
 
 @lru_cache(1)
 def ptk_version_info():
+    """ Returns `prompt_toolkit`'s version as tuple of integers. """
     if has_prompt_toolkit():
         return tuple(int(x) for x in ptk_version().strip('<>+-=.').split('.'))
     else:
         return None
 
+
+BEST_SHELL_TYPE = None
+""" The 'best' available shell type, either 'prompt_toollit' or 'readline'. """
 
 if ON_WINDOWS or has_prompt_toolkit():
     BEST_SHELL_TYPE = 'prompt_toolkit'
@@ -96,11 +114,18 @@ def is_readline_available():
 #
 
 DEFAULT_ENCODING = sys.getdefaultencoding()
+""" Default string encoding. """
 
 
 #
 # Linux distro
 #
+
+LINUX_DISTRO = None
+""" The id of the Linux distribution running on, possibly 'unknown'.
+    ``Ǹone`` on non-Linux platforms.
+"""
+
 
 if ON_LINUX:
     if distro:
@@ -111,8 +136,6 @@ if ON_LINUX:
         LINUX_DISTRO = 'arch'  # that's the only one we need to know for now
     else:
         LINUX_DISTRO = 'unknown'
-else:
-    LINUX_DISTRO = None
 
 
 #
@@ -131,6 +154,11 @@ else:
 #
 # Bash completions defaults
 #
+
+BASH_COMPLETIONS_DEFAULT = ()
+""" A possibly empty tuple with default paths to Bash completions known for
+    the current platform.
+"""
 
 if LINUX_DISTRO == 'arch':
     BASH_COMPLETIONS_DEFAULT = (
@@ -151,12 +179,10 @@ elif ON_WINDOWS:
         progamfiles + '/Git/usr/share/bash-completion/completions',
         progamfiles + '/Git/mingw64/share/git/completion/git-completion.bash')
 
-else:
-    BASH_COMPLETIONS_DEFAULT = ()
-
 #
 # All constants as a dict
 #
 
 PLATFORM_INFO = {name: obj for name, obj in globals().items()
                  if name.isupper()}
+""" The constants of this module as dictionary. """

--- a/xonsh/vox.py
+++ b/xonsh/vox.py
@@ -5,7 +5,7 @@ import builtins
 from shutil import rmtree
 
 import xonsh.tools
-from xonsh.platform import ON_POSIX, ON_WINDOWS
+from xonsh.platform import ON_POSIX, ON_WINDOWS, scandir
 
 
 class Vox:
@@ -139,7 +139,7 @@ class Vox:
 
         venv_home = builtins.__xonsh_env__['VIRTUALENV_HOME']
         try:
-            env_dirs = os.listdir(builtins.__xonsh_env__['VIRTUALENV_HOME'])
+            env_dirs = list(x.name for x in scandir(venv_home) if x.is_dir())
         except PermissionError:
             print('No permissions on {}'.format(venv_home))
             return None


### PR DESCRIPTION
as discussed.

i also added docs for the `platform` module. however they render also the values of constants from the build environment. there seems to be no way to disable this on a `automodule` level. i'd rather add them manually to the `rst` file. any other idea?