### PR TITLE
Bash completions fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,6 @@ Current Developments
 **Fixed:**
 
 * Show sorted bash completions suggestions.
-* When doing bash completions path completions are no longer added to the suggestions
 * Fix bash completions (e.g git etc.) on windows when completions files have
   spaces in their path names
 * Fixed a bug preventing ``source-bash`` from working on Windows

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Current Developments
 
 **Fixed:**
 
+* Show sorted bash completions suggestions.
+* When doing bash completions path completions are no longer added to the suggestions
 * Fix bash completions (e.g git etc.) on windows when completions files have
   spaces in their path names
 * Fixed a bug preventing ``source-bash`` from working on Windows

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -193,7 +193,7 @@ class Completer(object):
         elif cmd in self.bash_complete_funcs:
             # bash completions
             rtn = self.bash_complete(prefix, line, begidx, endidx)
-            #rtn |= self.path_complete(prefix, path_str_start, path_str_end)
+            rtn |= self.path_complete(prefix, path_str_start, path_str_end)
             return sorted(self._filter_repeats(rtn)), lprefix
         elif prefix.startswith('${') or prefix.startswith('@('):
             # python mode explicitly

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -272,9 +272,9 @@ class Completer(object):
 
     def _replace_canonical_rep(self, comps, replacements):
         """ Replaces any entries in comps with its cononical duplicate
-            from replacements 
+            from replacements
         """
-        replacements = {self._canonical_rep(v):v for v in replacements}
+        replacements = {self._canonical_rep(v): v for v in replacements}
         rtn = set()
         for comp in comps:
             canon = self._canonical_rep(comp)
@@ -282,8 +282,8 @@ class Completer(object):
                 rtn.add(replacements[canon])
             else:
                 rtn.add(comp)
-        return rtn       
-        
+        return rtn
+
     def find_and_complete(self, line, idx, ctx=None):
         """Finds the completions given only the full code line and a current
         cursor position. This represents an easier alternative to the

--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -193,8 +193,8 @@ class Completer(object):
         elif cmd in self.bash_complete_funcs:
             # bash completions
             rtn = self.bash_complete(prefix, line, begidx, endidx)
-            rtn |= self.path_complete(prefix, path_str_start, path_str_end)
-            return self._filter_repeats(rtn), lprefix
+            #rtn |= self.path_complete(prefix, path_str_start, path_str_end)
+            return sorted(self._filter_repeats(rtn)), lprefix
         elif prefix.startswith('${') or prefix.startswith('@('):
             # python mode explicitly
             return self._python_mode_completions(prefix, ctx,


### PR DESCRIPTION
This fixes bash completions so path-completions are no longer added to the suggestions. It also sorts the result so the resembles the suggestions in bash

See: https://github.com/scopatz/xonsh/issues/981#issuecomment-220867257