### PR TITLE
Speed up in attr completer

### DIFF
--- a/xonsh/completer.py
+++ b/xonsh/completer.py
@@ -534,25 +534,20 @@ class Completer(object):
                 _ctx = builtins.__dict__
             except:  # pylint:disable=bare-except
                 return attrs  # anything could have gone wrong!
-        _opts = dir(val)
-        # check whether these options actually work (e.g., disallow 7.imag)
-        opts = []
-        for i in _opts:
-            try:
-                builtins.__xonsh_execer__.eval('{0}.{1}'.format(expr, i), _ctx)
-            except:  # pylint:disable=bare-except
-                continue
-            else:
-                opts.append(i)
         if len(attr) == 0:
-            opts = [o for o in opts if not o.startswith('_')]
+            opts = [o for o in dir(val) if not o.startswith('_')]
         else:
             csc = builtins.__xonsh_env__.get('CASE_SENSITIVE_COMPLETIONS')
             startswither = startswithnorm if csc else startswithlow
             attrlow = attr.lower()
-            opts = [o for o in opts if startswither(o, attr, attrlow)]
+            opts = [o for o in dir(val) if startswither(o, attr, attrlow)]
         prelen = len(prefix)
         for opt in opts:
+            # check whether these options actually work (e.g., disallow 7.imag)
+            try:
+                builtins.__xonsh_execer__.eval('{0}.{1}'.format(expr, opt), _ctx)
+            except:  # pylint:disable=bare-except
+                continue
             a = getattr(val, opt)
             rpl = opt + '(' if callable(a) else opt
             # note that prefix[:prelen-len(attr)] != prefix[:-len(attr)]


### PR DESCRIPTION
Speed up attr completions a tiny bit by only calling __xonsh_execer__.eval on the final candidates. Before it was called on all output from `dir(val)`