### PR TITLE
Attempted Fix for Loading .inputrc on Mac

### DIFF
--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -35,3 +35,13 @@ the following from the source directory,
 .. include:: add_to_shell.rst
 
 .. include:: dependencies.rst
+
+
+GNU Readline
+============
+
+On Mac OSX, it is _strongly_ recommended to install the ``gnureadline`` library if using the readline shell (as opposed to prompt_toolkit).  ``gnureadline`` can be installed via pip:
+
+.. code-block:: bash
+
+    $ pip install gnureadline

--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -40,7 +40,7 @@ the following from the source directory,
 GNU Readline
 ============
 
-On Mac OSX, it is _strongly_ recommended to install the ``gnureadline`` library if using the readline shell (as opposed to prompt_toolkit).  ``gnureadline`` can be installed via pip:
+On Mac OSX, it is *strongly* recommended to install the ``gnureadline`` library if using the readline shell.  ``gnureadline`` can be installed via pip:
 
 .. code-block:: bash
 

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -13,6 +13,7 @@ import sys
 import time
 import select
 import builtins
+import importlib
 from cmd import Cmd
 from threading import Thread
 from collections import deque
@@ -44,7 +45,7 @@ def setup_readline():
         return
     for _rlmod_name in ('gnureadline', 'readline'):
         try:
-            readline = __import__(_rlmod_name)
+            readline = importlib.import_module(_rlmod_name)
             sys.modules['readline'] = readline
         except ImportError:
             pass

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -95,7 +95,7 @@ def setup_readline():
             "",
             "It is highly recommended that you install gnureadline, which is installable with:",
             "     pip install gnureadline",
-            "*"*78]))
+            "*"*78]), file=sys.stderr)
     else:
         readline.parse_and_bind("tab: complete")
     # try to load custom user settings

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -105,6 +105,8 @@ def setup_readline():
         else:
             inputrc_name = '.inputrc'
         inputrc_name = os.path.join(os.path.expanduser('~'), inputrc_name)
+    if (not ON_WINDOWS) and (not os.path.isfile(inputrc_name)):
+        inputrc_name = '/etc/inputrc'
     if os.path.isfile(inputrc_name):
         try:
             readline.read_init_file(inputrc_name)

--- a/xonsh/readline_shell.py
+++ b/xonsh/readline_shell.py
@@ -1,5 +1,13 @@
 # -*- coding: utf-8 -*-
-"""The readline based xonsh shell."""
+"""The readline based xonsh shell.
+
+Portions of this code related to initializing the readline library
+are included from the IPython project.  The IPython project is:
+    * Copyright (c) 2008-2014, IPython Development Team
+    * Copyright (c) 2001-2007, Fernando Perez <fernando.perez@colorado.edu>
+    * Copyright (c) 2001, Janko Hauser <jhauser@zscout.de>
+    * Copyright (c) 2001, Nathaniel Gray <n8gray@caltech.edu>
+"""
 import os
 import sys
 import time
@@ -14,7 +22,7 @@ from xonsh.base_shell import BaseShell
 from xonsh.ansi_colors import partial_color_format, color_style_names, color_style
 from xonsh.environ import partial_format_prompt, multiline_prompt
 from xonsh.tools import print_exception
-from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS, ON_CYGWIN
+from xonsh.platform import HAS_PYGMENTS, ON_WINDOWS, ON_CYGWIN, ON_DARWIN
 
 if HAS_PYGMENTS:
     from xonsh import pyghooks
@@ -34,12 +42,20 @@ def setup_readline():
     global RL_COMPLETION_SUPPRESS_APPEND, RL_LIB, RL_CAN_RESIZE, RL_STATE, readline
     if RL_COMPLETION_SUPPRESS_APPEND is not None:
         return
-    try:
-        import readline
-    except ImportError:
+    for _rlmod_name in ('gnureadline', 'readline'):
+        try:
+            readline = __import__(_rlmod_name)
+            sys.modules['readline'] = readline
+        except ImportError:
+            pass
+        else:
+            break
+    if readline is None:
+        print("No readline implementation available.  Skipping setup.")
         return
     import ctypes
     import ctypes.util
+    uses_libedit = readline.__doc__ and 'libedit' in readline.__doc__
     readline.set_completer_delims(' \t\n')
     # Cygwin seems to hang indefinitely when querying the readline lib
     if (not ON_CYGWIN) and (not readline.__file__.endswith('.py')):
@@ -67,16 +83,34 @@ def setup_readline():
 
     # handle tab completion differences found in libedit readline compatibility
     # as discussed at http://stackoverflow.com/a/7116997
-    if readline.__doc__ and 'libedit' in readline.__doc__:
+    if uses_libedit and ON_DARWIN:
         readline.parse_and_bind("bind ^I rl_complete")
+        print('\n'.join(['', "*"*78,
+            "libedit detected - readline will not be well behaved, including but not limited to:",
+            "   * crashes on tab completion",
+            "   * incorrect history navigation",
+            "   * corrupting long-lines",
+            "   * failure to wrap or indent lines properly",
+            "",
+            "It is highly recommended that you install gnureadline, which is installable with:",
+            "     pip install gnureadline",
+            "*"*78]))
     else:
         readline.parse_and_bind("tab: complete")
     # try to load custom user settings
-    try:
-        readline.read_init_file()
-    except Exception:
-        # this seems to fail with libedit
-        print_exception('xonsh: could not load readline default init file.')
+    inputrc_name = os.environ.get('INPUTRC')
+    if inputrc_name is None:
+        if uses_libedit:
+            inputrc_name = '.editrc'
+        else:
+            inputrc_name = '.inputrc'
+        inputrc_name = os.path.join(os.path.expanduser('~'), inputrc_name)
+    if os.path.isfile(inputrc_name):
+        try:
+            readline.read_init_file(inputrc_name)
+        except Exception:
+            # this seems to fail with libedit
+            print_exception('xonsh: could not load readline default init file.')
 
 
 def teardown_readline():


### PR DESCRIPTION
This changeset forks some code from IPython related to reading `.inputrc` on Mac.  Hopefully, it will fix #1049, though I do not have access to a Mac to test.