### PR TITLE
Verbose which

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,15 @@ Current Developments
 ====================
 **Added:** None
 
-**Changed:** None
+**Changed:** 
+
+ * ``which`` now give a better verbose report of where the executables are found.  
 
 **Deprecated:** None
 
-**Removed:** None
+**Removed:** 
+
+ * Fixed bug on Windows where ``which`` did not include current directory
 
 **Fixed:** None
 

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -408,8 +408,13 @@ def which(args, stdin=None, stdout=None, stderr=None):
             nmatches += 1
             if not pargs.all:
                 continue
-        matches = _which.whichgen(arg, exts=exts, verbose=pargs.verbose,
-                                  path=builtins.__xonsh_env__['PATH'])
+        # which.whichgen gives the nicest 'verbose' output if PATH is taken
+        # from os.environ so we temporarily override it with
+        # __xosnh_env__['PATH']
+        original_os_path = os.envrion['PATH']
+        os.environ['PATH'] = builtins.__xonsh_env__['PATH']
+        matches = _which.whichgen(arg, exts=exts, verbose=pargs.verbose)
+        os.envrion['PATH'] = original_os_path
         for abs_name, from_where in matches:
             if ON_WINDOWS:
                 # Use list dir to get correct case for the filename
@@ -422,8 +427,6 @@ def which(args, stdin=None, stdout=None, stderr=None):
             if pargs.plain or not pargs.verbose:
                 print(abs_name, file=stdout)
             else:
-                if 'given path element' in from_where:
-                    from_where = from_where.replace('given path', '$PATH')
                 print('{} ({})'.format(abs_name, from_where), file=stdout)
             nmatches += 1
             if not pargs.all:

--- a/xonsh/aliases.py
+++ b/xonsh/aliases.py
@@ -411,10 +411,10 @@ def which(args, stdin=None, stdout=None, stderr=None):
         # which.whichgen gives the nicest 'verbose' output if PATH is taken
         # from os.environ so we temporarily override it with
         # __xosnh_env__['PATH']
-        original_os_path = os.envrion['PATH']
-        os.environ['PATH'] = builtins.__xonsh_env__['PATH']
+        original_os_path = os.environ['PATH']
+        os.environ['PATH'] = builtins.__xonsh_env__.detype()['PATH']
         matches = _which.whichgen(arg, exts=exts, verbose=pargs.verbose)
-        os.envrion['PATH'] = original_os_path
+        os.environ['PATH'] = original_os_path
         for abs_name, from_where in matches:
             if ON_WINDOWS:
                 # Use list dir to get correct case for the filename


### PR DESCRIPTION
This fixes a bug on Windows where `which` did not include the current directory. It also gives better verbose output on windows. 

The bug was caused by us explicitly giving `which.whichgen` the `__xonsh_env__['PATH']`  That changes the behaviour of the module a bit. 