### PR TITLE
Make .bat files 'text' in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
+*.bat text
+
 tests/histories/*.json text eol=lf


### PR DESCRIPTION
The file scripts/xonsh.bat was showing up as changed, and making the repo basically unusable. Making .bat files explicitly text in the .gitattributes file fixes it for me.

The commands at the bottom of http://www.marten-online.com/source-versioning/git-dealing-with-line-endings-solution-2.html were necessary to reflect the adjusted .gitattributes file in the working copy (this will throw away any changes in your working copy, don't just run these commands arbitrarily):

```
$ git rm --cached -r .
$ git reset --hard
```