### PR TITLE
Lazily load prompt_toolkit

### DIFF
--- a/xonsh/platform.py
+++ b/xonsh/platform.py
@@ -93,13 +93,12 @@ def ptk_version_info():
         return None
 
 
-BEST_SHELL_TYPE = None
-""" The 'best' available shell type, either 'prompt_toollit' or 'readline'. """
-
-if ON_WINDOWS or has_prompt_toolkit():
-    BEST_SHELL_TYPE = 'prompt_toolkit'
-else:
-    BEST_SHELL_TYPE = 'readline'
+@lru_cache(1)
+def best_shell_type():
+    if ON_WINDOWS or has_prompt_toolkit():
+        return 'prompt_toolkit'
+    else:
+        return 'readline'
 
 
 @lru_cache(1)

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -44,8 +44,6 @@ class Shell(object):
                            kwargs.get('cacheall', False))
         env = builtins.__xonsh_env__
         # pick a valid shell
-        if shell_type is not None:
-            env['SHELL_TYPE'] = shell_type
         shell_type = env.get('SHELL_TYPE')
         if shell_type == 'best' or shell_type is None:
             shell_type = best_shell_type()
@@ -54,7 +52,8 @@ class Shell(object):
         if shell_type == 'prompt_toolkit':
             if not has_prompt_toolkit():
                 warn('prompt_toolkit is not available, using readline instead.')
-                shell_type = env['SHELL_TYPE'] = 'readline'
+                shell_type = 'readline'
+        env['SHELL_TYPE'] = shell_type
         # actually make the shell
         if shell_type == 'none':
             from xonsh.base_shell import BaseShell as shell_class

--- a/xonsh/shell.py
+++ b/xonsh/shell.py
@@ -7,7 +7,7 @@ from warnings import warn
 from xonsh import xontribs
 from xonsh.environ import xonshrc_context
 from xonsh.execer import Execer
-from xonsh.platform import (BEST_SHELL_TYPE, has_prompt_toolkit, ptk_version,
+from xonsh.platform import (best_shell_type, has_prompt_toolkit, ptk_version,
                             ptk_version_info)
 from xonsh.tools import XonshError
 
@@ -48,7 +48,7 @@ class Shell(object):
             env['SHELL_TYPE'] = shell_type
         shell_type = env.get('SHELL_TYPE')
         if shell_type == 'best' or shell_type is None:
-            shell_type = BEST_SHELL_TYPE
+            shell_type = best_shell_type()
         elif shell_type == 'random':
             shell_type = random.choice(('readline', 'prompt_toolkit'))
         if shell_type == 'prompt_toolkit':

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -36,11 +36,6 @@ from collections import OrderedDict, Sequence, Set
 from xonsh.platform import (has_prompt_toolkit, scandir, win_unicode_console,
                             DEFAULT_ENCODING, ON_LINUX, ON_WINDOWS,
                             PYTHON_VERSION_INFO)
-if has_prompt_toolkit():
-    import prompt_toolkit
-else:
-    prompt_toolkit = None
-
 
 IS_SUPERUSER = ctypes.windll.shell32.IsUserAnAdmin() != 0 if ON_WINDOWS else os.getuid() == 0
 
@@ -882,7 +877,7 @@ def intensify_colors_for_cmd_exe(style_map, replace_colors=None):
        range used by the gray colors
     """
     modified_style = {}
-    if not ON_WINDOWS or prompt_toolkit is None:
+    if not ON_WINDOWS or builtins.__xonsh_shell__.stype != 'prompt_toolkit':
         return modified_style
     if replace_colors is None:
         replace_colors = {1: '#44ffff',  # subst blue with bright cyan

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -878,7 +878,10 @@ def intensify_colors_for_cmd_exe(style_map, replace_colors=None):
        range used by the gray colors
     """
     modified_style = {}
-    if not ON_WINDOWS or builtins.__xonsh_shell__.stype != 'prompt_toolkit':
+    stype = builtins.__xonsh_env__.get('SHELL_TYPE')
+    if (not ON_WINDOWS or
+            (stype not in ('prompt_toolkit', 'best')) or
+            (stype == 'best' and not has_prompt_toolkit())):
         return modified_style
     if replace_colors is None:
         replace_colors = {1: '#44ffff',  # subst blue with bright cyan
@@ -901,7 +904,10 @@ def expand_gray_colors_for_cmd_exe(style_map):
         in cmd.exe.
     """
     modified_style = {}
-    if not ON_WINDOWS or builtins.__xonsh_shell__.stype != 'prompt_toolkit':
+    stype = builtins.__xonsh_env__.get('SHELL_TYPE')
+    if (not ON_WINDOWS or
+            (stype not in ('prompt_toolkit', 'best')) or
+            (stype == 'best' and not has_prompt_toolkit())):
         return modified_style
     for token, idx, rgb in _get_color_indexes(style_map):
         if idx == 7 and rgb:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -856,6 +856,7 @@ def color_style():
 
 def _get_color_indexes(style_map):
     """ Generates the color and windows color index for a style """
+    import prompt_toolkit
     table = prompt_toolkit.terminal.win32_output.ColorLookupTable()
     pt_style = prompt_toolkit.styles.style_from_dict(style_map)
     for token in style_map:

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -901,7 +901,7 @@ def expand_gray_colors_for_cmd_exe(style_map):
         in cmd.exe.
     """
     modified_style = {}
-    if not ON_WINDOWS or prompt_toolkit is None:
+    if not ON_WINDOWS or builtins.__xonsh_shell__.stype != 'prompt_toolkit':
         return modified_style
     for token, idx, rgb in _get_color_indexes(style_map):
         if idx == 7 and rgb:


### PR DESCRIPTION
This doesn't entirely fix the slow startup time of xonsh, but it makes it so that people using the readline shell explicitly don't have to wait for prompt_toolkit to be loaded, which results in a modest speedup (though it is still quite slow due to loading the bash completion functions).

This should be tested by a Windows user.  Part of the changes were related to `intensify_colors_for_cmd_exe`, and not being around a Windows machine, I haven't been able to test that that function still works as intended on Windows.