### PR TITLE
Eradicate evil

### DIFF
--- a/docs/linux.rst
+++ b/docs/linux.rst
@@ -29,7 +29,7 @@ the following from the source directory,
 
 .. code-block:: bash
 
-    $ python setup.py install
+    $ pip install .
 
 
 Arch Linux users can install xonsh from the Arch User Repository with e.g.

--- a/docs/osx.rst
+++ b/docs/osx.rst
@@ -29,7 +29,7 @@ the following from the source directory,
 
 .. code-block:: bash
 
-    $ python setup.py install
+    $ pip install .
 
 
 .. include:: add_to_shell.rst

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -56,7 +56,7 @@ Now install xonsh:
 .. code-block:: bat
 
    > cd xonsh-master
-   > python setup.py install
+   > pip install .
 
 Next, run xonsh:
 


### PR DESCRIPTION
Consider `python setup.py install` to be harmful, the preferred
way to do this is `pip install <dir>`. Please put on a hair
shirt and see: https://youtu.be/5BqAeN-F9Qs?t=10m1s