### PR TITLE
remove prompt_toolkit < v1.0.0 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,8 @@ Current Developments
 
 **Deprecated:** None
 
-**Removed:** None
+**Removed:** 
+* Special cased code for handling version of prompt_toolkit < v1.0.0
 
 **Fixed:**
 

--- a/xonsh/ptk/completer.py
+++ b/xonsh/ptk/completer.py
@@ -43,17 +43,7 @@ class PromptToolkitCompleter(Completer):
 
     def reserve_space(self):
         cli = builtins.__xonsh_shell__.shell.prompter.cli
-        if ptk_version().startswith("1.0"):
-            # This is the layout for ptk 1.0
-            window = cli.application.layout.children[0].content.children[1]
-        else:
-            #TODO remove after next prompt_toolkit release
-            try:
-                #old layout to be removed at next ptk release
-                window = cli.application.layout.children[1].children[1].content
-            except AttributeError:
-                #new layout to become default
-                window = cli.application.layout.children[1].content
+        window = cli.application.layout.children[0].content.children[1]
 
         if window and window.render_info:
             h = window.render_info.content_height

--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -37,8 +37,8 @@ class PromptToolkitHistory(prompt_toolkit.history.History):
 class PromptToolkitHistoryAdder(Thread):
 
     def __init__(self, ptkhist, wait_for_gc=True, *args, **kwargs):
