### PR TITLE
return empty set instead of None when no python completions match

### DIFF
--- a/xonsh/completers/python.py
+++ b/xonsh/completers/python.py
@@ -31,7 +31,7 @@ def complete_python(prefix, line, start, end, ctx):
     """
     first = line.split()[0]
     if first in builtins.__xonsh_commands_cache__ and first not in ctx:
-        return None
+        return set()
     filt = get_filter_function()
     rtn = {s for s in XONSH_TOKENS if filt(s, prefix)}
     if ctx is not None:


### PR DESCRIPTION
This avoids this error when (for example) completing "rm":
```
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.5/threading.py", line 862, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python3.5/site-packages/prompt_toolkit/interface.py", line 759, in run
    completions = list(buffer.completer.get_completions(document,complete_event))
  File "/usr/lib/python3.5/site-packages/xonsh/ptk/completer.py", line 36, in get_completions
    self.ctx)
  File "/usr/lib/python3.5/site-packages/xonsh/completer.py", line 41, in complete
    out = func(prefix, line, begidx, endidx, ctx)
  File "/usr/lib/python3.5/site-packages/xonsh/completers/base.py", line 21, in complete_base
    complete_command(prefix, line, start, end, ctx))
TypeError: unsupported operand type(s) for |: 'NoneType' and 'set'
```