### PR TITLE
Syntax error pointer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Current Developments
 
 * Question mark literals, ``?``, are now allowed as part of
   subprocess argument names.
+* IPython style visual pointer to show where syntax error was detected
 
 **Changed:**
 


### PR DESCRIPTION
As suggested by @asmeurer in #1081, interactive syntax errors print the line in question and a little caret pointer.

```console
gil@bad_cat ~ $ test())
............... 
  File "<string>", line None
SyntaxError: <xonsh-code>:1:6: Unmatched ")" at line 1, column 6 
test())
      ^
gil@bad_cat ~ $ if True:
...............     test())
...............     
  File "<string>", line None
SyntaxError: <xonsh-code>:2:10: Unmatched ")" at line 2, column 10 
    test())
          ^
```
