### PR TITLE
Added comma literals to subproc mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Current Developments
 
 * When a subprocess exits with a signal (e.g. SIGSEGV), a message is printed,
   similar to Bash.
+* Added comma literals to subproc mode.
 * ``@$(cmd)`` has been added as a subprocess-mode operator, which replaces in
   the subprocess command itself with the result of running ``cmd``.
 

--- a/tests/test_execer.py
+++ b/tests/test_execer.py
@@ -113,6 +113,18 @@ def test_pyeval_redirect():
     code = 'echo @("foo") > bar\n'
     yield check_parse, code
 
+def test_echo_comma():
+    code = 'echo ,\n'
+    yield check_parse, code
+
+def test_echo_comma_val():
+    code = 'echo ,1\n'
+    yield check_parse, code
+
+def test_echo_comma_2val():
+    code = 'echo 1,2\n'
+    yield check_parse, code
+
 
 
 if __name__ == '__main__':

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1743,6 +1743,12 @@ def test_git_two_quotes_space_space():
 def test_ls_quotes_3_space():
     yield check_xonsh_ast, {}, '$[ls "wakka jawaka baraka"]', False
 
+def test_echo_comma():
+    yield check_xonsh_ast, {}, '![echo ,]', False
+
+def test_echo_internal_comma():
+    yield check_xonsh_ast, {}, '![echo 1,2]', False
+
 def test_comment_only():
     yield check_xonsh_ast, {}, '# hello'
 

--- a/xonsh/ast.py
+++ b/xonsh/ast.py
@@ -52,6 +52,9 @@ def leftmostname(node):
     elif isinstance(node, (Str, Bytes)):
         # handles case of "./my executable"
         rtn = leftmostname(node.s)
+    elif isinstance(node, Tuple) and len(node.elts) > 0:
+        # handles case of echo ,1,2,3
+        rtn = leftmostname(node.elts[0])
     else:
         rtn = None
     return rtn
@@ -149,7 +152,8 @@ class CtxAwareTransformer(NodeTransformer):
             maxcol = None
         else:
             mincol = min_col(node)
-            maxcol = max_col(node) + 1
+            maxcol = max_col(node)
+            maxcol = None if maxcol == mincol else maxcol + 1
         spline = subproc_toks(line,
                               mincol=mincol,
                               maxcol=maxcol,

--- a/xonsh/lexer.py
+++ b/xonsh/lexer.py
@@ -42,7 +42,7 @@ _op_map = {
     '&=': 'AMPERSANDEQUAL', '^=': 'XOREQUAL', '|=': 'PIPEEQUAL',
     '//=': 'DOUBLEDIVEQUAL',
     # extra xonsh operators
-    '?': 'QUESTION', '??': 'DOUBLE_QUESTION', '@$': 'ATDOLLAR', '!': 'BANG',
+    '?': 'QUESTION', '??': 'DOUBLE_QUESTION', '@$': 'ATDOLLAR',
     '&': 'AMPERSAND',
 }
 for (op, type) in _op_map.items():

--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2285,6 +2285,7 @@ class BaseParser(object):
                             | FALSE
                             | NUMBER
                             | STRING
+                            | COMMA
         """
         # Many tokens cannot be part of this list, such as $, ', ", ()
         # Use a string atom instead.


### PR DESCRIPTION
I was getting annoyed by having to put some compiler options in strings.  This doesn't seems to adversely affect anything, and even supports the sort of ridiculous and ambiguous case of `echo ,`