### PR TITLE
Fix win prompt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Current Developments
 **Fixed:**
 
  * Fixed bug on Windows where tab-completion for executables would return all files.
+ * Fixed bug on Windows which caused the bash $PROMPT variable to be used when no 
+   no $PROMPT variable was set in .xonshrc 
 
 **Security:** None
 

--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -1296,7 +1296,7 @@ def xonshrc_context(rcfiles=None, execer=None):
 def windows_foreign_env_fixes(ctx):
     """Environment fixes for Windows. Operates in-place."""
     # remove these bash variables which only cause problems.
-    for ev in ['HOME', 'OLDPWD']:
+    for ev in ['HOME', 'OLDPWD', 'PROMPT']:
         if ev in ctx:
             del ctx[ev]
     # Override path-related bash variables; on Windows bash uses


### PR DESCRIPTION
I think this should fix the prompt problem (reported by @phobson)  on windows when no `$PROMPT` was not set in `.xonshrc`

The problem was caused by #989 which basically enabled bash as a foreign shell for windows. This also meant that xonsh would load the `$PROMPT` variable from bash if it were not set in `.xonshrc`. 

@adqm / @scopatz could this also be a problem on other platforms?