### PR TITLE
fix issue with trying to delete a literal value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,10 @@ Current Developments
 
 **Removed:** None
 
-**Fixed:** None
+**Fixed:**
+
+* Fixed an issue whereby attempting to delete a literal value (e.g., ``del 7``)
+  in the prompt_toolkit shell would cause xonsh to crash.
 
 **Security:** None
 

--- a/xonsh/ptk/key_bindings.py
+++ b/xonsh/ptk/key_bindings.py
@@ -103,6 +103,8 @@ def can_compile(src):
         rtn = True
     except SyntaxError:
         rtn = False
+    except Exception:
+        rtn = True
     return rtn
 
 


### PR DESCRIPTION
I believe this should resolve the issue from #1127 and #1124 where attempting to delete a literal value in prompt toolkit shell would cause xonsh to crash.