### PR TITLE
Fix bash foreign_shell_data on Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Current Developments
 
 * Fix bash completions (e.g git etc.) on windows when completions files have 
   spaces in their path names
+* Fixed a bug preventing ``source-bash`` from working on Windows 
 * Numerous improvements to job control via a nearly-complete rewrite
 * Rectified install issue with Jupyter hook when installing with pyenv,
   Jupyter install hook now repects ``--prefix`` argument.

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -12,6 +12,7 @@ from tempfile import NamedTemporaryFile
 from collections import MutableMapping, Mapping, Sequence
 
 from xonsh.tools import to_bool, ensure_string
+from xonsh.platform import ON_WINDOWS
 
 
 COMMAND = """

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -30,7 +30,7 @@ echo __XONSH_FUNCS_END__
 {seterrpostcmd}
 """.strip()
 
-DEFAULT_BASH_FUNCSCMD = """
+DEFAULT_BASH_FUNCSCMD = r"""
 # get function names from declare
 declstr=$(declare -F)
 read -r -a decls <<< $declstr
@@ -56,7 +56,7 @@ while IFS='' read -r line || [[ -n "$line" ]]; do
   locfile=${line#*"$sep"}
   loc=${locfile%%"$sep"*}
   file=${locfile#*"$sep"}
-  namefile="${namefile}\\"${name}\\":\\"${file//\\/\\\\}\\","
+  namefile="${namefile}\"${name}\":\"${file//\\/\\\\}\","
 done <<< "$namelocfilestr"
 if [[ "{" == "${namefile}" ]]; then
   namefile="${namefile}}"
@@ -316,6 +316,8 @@ def parse_funcs(s, shell, sourcer=None):
     if m is None:
         return {}
     g1 = m.group(1)
+    if ON_WINDOWS:
+        g1 = g1.replace(os.sep,os.altsep)
     try:
         namefiles = json.loads(g1.strip())
     except json.decoder.JSONDecodeError as exc:

--- a/xonsh/foreign_shells.py
+++ b/xonsh/foreign_shells.py
@@ -318,7 +318,7 @@ def parse_funcs(s, shell, sourcer=None):
         return {}
     g1 = m.group(1)
     if ON_WINDOWS:
-        g1 = g1.replace(os.sep,os.altsep)
+        g1 = g1.replace(os.sep, os.altsep)
     try:
         namefiles = json.loads(g1.strip())
     except json.decoder.JSONDecodeError as exc:


### PR DESCRIPTION
@scopatz .. I realized that bash foreign_shell_data always failed for me. I experimented a bit and this PR is what solved it for me.

I am not completely sure what the change to `DEFAULT_BASH_FUNCSCMD` does. But it was necessary to get the subprocess calling bash to succeed. I have no idea if messes things up on other platforms.

The second change in `parse_func()` was necessary to get `json.loads()` to work.

