### PR TITLE
Respect decisions made about SHELL_TYPE in rc files

### DIFF
--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -186,8 +186,7 @@ def premain(argv=None):
         version = '/'.join(('xonsh', __version__)),
         print(version)
         exit()
-    shell_kwargs = {'shell_type': args.shell_type or
-                                  DEFAULT_VALUES.get('SHELL_TYPE'),
+    shell_kwargs = {'shell_type': args.shell_type,
                     'completer': False,
                     'login': False,
                     'scriptcache': args.scriptcache,

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -47,7 +47,7 @@ class Shell(object):
         if shell_type is not None:
             env['SHELL_TYPE'] = shell_type
         shell_type = env.get('SHELL_TYPE')
-        if shell_type == 'best':
+        if shell_type == 'best' or shell_type is None:
             shell_type = BEST_SHELL_TYPE
         elif shell_type == 'random':
             shell_type = random.choice(('readline', 'prompt_toolkit'))
@@ -89,7 +89,7 @@ class Shell(object):
             names = builtins.__xonsh_config__.get('xontribs', ())
             for name in names:
                 xontribs.update_context(name, ctx=self.ctx)
-            # load run contol files
+            # load run control files
             env = builtins.__xonsh_env__
             rc = env.get('XONSHRC') if rc is None else rc
             self.ctx.update(xonshrc_context(rcfiles=rc, execer=self.execer))


### PR DESCRIPTION
I believe this should fix the issue described in #961 where `$SHELL_TYPE` was always being set to `"best"` if the `--shell-type` flag was not used, _after_ the rc files were executed (thus overriding values set there).