### PR TITLE
Don't tell users to invoke setup.py directly.

### DIFF
--- a/docs/linux.rst
+++ b/docs/linux.rst
@@ -29,7 +29,7 @@ the following from the source directory,
 
 .. code-block:: bash
 
-    $ python setup.py install
+    $ pip install .
 
 
 Arch Linux users can install xonsh from the Arch User Repository with e.g.

--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -29,7 +29,7 @@ the following from the source directory,
 
 .. code-block:: bash
 
-    $ python setup.py install
+    $ pip install .
 
 
 .. include:: add_to_shell.rst

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -56,7 +56,7 @@ Now install xonsh:
 .. code-block:: bat
 
    > cd xonsh-master
-   > python setup.py install
+   > pip install .
 
 Next, run xonsh:
 


### PR DESCRIPTION
It's better to use `pip install .`, because yif you **really** like to
do things by hand you would have to pass options like
`--single-version-externally-managed`.

Editable install are also available with `pip install -e .`

And with this we will get all the benefits form pep518 (once we can use
it)

https://www.python.org/dev/peps/pep-0518/

And its future siblings, that will tell pip how to deals with
non-setup.py-based installation/wheel building.

Note that if you want a **specific** pip from a **specific** python
version you can use :

`python -m pip install .`

But that starts to be a bit verbose.


--- 

@scopatz Fix you slides :-), nice talk BTW. You forgot basic things like OMG it syntax highlight while I type !