### PR TITLE
Using string in scripts during install without setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ def main():
             }
         skw['cmdclass']['develop'] = xdevelop
     else:
-        skw['scripts'] = ['scripts/xonsh'] if 'win' not in sys.platform else ['scripts/xonsh.bat'],
+        skw['scripts'] = ['scripts/xonsh'] if 'win' not in sys.platform else ['scripts/xonsh.bat']
 
     setup(**skw)
 


### PR DESCRIPTION
Attempting to install in an environment without setuptools generates the following error:

```
Traceback (most recent call last):
  File "setup.py", line 194, in <module>
    main()
  File "setup.py", line 190, in main
    setup(**skw)
  File "/usr/lib/python3.4/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.4/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 105, in run
    install.run(self)
  File "/usr/lib/python3.4/distutils/command/install.py", line 583, in run
    self.run_command('build')
  File "/usr/lib/python3.4/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  FilTraceback (most recent call last):
  File "setup.py", line 194, in <module>
    main()
  File "setup.py", line 190, in main
    setup(**skw)
  File "/usr/lib/python3.4/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.4/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "setup.py", line 105, in run
    install.run(self)
  File "/usr/lib/python3.4/distutils/command/install.py", line 583, in run
    self.run_command('build')
  File "/usr/lib/python3.4/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.4/distutils/command/build.py", line 126, in run
    self.run_command(cmd_name)
  File "/usr/lib/python3.4/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.4/distutils/command/build_scripts.py", line 50, in run
    self.copy_scripts()
  File "/usr/lib/python3.4/distutils/command/build_scripts.py", line 65, in copy_scripts
    outfile = os.path.join(self.build_dir, os.path.basename(script))
  File "/usr/lib/python3.4/posixpath.py", line 139, in basename
    i = p.rfind(sep) + 1
AttributeError: 'list' object has no attribute 'rfind'e "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.4/distutils/command/build.py", line 126, in run
    self.run_command(cmd_name)
  File "/usr/lib/python3.4/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/lib/python3.4/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.4/distutils/command/build_scripts.py", line 50, in run
    self.copy_scripts()
  File "/usr/lib/python3.4/distutils/command/build_scripts.py", line 65, in copy_scripts
    outfile = os.path.join(self.build_dir, os.path.basename(script))
  File "/usr/lib/python3.4/posixpath.py", line 139, in basename
    i = p.rfind(sep) + 1
AttributeError: 'list' object has no attribute 'rfind'
```


Using strings in skw['scripts'] seems to fix the issue.