### PR TITLE
Defaults for bash completions file on Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,10 @@ Current Developments
 * ``@$(cmd)`` has been added as a subprocess-mode operator, which replaces in
   the subprocess command itself with the result of running ``cmd``.
 
-**Changed:** None
+**Changed:** 
+
+* On Windows the default bash completions files ``$BASH_COMPLETIONS`` now points 
+  to the default location of the completions files used by 'Git for Windows'
 
 **Deprecated:** None
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -144,6 +144,12 @@ elif ON_DARWIN:
     BASH_COMPLETIONS_DEFAULT = (
         '/usr/local/etc/bash_completion',
         '/opt/local/etc/profile.d/bash_completion.sh')
+elif ON_WINDOWS:
+    BASH_COMPLETIONS_DEFAULT = (
+        'C:/Program Files/Git/usr/share/bash-completion',
+        'C:/Program Files/Git/usr/share/bash-completion/completions',
+        'C:/Program Files/Git/mingw64/share/git/completion/git-completion.bash')
+
 else:
     BASH_COMPLETIONS_DEFAULT = ()
 

--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -145,10 +145,11 @@ elif ON_DARWIN:
         '/usr/local/etc/bash_completion',
         '/opt/local/etc/profile.d/bash_completion.sh')
 elif ON_WINDOWS:
+    progamfiles = os.environ.get('PROGRAMFILES', 'C:/Program Files')
     BASH_COMPLETIONS_DEFAULT = (
-        'C:/Program Files/Git/usr/share/bash-completion',
-        'C:/Program Files/Git/usr/share/bash-completion/completions',
-        'C:/Program Files/Git/mingw64/share/git/completion/git-completion.bash')
+        progamfiles + '/Git/usr/share/bash-completion',
+        progamfiles + '/Git/usr/share/bash-completion/completions',
+        progamfiles + '/Git/mingw64/share/git/completion/git-completion.bash')
 
 else:
     BASH_COMPLETIONS_DEFAULT = ()


### PR DESCRIPTION
Add defaults for $BASH_COMPLETIONS on windows. The default values are where GitForWindows stores the completions files in a standard installation. 

This should hopefully ensure that more people get the full xonsh experience by default.