### PR TITLE
Store result of wrapped subprocess call in _

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Current Developments
 * ``prompt_toolkit`` is now loaded lazily, decreasing load times when using
   the ``readline`` shell.
 * RC files are now executed directly in the appropriate context.
+* ``_`` is now updated by ``![]``, to contain the appropriate
+  ``CompletedCommand`` object.
 
 **Deprecated:** None
 

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -149,9 +149,12 @@ def undo_args(args):
 
 
 def _pprint_displayhook(value):
-    if value is None or isinstance(value, HiddenCompletedCommand):
+    if value is None:
         return
     builtins._ = None  # Set '_' to None to avoid recursion
+    if isinstance(value, HiddenCompletedCommand):
+        builtins._ = value
+        return
     if HAS_PYGMENTS:
         s = pretty(value)  # color case
         lexer = pyghooks.XonshLexer()


### PR DESCRIPTION
This modifies the semantics of `_` in interactive mode so that it now stores the `CompletedCommand` instance associated with a wrapped subprocess call.

This allows easier access to the previous command's return code (one of the common complains on the slashdot thread), via `_.rtn`.

Not sure whether this is something everyone wants, but I figured I'd put it in, and we can discuss from here.