### PR TITLE
support functions in $RIGHT_PROMPT

### DIFF
--- a/xonsh/environ.py
+++ b/xonsh/environ.py
@@ -106,7 +106,6 @@ DEFAULT_ENSURERS = {
     re.compile('\w*PATH$'): (is_env_path, str_to_env_path, env_path_to_str),
     'PATHEXT': (is_env_path, str_to_env_path, env_path_to_str),
     'RAISE_SUBPROC_ERROR': (is_bool, to_bool, bool_to_str),
-    'RIGHT_PROMPT': (is_string, ensure_string, ensure_string),
     'TEEPTY_PIPE_DELAY': (is_float, float, str),
     'UPDATE_OS_ENVIRON': (is_bool, to_bool, bool_to_str),
     'XONSHRC': (is_env_path, str_to_env_path, env_path_to_str),

--- a/xonsh/ptk/shell.py
+++ b/xonsh/ptk/shell.py
@@ -142,8 +142,6 @@ class PromptToolkitShell(BaseShell):
         prompt.
         """
         p = builtins.__xonsh_env__.get('RIGHT_PROMPT')
-        if len(p) == 0:
-            return []
         try:
             p = partial_format_prompt(p)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Functions and empty strings are already handled properly for PROMPT, so
no need to do something different for RIGHT_PROMPT.