### PR TITLE
(slightly) better string quoting for windows completion

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -378,11 +378,13 @@ class Completer(object):
                 _tail = space
             else:
                 _tail = ''
+            if start != '' and 'r' not in start and backslash in s:
+                start = 'r%s' % start
             s = s + _tail
             if end != '':
                 if "r" not in start.lower():
                     s = s.replace(backslash, double_backslash)
-                elif s.endswith(backslash):
+                if s.endswith(backslash) and not s.endswith(double_backslash):
                     s += backslash
             if end in s:
                 s = s.replace(end, ''.join('\\%s' % i for i in end))


### PR DESCRIPTION
This does not completely fix the issue described in #983 (see continued discussion there), but it makes progress by forcing paths with backslashes in the middle of them to be completed using raw strings.