### PR TITLE
Allow question mark as valid character in subprocess-mode name

### DIFF
--- a/xonsh/parsers/base.py
+++ b/xonsh/parsers/base.py
@@ -2286,6 +2286,7 @@ class BaseParser(object):
                             | NUMBER
                             | STRING
                             | COMMA
+                            | QUESTION
         """
         # Many tokens cannot be part of this list, such as $, ', ", ()
         # Use a string atom instead.


### PR DESCRIPTION
Per the discussion in #1059