### PR TITLE
xonsh will read history from locked files at startup to be included in up-arrow history

### DIFF
--- a/xonsh/history.py
+++ b/xonsh/history.py
@@ -102,7 +102,8 @@ class HistoryGC(Thread):
                 pass
 
     def files(self, only_unlocked=False):
-        """Find and return the history files that are unlocked.
+        """Find and return the history files. Optionally locked files may be
+        excluded.
 
         This is sorted by the last closed time. Returns a list of (timestamp,
         file) tuples.
@@ -115,14 +116,16 @@ class HistoryGC(Thread):
         for f in fs:
             try:
                 lj = lazyjson.LazyJSON(f, reopen=False)
-                if only_unlocked:
-                    if lj['locked']:
-                        continue
+                if only_unlocked and lj['locked']:
+                    continue
                 # info: closing timestamp, number of commands, filename
-                files.append((lj['ts'][1], len(lj.sizes['cmds']) - 1, f))
+                files.append((lj['ts'][1] or time.time(), 
+                              len(lj.sizes['cmds']) - 1, 
+                              f))
                 lj.close()
             except (IOError, OSError, ValueError):
                 continue
+        files.sort()
         return files
 
 

--- a/xonsh/ptk/history.py
+++ b/xonsh/ptk/history.py
@@ -53,7 +53,7 @@ class PromptToolkitHistoryAdder(Thread):
         ptkhist = self.ptkhist
         while self.wait_for_gc and hist.gc.is_alive():
             time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer
-        files = hist.gc.unlocked_files()
+        files = hist.gc.files()
         for _, _, f in files:
             try:
                 lj = lazyjson.LazyJSON(f, reopen=False)

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -402,7 +402,7 @@ class ReadlineHistoryAdder(Thread):
         hist = builtins.__xonsh_history__
         while self.wait_for_gc and hist.gc.is_alive():
             time.sleep(0.011)  # gc sleeps for 0.01 secs, sleep a beat longer
-        files = hist.gc.unlocked_files()
+        files = hist.gc.files()
         i = 1
         for _, _, f in files:
             try:


### PR DESCRIPTION
This should resolve #935.