-        """Thread responsible for adding inputs from history to the current 
-        prompt-toolkit history instance. May wait for the history garbage 
+        """Thread responsible for adding inputs from history to the current
+        prompt-toolkit history instance. May wait for the history garbage
         collector to finish.
         """
         super(PromptToolkitHistoryAdder, self).__init__(*args, **kwargs)
@@ -75,7 +75,7 @@ class PromptToolkitHistoryAdder(Thread):
     def _buf(self):
         # Thread-safe version of
         # buf = builtins.__xonsh_shell__.shell.prompter.cli.application.buffer
-        path = ['__xonsh_shell__', 'shell', 'prompter', 'cli', 'application', 
+        path = ['__xonsh_shell__', 'shell', 'prompter', 'cli', 'application',
                 'buffer']
         buf = builtins
         for a in path:
@@ -83,4 +83,3 @@ class PromptToolkitHistoryAdder(Thread):
             if buf is None:
                 break
         return buf
-        

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -43,8 +43,8 @@ def carriage_return(b, cli):
     elif (not b.document.on_first_line and
             not current_line_blank):
         b.newline(copy_margin=True)
-    elif (b.document.char_before_cursor == '\\' and 
-            not (not builtins.__xonsh_env__.get('FORCE_POSIX_PATHS') 
+    elif (b.document.char_before_cursor == '\\' and
+            not (not builtins.__xonsh_env__.get('FORCE_POSIX_PATHS')
                 and ON_WINDOWS)):
         b.newline()
     elif (b.document.find_next_word_beginning() is not None and

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -5,6 +5,7 @@ import builtins
 from prompt_toolkit.key_binding.manager import KeyBindingManager
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from prompt_toolkit.layout.lexers import PygmentsLexer
+from prompt_toolkit.shortcuts import print_tokens
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.styles import PygmentsStyle
 from pygments.styles import get_all_styles
@@ -19,7 +20,7 @@ from xonsh.pyghooks import (XonshLexer, partial_color_tokenize,
 from xonsh.ptk.completer import PromptToolkitCompleter
 from xonsh.ptk.history import PromptToolkitHistory
 from xonsh.ptk.key_bindings import load_xonsh_bindings
-from xonsh.ptk.shortcuts import Prompter, print_tokens
+from xonsh.ptk.shortcuts import Prompter
 
 
 class PromptToolkitShell(BaseShell):
@@ -37,12 +38,6 @@ class PromptToolkitShell(BaseShell):
                 'enable_abort_and_exit_bindings': True,
                 'enable_open_in_editor': True,
                 }
-        major, minor = ptk_version_info()[:2]
-        self.new_vi_mode_flag = (major, minor) >= (1, 0) \
-                                and ptk_version() != '<0.57'
-        if not self.new_vi_mode_flag:
-            # enable_vi_mode is deprecated acoording to prompt_toolset 1.0 document.
-            key_bindings_manager_args['enable_vi_mode'] = Condition(lambda cli: builtins.__xonsh_env__.get('VI_MODE'))
 
         self.key_bindings_manager = KeyBindingManager(**key_bindings_manager_args)
         load_xonsh_bindings(self.key_bindings_manager)
@@ -84,10 +79,8 @@ class PromptToolkitShell(BaseShell):
                     'enable_history_search': enable_history_search,
                     'reserve_space_for_menu': 0,
                     'key_bindings_registry': self.key_bindings_manager.registry,
-                    'display_completions_in_columns': multicolumn
+                    'display_completions_in_columns': multicolumn,
                     }
-            if self.new_vi_mode_flag:
-                prompt_args['vi_mode'] = env.get('VI_MODE')
             line = self.prompter.prompt(**prompt_args)
         return line
 

--- a/xonsh/ptk/shortcuts.py
+++ b/xonsh/ptk/shortcuts.py
@@ -3,6 +3,7 @@ import builtins
 import textwrap
 
 from prompt_toolkit.interface import CommandLineInterface
+from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.utils import DummyContext
 from prompt_toolkit.shortcuts import (create_prompt_application,
     create_eventloop, create_asyncio_eventloop, create_output)
@@ -68,20 +69,11 @@ class Prompter(object):
 
         # Create CommandLineInterface.
         if self.cli is None:
-            if self.major_minor < (0, 57):
-                kwargs.pop('reserve_space_for_menu', None)
-            if self.major_minor <= (0, 57):
-                kwargs.pop('get_rprompt_tokens', None)
-                kwargs.pop('get_continuation_tokens', None)
-            # VI_Mode handling changed in prompt_toolkit v1.0
-            if self.major_minor >= (1, 0):
-                from prompt_toolkit.enums import EditingMode
-                if builtins.__xonsh_env__.get('VI_MODE'):
-                    editing_mode = EditingMode.VI
-                else:
-                    editing_mode = EditingMode.EMACS
-                kwargs['editing_mode'] = editing_mode
-                kwargs['vi_mode'] = builtins.__xonsh_env__.get('VI_MODE')
+            if builtins.__xonsh_env__.get('VI_MODE'):
+                editing_mode = EditingMode.VI
+            else:
+                editing_mode = EditingMode.EMACS
+            kwargs['editing_mode'] = editing_mode
             cli = CommandLineInterface(
                 application=create_prompt_application(message, **kwargs),
                 eventloop=eventloop,
@@ -124,78 +116,3 @@ class Prompter(object):
     def reset(self):
         """Resets the prompt and cli to a pristine state on this object."""
         self.cli = None
-
-
-try:
-    from prompt_toolkit.shortcuts import print_tokens
-except ImportError:
-    import os
-    import sys
-    from prompt_toolkit.renderer import print_tokens as renderer_print_tokens
-    from prompt_toolkit.filters import to_simple_filter
-    from prompt_toolkit.utils import is_conemu_ansi, is_windows
-    if is_windows():
-        from prompt_toolkit.terminal.win32_output import Win32Output
-        from prompt_toolkit.terminal.conemu_output import ConEmuOutput
-    else:
-        from prompt_toolkit.terminal.vt100_output import Vt100_Output
-    from pygments.style import Style
-    from prompt_toolkit.styles import Style
-    from six import PY2
-
-    def create_output(stdout=None, true_color=False):
-        """
-        Return an :class:`~prompt_toolkit.output.Output` instance for the command
-        line.
-        :param true_color: When True, use 24bit colors instead of 256 colors.
-            (`bool` or :class:`~prompt_toolkit.filters.SimpleFilter`.)
-
-        Notes
-        -----
-        This method was forked from the mainline prompt-toolkit repo.
-        Copyright (c) 2014, Jonathan Slenders, All rights reserved.
-        This is deprecated and slated for removal after a prompt-toolkit
-        v0.57+ release.
-        """
-        stdout = stdout or sys.__stdout__
-        true_color = to_simple_filter(true_color)
-
-        if is_windows():
-            if is_conemu_ansi():
-                return ConEmuOutput(stdout)
-            else:
-                return Win32Output(stdout)
-        else:
-            term = os.environ.get('TERM', '')
-            if PY2:
-                term = term.decode('utf-8')
-
-            return Vt100_Output.from_pty(stdout, true_color=true_color)#, term=term)
-
-    def print_tokens(tokens, style=None, true_color=False):
-        """
-        Print a list of (Token, text) tuples in the given style to the output.
-        E.g.::
-            style = PygmentsStyle.from_defaults(style_dict={
-                Token.Hello: '#ff0066',
-                Token.World: '#884444 italic',
-            })
-            tokens = [
-                (Token.Hello, 'Hello'),
-                (Token.World, 'World'),
-            ]
-            print_tokens(tokens, style=style)
-        :param tokens: List of ``(Token, text)`` tuples.
-        :param style: :class:`.Style` instance for the color scheme.
-        :param true_color: When True, use 24bit colors instead of 256 colors.
-
-        Notes
-        -----
-        This method was forked from the mainline prompt-toolkit repo.
-        Copyright (c) 2014, Jonathan Slenders, All rights reserved.
-        This is deprecated and slated for removal after a prompt-toolkit
-        v0.57+ release.
-        """
-        assert isinstance(style, Style)
-        output = create_output(true_color=true_color)
-        renderer_print_tokens(output, tokens, style)

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -59,10 +59,9 @@ class Shell(object):
         if shell_type == 'none':
             from xonsh.base_shell import BaseShell as shell_class
         elif shell_type == 'prompt_toolkit':
-            if ptk_version_info()[:2] < (0, 57) or \
-                    ptk_version() == '<0.57':  # TODO: remove in future
-                msg = ('prompt-toolkit version < v0.57 and may not work as '
-                       'expected. Please update.')
+            if ptk_version_info()[:2] < (1, 0):
+                msg = ('prompt-toolkit version < v1.0.0 is not supported, '
+                       'xonsh may not work as expected. Please update.')
                 warn(msg, RuntimeWarning)
             from xonsh.ptk.shell import PromptToolkitShell as shell_class
         elif shell_type == 'readline':


### PR DESCRIPTION
As per #980 this removes all of the cased code for dealing with various
versions of prompt_toolkit in favor of supporting only v1.0.0+