### PR TITLE
Fix Permission error when tab-completing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,9 @@ Current Developments
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:** 
+
+Fixed PermissionError when tabcompletions tries to lookup executables in directories without read permissions. 
 
 **Security:** None
 

--- a/xonsh/tools.py
+++ b/xonsh/tools.py
@@ -319,15 +319,18 @@ class redirect_stderr(_RedirectStream):
 
 def executables_in(path):
     """Returns a generator of files in `path` that the user could execute. """
-    if PYTHON_VERSION_INFO < (3, 5, 0):
-        for i in os.listdir(path):
-            name  = os.path.join(path, i)
-            if (os.path.exists(name) and os.access(name, os.X_OK) and \
-                                    (not os.path.isdir(name))):
-                yield i
-    else:
-        yield from (x.name for x in scandir(path)
-                    if x.is_file() and os.access(x.path, os.X_OK))
+    try:
+        if PYTHON_VERSION_INFO < (3, 5, 0):
+            for i in os.listdir(path):
+                name  = os.path.join(path, i)
+                if (os.path.exists(name) and os.access(name, os.X_OK) and \
+                                        (not os.path.isdir(name))):
+                    yield i
+        else:
+            yield from (x.name for x in scandir(path)
+                        if x.is_file() and os.access(x.path, os.X_OK))
+    except PermissionError:
+        return
 
 
 def command_not_found(cmd):


### PR DESCRIPTION
This is a quick fix for https://github.com/scopatz/xonsh/issues/1033 . Where `executables_in` fails if the directory is read-protected.  It doesn't fix the problem that `executables_in` return all files on windows. 

@asmeurer . Can you test? 