### PR TITLE
add current shell_type to xonfig output

### DIFF
--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -336,6 +336,7 @@ def _info(ns):
         ('PLY', ply.__version__),
         ('have readline', is_readline_available()),
         ('prompt toolkit', ptk_version() or None),
+        ('shell type', builtins.__xonsh_env__.get('SHELL_TYPE')),
         ('pygments', platform.PYGMENTS_VERSION),
         ('on posix', platform.ON_POSIX),
         ('on linux', platform.ON_LINUX)]


### PR DESCRIPTION
I think this will be useful for troubleshooting as it's something we
often end up asking when users open issues.