### PR TITLE
do not require directories in BASH_COMPLETIONS to exist

### DIFF
--- a/xonsh/completers/bash.py
+++ b/xonsh/completers/bash.py
@@ -181,4 +181,5 @@ def _collect_completions_sources():
 
 def _completions_time():
     compfiles = builtins.__xonsh_env__.get('BASH_COMPLETIONS', ())
-    return max(os.stat(x).st_mtime for x in compfiles)
+    compfiles = [os.stat(x).st_mtime for x in compfiles if os.path.exists(x)]
+    return max(compfiles) if compfiles else 0


### PR DESCRIPTION
When trying this out on my mac (from master e9a2b96) I ran into this error:

```
% xonsh
Traceback (most recent call last):
  File "/usr/local/bin/xonsh", line 9, in <module>
    load_entry_point('xonsh', 'console_scripts', 'xonsh')()
  File "/Users/william/dev/xonsh/xonsh/main.py", line 230, in main
    args = premain(argv)
  File "/Users/william/dev/xonsh/xonsh/main.py", line 217, in premain
    shell = builtins.__xonsh_shell__ = Shell(**shell_kwargs)
  File "/Users/william/dev/xonsh/xonsh/shell.py", line 72, in __init__
    ctx=self.ctx, **kwargs)
  File "/Users/william/dev/xonsh/xonsh/readline_shell.py", line 199, in __init__
    **kwargs)
  File "/Users/william/dev/xonsh/xonsh/base_shell.py", line 118, in __init__
    self.completer = Completer()
  File "/Users/william/dev/xonsh/xonsh/completer.py", line 13, in __init__
    update_bash_completion()
  File "/Users/william/dev/xonsh/xonsh/completers/bash.py", line 69, in update_bash_completion
    _completions_time() > os.stat(cachefname).st_mtime)
  File "/Users/william/dev/xonsh/xonsh/completers/bash.py", line 184, in _completions_time
    return max(os.stat(x).st_mtime for x in compfiles)
  File "/Users/william/dev/xonsh/xonsh/completers/bash.py", line 184, in <genexpr>
    return max(os.stat(x).st_mtime for x in compfiles)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/etc/bash_completion'
```

I narrowed it down to the `_completions_time` function (https://github.com/scopatz/xonsh/blob/08483fdcc3c8f6a6ec9202bfe0448776ec92e41c/xonsh/completers/bash.py#L182-L184) which  assumes that the directories in the `builtins.__xonsh_env__.get('BASH_COMPLETIONS', ())` exist. Also, that last snippet can return an empty tuple `()` if `BASH_COMPLETIONS` is **not** in the `__xonsh_env__`, which would lead to `max()` on the next line to complain as such `ValueError: max() arg is an empty sequence`.

To fix this I pruned the list to only include directories that actually exist and by returning `0` if the resulting list is empty rather than passing an empty list to `max()`.

I looked, but I didn't see an existing issue about this and since I was using master to work around another problem that's been fixed in master, but not the released version I decided to open this.

I was going to write a test for this, but I wasn't sure about how to inject an obviously bogus path into the builtin env for a test. If someone could give me some guidance on that, I'd gladly try to write the test.