### PR TITLE
Add explicit extension ->text/binary mapping in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,29 @@
-tests/histories/*.json text eol=lf
-
 # Set the default behavior, in case people don't have core.autocrlf set.
+# This should be first, because the git documentation says "When more
+# than one pattern matches the path, a later line overrides an earlier line."
 * text=auto
+
+# Text files
+*.bat text
+*.css_t text
+*.in text
+*.json text
+*.py text
+*.rst text
+*.sh text
+*.txt text
+*.xsh text
+*.yaml text
+*.yml text
+CONTRIBUTING text
+license text
+LICENSE text
+Makefile text
+README text
+
+# Binary files
+*.ico binary
+*.gif binary
+*.gz binary
+*.png binary
+*.webm binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,9 @@ LICENSE text
 Makefile text
 README text
 
+# Files in the lazyjson format require LF line endings
+tests/histories/*.json text eol=lf
+
 # Binary files
 *.ico binary
 *.gif binary


### PR DESCRIPTION
Follow-on from discussion in https://github.com/scopatz/xonsh/pull/984, recreating since I can't reopen it.

This makes all the existing extensions in the repo explicitly text or binary. I changed the existing *.json rule that was forcing LF for text to just being text, is there a reason it should have unix line endings? Alternatively, could keep that, and force .bat files to have CRLF.